### PR TITLE
Upgrade PicoHost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "numpy",
   "pyyaml",
   "flask",
-  "picohost>=0.0.2",
+  "picohost>=0.0.3",
   "cmt_vna @ git+https://github.com/EIGSEP/CMT-VNA.git@main",
   "eigsep_corr @ git+https://github.com/EIGSEP/eigsep_corr.git@main",
   "fakeredis",

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -299,9 +299,9 @@ class PandaClient:
             try:
                 p = cls(
                     port,
+                    self.redis,
                     timeout=self.serial_timeout,
                     name=name,
-                    eig_redis=self.redis,
                 )
                 if p.is_connected:
                     self.picos[name] = p


### PR DESCRIPTION
PicoHost v0.0.3 has a breaking change in the way Picodevices are instantiated. They now require a redis instance. This PR implements the newest version of picohost. The PR can be merged once the picohost PR is merged - see https://github.com/EIGSEP/pico-firmware/pull/9