### PR TITLE
refactor!: split EigsepRedis into Transport + writer/reader classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,17 @@ ruff format --check .             # Check formatting (line length 79)
 
 ### Core classes (all use Redis for communication):
 
-- **EigsepRedis** (`eig_redis.py`) - Redis message bus wrapping `redis.Redis`. Manages streams: `stream:ctrl` (commands), `stream:status` (status updates), `stream:data:{sensor}` (sensor data). Large file (~1000 lines).
+- **EigsepRedis** (`eigsep_redis/eig_redis.py`) - Thin composition object over a shared `Transport`. Exposes per-bus writer/reader attributes, not a god-class of methods. Surfaces: `metadata` (writer), `metadata_snapshot` / `metadata_stream` (readers), `status` (writer), `status_reader`, `heartbeat` (writer), `heartbeat_reader`, `config` (store). Picohost and other external producers consume this; it lives in the shared `eigsep_redis` package so everyone sees the same wire format.
+- **EigsepObsRedis** (`eigsep_observing/eig_redis.py`) - Observer-side subclass. Adds `corr_config` (store — config + header), `corr` (writer), `corr_reader`, `vna` (writer), `vna_reader`. The observer-specific classes live in `corr.py` and `vna.py`.
 - **EigObserver** (`observer.py`) - Main orchestrator on the ground computer. Takes two Redis connections (`redis_snap` for SNAP correlator, `redis_panda` for LattePanda). Manages observation schedules, data collection, and file writing.
 - **PandaClient** (`client.py`) - Runs on the suspended LattePanda. Pulls sensor data, pushes to Redis, listens for control commands. Manages Pico devices (IMU, thermometers, peltier, lidar, RF switch) via `picohost` library.
-- **EigsepFpga** (`fpga.py`) - SNAP FPGA/correlator driver. Owns the register blocks (`blocks.py`), the `.fpg` bitstream (`data/`), and the `EigsepRedis`-backed metadata publication path. Was historically a subclass of `eigsep_corr.fpga.EigsepFpga`; the two were merged in-tree when `eigsep_corr` was archived.
+- **EigsepFpga** (`fpga.py`) - SNAP FPGA/correlator driver. Owns the register blocks (`blocks.py`), the `.fpg` bitstream (`data/`), and the corr-bus publication path (`redis.corr.add`, `redis.corr_config.upload_header`). Was historically a subclass of `eigsep_corr.fpga.EigsepFpga`; the two were merged in-tree when `eigsep_corr` was archived.
+
+### Per-bus class split (why `EigsepRedis` is not a god-class)
+
+Writer and reader classes are separated per bus so that **wrong-stream writes are structurally impossible**, not runtime-checked. `MetadataWriter` has no method that accepts a VNA payload; `CorrWriter` has no method that accepts a metadata payload; etc. Structural-impossibility guards in `tests/test_redis.py` enforce this at test time. Motivated by a real VNA→metadata leak bug caught in PR review (fixed in `b8cc1ed` / `ba42f1f`, then made structural in this refactor).
+
+`EigsepRedis.add_metadata` remains as a one-line shim with `DeprecationWarning`, narrowly for picohost (`pico-firmware/picohost/src/picohost/base.py:65` until the monorepo merge). In-tree code must use `redis.metadata.add(...)` directly.
 
 ### Testing architecture (`testing/` subpackage):
 
@@ -70,42 +77,57 @@ Two principles, in priority order:
 
 ## Metadata flow: streaming for corr, snapshot for VNA
 
-`EigsepRedis` exposes two metadata-fetching mechanisms with deliberately different
-semantics. They look inconsistent, but the inconsistency is intentional and not
-something to "fix" by unifying them.
+Two reader classes expose metadata with deliberately different semantics. They
+look inconsistent, but the inconsistency is intentional and not something to
+"fix" by unifying them.
 
-- **`get_metadata()` — streaming, used by corr.** Drains all sensor readings since
-  the last call from per-stream Redis streams (advances a position pointer). Used by
-  `EigObserver.record_corr_data` per integration. Each integration is a sub-second
-  window, and the corr loop averages all sensor readings within that window down to
-  one entry per spectrum (via `io.avg_metadata`). The streaming path matches the corr
-  cadence and gives cadence-correct averages. Because it advances a position pointer,
-  only one consumer per `EigsepRedis` instance can call it per stream.
+- **`MetadataStreamReader.drain()` — streaming, used by corr.** Drains all
+  sensor readings since the last call from per-stream Redis streams (advances a
+  position pointer). Used by `EigObserver.record_corr_data` per integration.
+  Each integration is a sub-second window, and the corr loop averages all sensor
+  readings within that window down to one entry per spectrum (via
+  `io.avg_metadata`). The streaming path matches the corr cadence and gives
+  cadence-correct averages. Because it advances a position pointer, only one
+  consumer per `Transport` can call it per stream.
 
-- **`get_live_metadata()` — snapshot, used by VNA.** Reads the latest values from
-  the Redis metadata hash (no position pointer, no draining). Used by
-  `PandaClient.execute_vna` when packaging a VNA measurement. A VNA reading is
-  point-in-time, taken at ~1/hour cadence; the right semantic is "what was the
-  latest sensor reading at the moment the VNA was triggered," not "average everything
-  since the last VNA an hour ago." The VNA file header includes
-  `metadata_snapshot_unix` so downstream can sanity-check the snapshot's recency.
+- **`MetadataSnapshotReader.get()` — snapshot, used by VNA.** Reads the latest
+  values from the Redis metadata hash (no position pointer, no draining). Used
+  by `PandaClient.execute_vna` when packaging a VNA measurement. A VNA reading
+  is point-in-time, taken at ~1/hour cadence; the right semantic is "what was
+  the latest sensor reading at the moment the VNA was triggered," not "average
+  everything since the last VNA an hour ago." The VNA file header includes
+  `metadata_snapshot_unix` so downstream can sanity-check the snapshot's
+  recency.
 
-**Do not unify these.** Using `get_metadata` for VNA would compete with the corr
-loop for stream position (consumer race) and would average over an irrelevantly long
-window. Using `get_live_metadata` for corr would lose the cadence-matched averaging
-and would mix in stale readings. The two paths reflect different physical semantics
-(integration window vs point-in-time) and run in different processes
-(`EigObserver` on the ground PC vs `PandaClient` on the panda).
+**Do not unify these.** Using the stream reader for VNA would compete with the
+corr loop for stream position (consumer race) and would average over an
+irrelevantly long window. Using the snapshot reader for corr would lose the
+cadence-matched averaging and would mix in stale readings. The two paths
+reflect different physical semantics (integration window vs point-in-time) and
+run in different processes (`EigObserver` on the ground PC vs `PandaClient` on
+the panda).
 
-**Known weakness:** `get_live_metadata` has no freshness check. A dead sensor
-silently returns its last reading. The `metadata_snapshot_unix` header field lets
-downstream detect this at file inspection time, but a runtime warning would require
-panda-side timestamping in `add_metadata` (no firmware change needed). Tracked
-informally; not yet implemented.
+**Known weakness:** the snapshot reader has no freshness check. A dead sensor
+silently returns its last reading. The `metadata_snapshot_unix` header field
+lets downstream detect this at file inspection time, but a runtime warning
+would require panda-side timestamping in `MetadataWriter.add` (no firmware
+change needed). Tracked informally; not yet implemented.
+
+## corr `sync_time` lives on the corr header, not metadata
+
+`sync_time` is a per-sync invariant (set once when the SNAP is synchronized),
+not a per-integration sensor reading. It rides on the corr header
+(`redis.corr_config.get_header()["sync_time"]`), published by
+`EigsepFpga.synchronize` and re-uploaded every ~100 integrations inside the
+observe loop. `EigObserver.record_corr_data` caches it from the header at
+file-start; a mid-file re-sync is an edge case that warrants a new file
+anyway. Historically `sync_time` was pushed through `add_metadata` and fetched
+inline by `read_corr_data` — that was the last cross-bus read inside a reader,
+removed in this refactor.
 
 ## Metadata averaging: per-type reduction policy
 
-When `EigObserver.record_corr_data` calls `get_metadata` it gets a list of raw
+When `EigObserver.record_corr_data` calls `redis.metadata_stream.drain` it gets a list of raw
 sensor dicts since the last call (one entry per producer push, ~5 per integration
 at typical pico cadence). Those get reduced to one entry per integration via
 `io.avg_metadata` → `_avg_sensor_values`. The reduction is **per-type**, derived

--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -56,7 +56,7 @@ pairs = args.pairs or all_autos + all_cross
 all_data = {}
 logger.info(f"Capturing {args.num_spec} spectra for pairs: {pairs}")
 for i in range(args.num_spec):
-    data = redis.read_corr_data(pairs=pairs, timeout=10)[-1]
+    data = redis.corr_reader.read(pairs=pairs, timeout=10)[-1]
     data = reshape_data(data, avg_even_odd=True)
     for k, v in data.items():
         if k not in all_data:

--- a/scripts/linearity_test/corr_linearity.py
+++ b/scripts/linearity_test/corr_linearity.py
@@ -53,14 +53,14 @@ while True:
     # Skip to latest entry in the stream
     last_id = redis.r.xrevrange("stream:corr", count=1)
     if last_id:
-        redis._set_last_read_id("stream:corr", last_id[0][0])
+        redis.corr_reader.seek(last_id[0][0])
 
     print(f"  Capturing {args.nsamples} integrations...")
     pwr = {p: [] for p in pairs}
     last_cnt = None
     collected = 0
     while collected < args.nsamples:
-        acc_cnt, _, data = redis.read_corr_data(pairs=pairs, timeout=10)
+        acc_cnt, data = redis.corr_reader.read(pairs=pairs, timeout=10)
         if acc_cnt == last_cnt:
             continue
         last_cnt = acc_cnt

--- a/scripts/monitor_meta.py
+++ b/scripts/monitor_meta.py
@@ -6,9 +6,9 @@ r = EigsepObsRedis("10.10.10.11")
 
 while True:
     try:
-        # m = r.get_live_metadata()
-        m = r.get_live_metadata(keys=["lidar", "lidar_ts"])
-        # m = r.get_live_metadata(keys=["imu_el", "imu_az", "lidar"])
+        # m = r.metadata_snapshot.get()
+        m = r.metadata_snapshot.get(keys=["lidar", "lidar_ts"])
+        # m = r.metadata_snapshot.get(keys=["imu_el", "imu_az", "lidar"])
         print(json.dumps(m, indent=2, sort_keys=False))
         time.sleep(1.0)
     except KeyboardInterrupt:

--- a/scripts/observe.py
+++ b/scripts/observe.py
@@ -90,7 +90,7 @@ if args.use_panda:
     logger.info("Waiting for Panda config in Redis.")
     while True:
         try:
-            redis_panda.get_config()
+            redis_panda.config.get()
             break
         except ValueError:
             logger.info("Panda config not yet available, retrying...")

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -47,7 +47,7 @@ class PandaClient:
             self.logger.warning(
                 "No configuration found in Redis, using default config."
             )
-            self.redis.upload_config(default_cfg, from_file=False)
+            self.redis.config.upload(default_cfg, from_file=False)
             cfg = self._get_cfg()
         self.cfg = json.loads(json.dumps(cfg))
 
@@ -69,7 +69,7 @@ class PandaClient:
 
         """
         try:
-            cfg = self.redis.get_config()
+            cfg = self.redis.config.get()
         except ValueError:
             return None  # no config in Redis
         upload_time = cfg["upload_time"]
@@ -124,9 +124,9 @@ class PandaClient:
 
         """
         while not self.stop_client.is_set():
-            self.redis.client_heartbeat_set(ex=ex, alive=True)
+            self.redis.heartbeat.set(ex=ex, alive=True)
             self.stop_client.wait(1.0)
-        self.redis.client_heartbeat_set(alive=False)
+        self.redis.heartbeat.set(alive=False)
 
     def init_VNA(self):
         """
@@ -310,8 +310,8 @@ class PandaClient:
         header = self.vna.header
         header["mode"] = mode
         header["metadata_snapshot_unix"] = time.time()
-        metadata = self.redis.get_live_metadata()
-        self.redis.add_vna_data(s11, header=header, metadata=metadata)
+        metadata = self.redis.metadata_snapshot.get()
+        self.redis.vna.add(s11, header=header, metadata=metadata)
         self.logger.info("Vna data added to redis")
 
     def vna_loop(self):

--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -1,0 +1,197 @@
+import json
+import logging
+
+import numpy as np
+
+from eigsep_redis.keys import DATA_STREAMS_SET
+
+from .keys import (
+    CORR_CONFIG_KEY,
+    CORR_HEADER_KEY,
+    CORR_PAIRS_SET,
+    CORR_STREAM,
+)
+from .utils import load_config
+
+logger = logging.getLogger(__name__)
+
+
+class CorrConfigStore:
+    """
+    Persistent store for the SNAP correlator config and corr header.
+
+    Both are single-key JSON blobs keyed off ``corr_config`` and
+    ``corr_header``. The header carries per-sync invariants
+    (``sync_time``, integration time, RF chain state) and is uploaded
+    by the producer when SNAP is synchronized.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload_config(self, config, from_file=False):
+        """
+        Upload the SNAP configuration.
+
+        Parameters
+        ----------
+        config : str or dict
+            Path to a YAML file if ``from_file`` is True, else a dict.
+        from_file : bool
+        """
+        if from_file:
+            config = load_config(config)
+        self.transport._upload_dict(config, CORR_CONFIG_KEY)
+
+    def get_config(self):
+        """
+        Return the SNAP configuration.
+
+        Raises
+        ------
+        ValueError
+            If no configuration is present.
+        """
+        raw = self.transport.get_raw(CORR_CONFIG_KEY)
+        if raw is None:
+            raise ValueError("No SNAP configuration found in Redis.")
+        return json.loads(raw)
+
+    def upload_header(self, header):
+        """Upload the correlator header (from ``EigsepFpga.header``)."""
+        self.transport._upload_dict(header, CORR_HEADER_KEY)
+
+    def get_header(self):
+        """
+        Return the correlator header.
+
+        Raises
+        ------
+        ValueError
+            If no header is present.
+        """
+        raw = self.transport.get_raw(CORR_HEADER_KEY)
+        if raw is None:
+            raise ValueError("No correlation header found in Redis.")
+        return json.loads(raw)
+
+
+class CorrWriter:
+    """
+    Publish raw correlator spectra onto the corr stream.
+
+    The wire format matches ``EigsepFpga.read_data``: per-pair bytes
+    plus ``acc_cnt`` and ``dtype`` sidecars so the reader can
+    ``np.frombuffer`` without a separate type registry.
+    """
+
+    maxlen = 5000
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def add(self, data, cnt, dtype=">i4"):
+        """
+        Publish one integration.
+
+        Parameters
+        ----------
+        data : dict[str, bytes]
+            Keys are correlation pair names, values are raw bytes.
+        cnt : int
+            Accumulation count from SNAP.
+        dtype : str
+            NumPy dtype string for unpacking downstream.
+        """
+        redis_data = {p.encode("utf-8"): d for p, d in data.items()}
+        r = self.transport.r
+        r.sadd(CORR_PAIRS_SET, *redis_data.keys())
+        redis_data["acc_cnt"] = str(cnt).encode("utf-8")
+        redis_data["dtype"] = dtype.encode("utf-8")
+        r.xadd(
+            CORR_STREAM,
+            redis_data,
+            maxlen=self.maxlen,
+            approximate=True,
+        )
+        r.sadd(DATA_STREAMS_SET, CORR_STREAM)
+
+
+class CorrReader:
+    """
+    Consume raw correlator spectra from the corr stream.
+
+    Pure corr-stream reader — does no cross-bus fetch. Sync_time and
+    other per-sync invariants live on the corr header; callers that
+    need them should read the header separately
+    (:class:`CorrConfigStore.get_header`).
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def seek(self, position):
+        """
+        Reset the read position. Used by offline tools (e.g. the
+        linearity sweep) that want to start from a specific entry
+        rather than from '$' / the last read.
+        """
+        self.transport._set_last_read_id(CORR_STREAM, position)
+
+    def read(self, pairs=None, timeout=10, unpack=True):
+        """
+        Blocking read of one corr entry.
+
+        Parameters
+        ----------
+        pairs : list of str or None
+            Pairs to include; ``None`` means read all registered pairs.
+        timeout : int
+            Timeout in seconds for the blocking XREAD.
+        unpack : bool
+            If True, return numpy arrays of ``dtype``; else raw bytes.
+
+        Returns
+        -------
+        (acc_cnt, data) : tuple
+            ``(int, {pair: np.ndarray | bytes})``. Returns
+            ``(None, {})`` if no corr stream exists yet.
+
+        Raises
+        ------
+        TimeoutError
+            If no entry arrives within ``timeout``.
+        """
+        r = self.transport.r
+        if not r.sismember(DATA_STREAMS_SET, CORR_STREAM):
+            self.transport.logger.warning(
+                "No correlation data stream found. "
+                "Please ensure the SNAP is running and sending data."
+            )
+            return None, {}
+        if pairs is None:
+            pairs = r.smembers(CORR_PAIRS_SET)
+        pairs = {p.encode() if isinstance(p, str) else p for p in pairs}
+        last_id = self.transport._streams_from_set(DATA_STREAMS_SET)[
+            CORR_STREAM
+        ]
+        out = r.xread(
+            {CORR_STREAM: last_id},
+            count=1,
+            block=int(timeout * 1000),
+        )
+        if not out:
+            raise TimeoutError("No correlation data received within timeout.")
+        eid, fields = out[0][1][0]
+        self.transport._set_last_read_id(CORR_STREAM, eid)
+        acc_cnt = int(fields.pop(b"acc_cnt").decode())
+        dtype = fields.pop(b"dtype").decode()
+        data = {}
+        for k, v in fields.items():
+            if k not in pairs:
+                continue
+            if unpack:
+                data[k.decode()] = np.frombuffer(v, dtype=dtype)
+            else:
+                data[k.decode()] = v
+        return acc_cnt, data

--- a/src/eigsep_observing/eig_redis.py
+++ b/src/eigsep_observing/eig_redis.py
@@ -1,324 +1,35 @@
-import json
 import logging
-
-import numpy as np
 
 from eigsep_redis import EigsepRedis
 
-from .utils import load_config
+from .corr import CorrConfigStore, CorrReader, CorrWriter
+from .vna import VnaReader, VnaWriter
 
 logger = logging.getLogger(__name__)
 
 
 class EigsepObsRedis(EigsepRedis):
     """
-    Observing-side Redis client. Adds correlator and VNA data paths
-    on top of the generic ``eigsep_redis.EigsepRedis`` bus primitives.
+    Observing-side Redis client. Adds correlator and VNA data paths on
+    top of the generic ``eigsep_redis.EigsepRedis`` bus primitives.
 
-    The split between base and subclass is deliberate: ``picohost``
-    depends only on the base bus (connection, streams, metadata,
-    heartbeat, status); the methods here hardcode correlator pair
-    layouts, VNA trace dtypes, and SNAP-side serialization conventions
-    that producers outside observing don't care about. See
-    ``CLAUDE.md`` for the full rationale.
+    The base class (``EigsepRedis``) provides the shared transport,
+    metadata, status, heartbeat, and config surfaces — everything
+    picohost and other external producers need. The observing-specific
+    attributes added here are:
+
+    - ``corr_config`` — :class:`CorrConfigStore` (upload/get SNAP
+      config and corr header).
+    - ``corr`` — :class:`CorrWriter`; producer-side corr stream.
+    - ``corr_reader`` — :class:`CorrReader`; consumer-side corr stream.
+    - ``vna`` — :class:`VnaWriter`; producer-side VNA stream.
+    - ``vna_reader`` — :class:`VnaReader`; consumer-side VNA stream.
     """
 
-    maxlen = {**EigsepRedis.maxlen, "vna_data": 1000}
-
-    def upload_corr_config(self, config, from_file=False):
-        """
-        Upload the SNAP configuration to Redis. This is the
-        configuration parameters used for programming the SNAP.
-
-        Parameters
-        ----------
-        config : str or dict
-            Path to the configuration file if `from_file` is True, or a
-            dictionary containing the configuration data if `from_file`
-            is False.
-        from_file : bool
-
-        """
-        if from_file:
-            config = load_config(config)
-        self._upload_dict(config, "corr_config")
-
-    def get_corr_config(self):
-        """
-        Get the SNAP configuration file from Redis. These are the
-        configuration parameters used for programming the SNAP.
-
-        Returns
-        -------
-        config : dict
-            Dictionary containing the SNAP configuration data.
-
-        Raises
-        ------
-        ValueError
-            If no configuration is found in Redis.
-
-        """
-        raw = self.get_raw("corr_config")
-        if raw is None:
-            raise ValueError("No SNAP configuration found in Redis.")
-        return json.loads(raw)
-
-    def upload_corr_header(self, header):
-        """
-        Upload correlation data header, from `fpga.header` attribute.
-
-        Parameters
-        ----------
-        header : dict
-
-        """
-        self._upload_dict(header, "corr_header")
-
-    def get_corr_header(self):
-        """
-        Get the correlation data header from Redis.
-
-        Returns
-        -------
-        header : dict
-            Dictionary containing the correlation data header.
-
-        Raises
-        ------
-        ValueError
-            If no correlation header is found in Redis.
-
-        """
-        raw = self.get_raw("corr_header")
-        if raw is None:
-            raise ValueError("No correlation header found in Redis.")
-        return json.loads(raw)
-
-    # ---------- correlation data and s11 measurements ----------
-
-    def add_corr_data(self, data, cnt, dtype=">i4"):
-        """
-        Upload raw correlation data to Redis.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary holding correlation data. Keys are correlation
-            pairs and values are bytes. See the `read_data` method of
-            EigsepFpga in eigsep_observing.fpga for the expected format.
-        cnt : int
-            Accumulation count, read from SNAP.
-        dtype : str
-            Data type of the correlation data. Default is '>i4'
-            (big-endian 32-bit integer). This is used for unpacking the
-            data on the consumer side.
-
-
-        """
-        redis_data = {p.encode("utf-8"): d for p, d in data.items()}
-        # add pairs to the set of correlation pairs
-        self.r.sadd("corr_pairs", *redis_data.keys())
-        # add acc_cnt and dtype to the dict
-        redis_data["acc_cnt"] = str(cnt).encode("utf-8")
-        redis_data["dtype"] = dtype.encode("utf-8")
-        # add the data to the stream
-        self.r.xadd(
-            "stream:corr",
-            redis_data,
-            maxlen=self.maxlen["data"],
-            approximate=True,
-        )
-        self.r.sadd("data_streams", "stream:corr")
-
-    def read_corr_data(self, pairs=None, timeout=10, unpack=True):
-        """
-        Read raw correlation data from Redis and optionally unpack
-        from bytes. This is a blocking read, so it will wait until
-        data is available.
-
-        Parameters
-        ----------
-        pairs : list of str
-            List of correlation pairs to read. If None, read all pairs.
-        timeout : int
-            Timeout in seconds for blocking read.
-        unpack : bool
-            If True, unpack the data from bytes to numpy arrays.
-            If False, return the raw bytes.
-
-        Returns
-        -------
-        acc_cnt : int
-            Accumulation count, read from the correlation data.
-        sync_time : float
-            Synchronization time, when `acc_cnt` is 0.
-        data : dict
-            If `unpack` is True, return a dictionary with keys as
-            correlation pairs and values as numpy arrays of complex
-            numbers. If `unpack` is False, values are the raw bytes.
-
-        Raises
-        ------
-        TimeoutError
-            If no data is received within the timeout period.
-
-        Notes
-        -----
-        The length of the data arrays is the product of the 'nchan' and
-        'acc_bins' parameters in the SNAP configuration. The 'nchan'
-        parameter is the number of frequency channels, while 'acc_bins'
-        is the number of spectra read at each integration step.
-
-        """
-        if not self.r.sismember("data_streams", "stream:corr"):
-            self.logger.warning(
-                "No correlation data stream found. "
-                "Please ensure the SNAP is running and sending data."
-            )
-            return None, None, {}
-        if pairs is None:
-            pairs = self.r.smembers("corr_pairs")
-        last_id = self.data_streams["stream:corr"]
-        out = self.r.xread(
-            {"stream:corr": last_id},
-            count=1,
-            block=int(timeout * 1000),
-        )
-        if not out:
-            raise TimeoutError("No correlation data received within timeout.")
-        eid, fields = out[0][1][0]
-        self._set_last_read_id("stream:corr", eid)  # update last read id
-        acc_cnt = int(fields.pop(b"acc_cnt").decode())
-        dtype = fields.pop(b"dtype").decode()
-        data = {}
-        for k, v in fields.items():
-            if unpack:
-                # unpack the bytes to numpy array of complex numbers
-                arr = np.frombuffer(v, dtype=dtype)
-            else:
-                # return raw bytes
-                arr = v
-            data[k.decode()] = arr
-        sync_time = self.get_live_metadata(keys="corr_sync_time")[
-            "sync_time_unix"
-        ]
-        return acc_cnt, sync_time, data
-
-    def add_vna_data(self, data, header=None, metadata=None):
-        """
-        Send VNA data to Redis using a stream. Used by client.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary holding VNA data. Keys are measurement modes and
-            values are arrays of complex numbers.
-        header : dict
-            VNA configuration. To be placed in file header.
-        metadata : dict
-            Live sensor metadata. To be placed in file header.
-
-        Raises
-        ------
-        ValueError
-            If data is empty or does not contain valid arrays.
-
-        """
-        # get array metadata
-        arr = next(iter(data.values()), None)
-        if arr is None:
-            raise ValueError("Data cannot be empty")
-        arr_meta = {
-            "dtype": arr.dtype.str,
-            "shape": arr.shape,
-            "order": "C" if arr.flags["C_CONTIGUOUS"] else "F",
-        }
-        payload = {}
-        for k, arr in data.items():
-            payload[k] = arr.tobytes()
-        payload["arr_meta"] = json.dumps(arr_meta)
-        if header is not None:
-            _hdr = header.copy()
-            for k, v in _hdr.items():
-                if isinstance(v, np.ndarray):
-                    _hdr[k] = v.tolist()
-            payload["header"] = json.dumps(_hdr)
-        if metadata is not None:
-            _md = metadata.copy()
-            for k, v in _md.items():
-                if isinstance(v, np.ndarray):
-                    _md[k] = v.tolist()
-            payload["metadata"] = json.dumps(_md)
-        self.r.xadd(
-            "stream:vna",
-            payload,
-            maxlen=self.maxlen["vna_data"],
-            approximate=True,
-        )
-        self.r.sadd("data_streams", "stream:vna")
-
-    def read_vna_data(self, timeout=0):
-        """
-        Blocking read of VNA data stream from Redis. Used by server.
-
-        Parameters
-        ----------
-        timeout : int
-            Timeout in seconds for blocking read. Set to 0 to block
-            indefinitely.
-
-        Returns
-        -------
-        data : dict
-            Dictionary holding VNA data. Keys are measurement modes and
-            values are arrays of complex numbers.
-        header : dict
-            VNA configuration. To be placed in file header.
-        metadata : dict
-            Live sensor metadata. To be placed in file header.
-
-        Raises
-        ------
-        TimeoutError
-            If no data is received within the timeout period.
-
-        Notes
-        -----
-        This is a blocking read with a timeout of ``timeout`` seconds.
-
-        """
-        if not self.r.sismember("data_streams", "stream:vna"):
-            self.logger.warning(
-                "No VNA data stream found. "
-                "Please ensure the VNA is running and sending data."
-            )
-            return None, None, None
-        last_id = self.data_streams["stream:vna"]
-        out = self.r.xread(
-            {"stream:vna": last_id},
-            count=1,
-            block=int(timeout * 1000),
-        )
-        if not out:
-            raise TimeoutError("No VNA data received within timeout.")
-        eid, fields = out[0][1][0]
-        self._set_last_read_id("stream:vna", eid)  # update last read id
-        # extract header, metadata, array_meta
-        arr_meta = json.loads(fields.pop(b"arr_meta").decode("utf-8"))
-        if b"header" in fields:
-            header = json.loads(fields.pop(b"header").decode("utf-8"))
-        else:
-            header = None
-        if b"metadata" in fields:
-            metadata = json.loads(fields.pop(b"metadata").decode("utf-8"))
-        else:
-            metadata = None
-        # decode the data arrays
-        vna_data = {}
-        for k, v in fields.items():
-            arr = np.frombuffer(v, dtype=np.dtype(arr_meta["dtype"])).reshape(
-                arr_meta["shape"], order=arr_meta["order"]
-            )
-            vna_data[k.decode()] = arr
-        return vna_data, header, metadata
+    def __init__(self, host="localhost", port=6379):
+        super().__init__(host=host, port=port)
+        self.corr_config = CorrConfigStore(self.transport)
+        self.corr = CorrWriter(self.transport)
+        self.corr_reader = CorrReader(self.transport)
+        self.vna = VnaWriter(self.transport)
+        self.vna_reader = VnaReader(self.transport)

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -12,7 +12,6 @@ CORR_SCALAR (18_8).
 """
 
 from copy import deepcopy
-import datetime
 import logging
 import time
 from pathlib import Path
@@ -301,7 +300,7 @@ class EigsepFpga:
                 self.logger.error(f"Configuration validation failed: {e}")
                 raise RuntimeError("Configuration validation failed") from e
         self.logger.debug("Uploading configuration to Redis.")
-        self.redis.upload_corr_config(self.cfg, from_file=False)
+        self.redis.corr_config.upload_config(self.cfg, from_file=False)
 
     def initialize(
         self,
@@ -601,13 +600,8 @@ class EigsepFpga:
             self.logger.info(f"Synchronized at {sync_time}.")
         self.sync_time = sync_time
         self.is_synchronized = True
-        sync_meta = {
-            "sync_time_unix": self.sync_time,
-            "sync_date": datetime.datetime.fromtimestamp(
-                self.sync_time
-            ).isoformat(),
-        }
-        self.redis.add_metadata("corr_sync_time", sync_meta)
+        # update header in redis with fresh sync time
+        self.redis.corr_config.upload_header(self.header)
 
     def unpack_data(self, data):
         """
@@ -807,23 +801,6 @@ class EigsepFpga:
         except AttributeError:
             self.logger.error("Observation not started or already ended.")
 
-    def update_redis(self, data, cnt):
-        """
-        Stream data and metadata to Redis.
-
-        Parameters
-        ----------
-        data : dict
-            A dictionary of raw data from the correlator.
-        cnt : int
-            Accumulation count from the correlator.
-
-        """
-        self.redis.add_corr_data(data, cnt, dtype=self.cfg["dtype"])
-        # hack to upload header regularly
-        if cnt % 100 == 0:
-            self.redis.upload_corr_header(self.header)
-
     def observe(self, pairs=None, timeout=10):
         """
         Read correlator data and stream it to Redis.
@@ -868,4 +845,4 @@ class EigsepFpga:
                     continue
             data = d["data"]
             cnt = d["cnt"]
-            self.update_redis(data, cnt)
+            self.redis.corr.add(data, cnt, dtype=self.cfg["dtype"])

--- a/src/eigsep_observing/keys.py
+++ b/src/eigsep_observing/keys.py
@@ -1,0 +1,14 @@
+"""
+Central registry of Redis keys owned by ``eigsep_observing``.
+
+Complements ``eigsep_redis.keys`` — this module holds observer-side
+keys (corr, vna) that don't belong in the shared lower-level package.
+Cross-package uniqueness is enforced by
+``tests/test_key_uniqueness.py``.
+"""
+
+CORR_STREAM = "stream:corr"
+CORR_CONFIG_KEY = "corr_config"
+CORR_HEADER_KEY = "corr_header"
+CORR_PAIRS_SET = "corr_pairs"
+VNA_STREAM = "stream:vna"

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -42,9 +42,9 @@ class EigObserver:
         self.redis_panda = redis_panda
 
         if self.redis_snap is not None:
-            self.corr_cfg = self.redis_snap.get_corr_config()
+            self.corr_cfg = self.redis_snap.corr_config.get_config()
         if self.redis_panda is not None:
-            self.cfg = self.redis_panda.get_config()
+            self.cfg = self.redis_panda.config.get()
 
         self.stop_event = threading.Event()  # main stop event
 
@@ -69,7 +69,7 @@ class EigObserver:
         """
         if self.redis_panda is None:
             return False
-        return self.redis_panda.client_heartbeat_check()
+        return self.redis_panda.heartbeat_reader.check()
 
     def status_logger(self):
         """
@@ -91,7 +91,7 @@ class EigObserver:
                 if self.stop_event.wait(1):  # wait 1s before checking again
                     return
             self.logger.debug("Panda connected.")
-            level, status = self.redis_panda.read_status(timeout=0.1)
+            level, status = self.redis_panda.status_reader.read(timeout=0.1)
             if status is not None:
                 self.logger.log(level, status)
 
@@ -132,27 +132,37 @@ class EigObserver:
             if self.stop_event.wait(1):
                 return
 
+        sync_time = None
         while not self.stop_event.is_set():
             if file.counter == 0:  # look up header in Redis once per file
                 try:
-                    header = self.redis_snap.get_corr_header()
+                    header = self.redis_snap.corr_config.get_header()
                 except ValueError as e:
                     self.logger.error(f"Error reading header from SNAP: {e}")
                     header = None
+                if header is not None:
+                    sync_time = header.get("sync_time")
+                if sync_time is None or sync_time == 0:
+                    self.logger.error(
+                        "No sync_time in corr header. Cannot "
+                        "derive accurate timestamps. Waiting "
+                        "for SNAP to synchronize."
+                    )
+                    if self.stop_event.wait(1):
+                        return
+                    continue
                 file.set_header(header=header)
             # blocking read from Redis
-            acc_cnt, sync_time, data = self.redis_snap.read_corr_data(
+            acc_cnt, data = self.redis_snap.corr_reader.read(
                 pairs=pairs, timeout=timeout, unpack=True
             )
             self.logger.info(f"{acc_cnt=}")
             if self.panda_connected:
-                metadata = self.redis_panda.get_metadata()
+                metadata = self.redis_panda.metadata_stream.drain()
             else:
                 metadata = None
             file.add_data(acc_cnt, sync_time, data, metadata=metadata)
 
-        # close() flushes any pending buffer to disk before shutting
-        # down the writer thread, so no manual flush is needed.
         file.close()
 
     def record_vna_data(self, save_dir, timeout=60):
@@ -186,7 +196,7 @@ class EigObserver:
                     return
                 continue
             try:
-                data, header, metadata = self.redis_panda.read_vna_data(
+                data, header, metadata = self.redis_panda.vna_reader.read(
                     timeout=timeout
                 )
             except TimeoutError:

--- a/src/eigsep_observing/plot.py
+++ b/src/eigsep_observing/plot.py
@@ -89,7 +89,7 @@ class LivePlotter:
         self.poll_interval = poll_interval
 
         # Get configuration from Redis
-        self.corr_cfg = self.redis.get_corr_config()
+        self.corr_cfg = self.redis.corr_config.get_config()
         self.nchan = self.corr_cfg.get("n_chans", 1024)
         self.sample_rate = self.corr_cfg.get("sample_rate", 500)
 
@@ -213,7 +213,7 @@ class LivePlotter:
 
     def update_plot(self, frame):
         """Update plot data (called by animation)."""
-        data = self.redis.read_corr_data(pairs=self.pairs, timeout=0)[-1]
+        data = self.redis.corr_reader.read(pairs=self.pairs, timeout=0)[-1]
         data = {k: v for k, v in data.items() if k in self.pairs}
         data = reshape_data(data, avg_even_odd=True)
         # Update magnitude plot

--- a/src/eigsep_observing/testing/eig_redis.py
+++ b/src/eigsep_observing/testing/eig_redis.py
@@ -1,12 +1,7 @@
-import fakeredis
+from eigsep_redis.testing import DummyTransport
 
 from ..eig_redis import EigsepObsRedis
 
 
 class DummyEigsepObsRedis(EigsepObsRedis):
-    def _make_redis(self, *args, **kwargs):
-        """
-        Create a fake Redis instance for testing purposes. Overrides
-        the parent class method.
-        """
-        return fakeredis.FakeRedis(decode_responses=False)
+    transport_cls = DummyTransport

--- a/src/eigsep_observing/testing/observer.py
+++ b/src/eigsep_observing/testing/observer.py
@@ -15,8 +15,8 @@ class DummyEigObserver(EigObserver):
         """
         # upload corr config to redis, parent class will read it
         if redis_snap is not None:
-            redis_snap.upload_corr_config(CORR_CFG_PATH, from_file=True)
+            redis_snap.corr_config.upload_config(CORR_CFG_PATH, from_file=True)
         if redis_panda is not None:
-            redis_panda.upload_config(CFG_PATH, from_file=True)
+            redis_panda.config.upload(CFG_PATH, from_file=True)
         # call parent constructor
         super().__init__(redis_snap=redis_snap, redis_panda=redis_panda)

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -1,0 +1,139 @@
+import json
+import logging
+
+import numpy as np
+
+from eigsep_redis.keys import DATA_STREAMS_SET
+
+from .keys import VNA_STREAM
+
+logger = logging.getLogger(__name__)
+
+
+class VnaWriter:
+    """
+    Publish VNA S11 measurements onto the VNA stream.
+
+    Each entry carries per-trace raw bytes, an ``arr_meta`` sidecar
+    (dtype/shape/order), and optional JSON-encoded ``header`` and
+    ``metadata`` blobs. Numpy arrays inside ``header`` / ``metadata``
+    are flattened to lists before encoding.
+    """
+
+    maxlen = 1000
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def add(self, data, header=None, metadata=None):
+        """
+        Publish one VNA measurement.
+
+        Parameters
+        ----------
+        data : dict[str, np.ndarray]
+            Keys are measurement modes (e.g. ``"ant"``, ``"rec"``,
+            ``"cal:open"``), values are complex arrays.
+        header : dict or None
+            VNA configuration. Placed in the file header downstream.
+        metadata : dict or None
+            Live sensor snapshot at VNA trigger time.
+
+        Raises
+        ------
+        ValueError
+            If ``data`` is empty.
+        """
+        arr = next(iter(data.values()), None)
+        if arr is None:
+            raise ValueError("Data cannot be empty")
+        arr_meta = {
+            "dtype": arr.dtype.str,
+            "shape": arr.shape,
+            "order": "C" if arr.flags["C_CONTIGUOUS"] else "F",
+        }
+        payload = {k: arr.tobytes() for k, arr in data.items()}
+        payload["arr_meta"] = json.dumps(arr_meta)
+        if header is not None:
+            _hdr = header.copy()
+            for k, v in _hdr.items():
+                if isinstance(v, np.ndarray):
+                    _hdr[k] = v.tolist()
+            payload["header"] = json.dumps(_hdr)
+        if metadata is not None:
+            _md = metadata.copy()
+            for k, v in _md.items():
+                if isinstance(v, np.ndarray):
+                    _md[k] = v.tolist()
+            payload["metadata"] = json.dumps(_md)
+        r = self.transport.r
+        r.xadd(
+            VNA_STREAM,
+            payload,
+            maxlen=self.maxlen,
+            approximate=True,
+        )
+        r.sadd(DATA_STREAMS_SET, VNA_STREAM)
+
+
+class VnaReader:
+    """Consume VNA S11 measurements from the VNA stream."""
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def read(self, timeout=0):
+        """
+        Blocking read of one VNA entry.
+
+        Parameters
+        ----------
+        timeout : int
+            Timeout in seconds. Pass 0 to block indefinitely.
+
+        Returns
+        -------
+        (data, header, metadata) : tuple
+            ``(dict[str, np.ndarray], dict | None, dict | None)``.
+            Returns ``(None, None, None)`` if no VNA stream exists yet.
+
+        Raises
+        ------
+        TimeoutError
+            If no entry arrives within ``timeout``.
+        """
+        r = self.transport.r
+        if not r.sismember(DATA_STREAMS_SET, VNA_STREAM):
+            self.transport.logger.warning(
+                "No VNA data stream found. "
+                "Please ensure the VNA is running and sending data."
+            )
+            return None, None, None
+        last_id = self.transport._streams_from_set(DATA_STREAMS_SET)[
+            VNA_STREAM
+        ]
+        out = r.xread(
+            {VNA_STREAM: last_id},
+            count=1,
+            block=int(timeout * 1000),
+        )
+        if not out:
+            raise TimeoutError("No VNA data received within timeout.")
+        eid, fields = out[0][1][0]
+        self.transport._set_last_read_id(VNA_STREAM, eid)
+        arr_meta = json.loads(fields.pop(b"arr_meta").decode("utf-8"))
+        if b"header" in fields:
+            header = json.loads(fields.pop(b"header").decode("utf-8"))
+        else:
+            header = None
+        if b"metadata" in fields:
+            metadata = json.loads(fields.pop(b"metadata").decode("utf-8"))
+        else:
+            metadata = None
+        vna_data = {}
+        for k, v in fields.items():
+            arr = np.frombuffer(v, dtype=np.dtype(arr_meta["dtype"])).reshape(
+                arr_meta["shape"], order=arr_meta["order"]
+            )
+            vna_data[k.decode()] = arr
+        return vna_data, header, metadata

--- a/src/eigsep_redis/__init__.py
+++ b/src/eigsep_redis/__init__.py
@@ -1,3 +1,23 @@
+from .config import ConfigStore
 from .eig_redis import EigsepRedis
+from .heartbeat import HeartbeatReader, HeartbeatWriter
+from .metadata import (
+    MetadataSnapshotReader,
+    MetadataStreamReader,
+    MetadataWriter,
+)
+from .status import StatusReader, StatusWriter
+from .transport import Transport
 
-__all__ = ["EigsepRedis"]
+__all__ = [
+    "ConfigStore",
+    "EigsepRedis",
+    "HeartbeatReader",
+    "HeartbeatWriter",
+    "MetadataSnapshotReader",
+    "MetadataStreamReader",
+    "MetadataWriter",
+    "StatusReader",
+    "StatusWriter",
+    "Transport",
+]

--- a/src/eigsep_redis/config.py
+++ b/src/eigsep_redis/config.py
@@ -1,0 +1,48 @@
+import json
+
+import yaml
+
+from .keys import CONFIG_KEY
+
+
+class ConfigStore:
+    """
+    Persistent single-key store for the panda-side YAML configuration.
+
+    ``upload`` serializes the config (plus an ``upload_time``) under a
+    well-known Redis key; ``get`` reads it back. This is the generic
+    panda config — the SNAP-side correlator config lives in a separate
+    store in ``eigsep_observing``.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload(self, config, from_file=True):
+        """
+        Upload the panda configuration to Redis.
+
+        Parameters
+        ----------
+        config : str or dict
+            Path to a YAML file if ``from_file`` is True, else a dict.
+        from_file : bool
+        """
+        if from_file:
+            with open(config, "r") as f:
+                config = yaml.safe_load(f)
+        self.transport._upload_dict(config, CONFIG_KEY)
+
+    def get(self):
+        """
+        Return the panda configuration.
+
+        Raises
+        ------
+        ValueError
+            If no configuration is present.
+        """
+        raw = self.transport.get_raw(CONFIG_KEY)
+        if raw is None:
+            raise ValueError("No configuration found in Redis.")
+        return json.loads(raw)

--- a/src/eigsep_redis/eig_redis.py
+++ b/src/eigsep_redis/eig_redis.py
@@ -1,17 +1,21 @@
-from datetime import datetime, timezone
-import json
 import logging
-import threading
-import yaml
+import warnings
 
-import redis
-import redis.exceptions
+from .config import ConfigStore
+from .heartbeat import HeartbeatReader, HeartbeatWriter
+from .metadata import (
+    MetadataSnapshotReader,
+    MetadataStreamReader,
+    MetadataWriter,
+)
+from .status import StatusReader, StatusWriter
+from .transport import Transport
 
 logger = logging.getLogger(__name__)
 
 
 class EigsepRedis:
-    maxlen = {"status": 5, "data": 5000}
+    transport_cls = Transport
 
     def __init__(self, host="localhost", port=6379):
         """
@@ -23,125 +27,78 @@ class EigsepRedis:
         port : int
 
         """
-        self.logger = logger
-        self._stream_lock = threading.RLock()
-        self._last_read_ids = {}
-        self._last_read_ids["stream:status"] = "$"
-        self.logger.info(f"{self._last_read_ids=}")
-        self.r = self._make_redis(host, port)
-        self.host = host
-        self.port = port
+        self.transport = self.transport_cls(host, port)
+        self.metadata = MetadataWriter(self.transport)
+        self.metadata_snapshot = MetadataSnapshotReader(self.transport)
+        self.metadata_stream = MetadataStreamReader(self.transport)
+        self.status = StatusWriter(self.transport)
+        self.status_reader = StatusReader(self.transport)
+        self.heartbeat = HeartbeatWriter(self.transport)
+        self.heartbeat_reader = HeartbeatReader(self.transport)
+        self.config = ConfigStore(self.transport)
 
-    def _make_redis(self, host, port):
-        """
-        Create a Redis connection with error handling.
+    # ---- forwarded attributes (state lives on the transport) ----
 
-        Parameters
-        ----------
-        host : str
-        port : int
+    @property
+    def r(self):
+        return self.transport.r
 
-        Returns
-        -------
-        r : redis.Redis
-            Redis client instance
+    @property
+    def logger(self):
+        return self.transport.logger
 
-        Raises
-        ------
-        redis.exceptions.ConnectionError
-            If connection to Redis fails
+    @property
+    def host(self):
+        return self.transport.host
 
-        """
-        try:
-            r = redis.Redis(
-                host=host,
-                port=port,
-                decode_responses=False,
-                socket_timeout=None,
-                socket_connect_timeout=None,
-                retry_on_timeout=False,
-            )
-            # Test connection
-            r.ping()
-            self.logger.info(f"Connected to Redis at {host}:{port}")
-        except redis.exceptions.ConnectionError as e:
-            self.logger.error(
-                f"Failed to connect to Redis at {host}:{port}: {e}"
-            )
-            raise
-        except Exception as e:
-            self.logger.error(f"Unexpected error connecting to Redis: {e}")
-            raise
-        return r
+    @property
+    def port(self):
+        return self.transport.port
+
+    @property
+    def _stream_lock(self):
+        return self.transport._stream_lock
+
+    @property
+    def _last_read_ids(self):
+        return self.transport._last_read_ids
+
+    # ---- thin forwarders for transport helpers ----
 
     def _get_last_read_id(self, stream):
-        """
-        Thread-safe getter for last read ID.
-
-        Parameters
-        ----------
-        stream : str
-            Stream name
-
-        Returns
-        -------
-        str
-            Last read ID for the stream
-        """
-        with self._stream_lock:
-            try:
-                last = self._last_read_ids[stream]
-            except KeyError:
-                last = self.r.xinfo_stream(stream)["last-generated-id"]
-            return last
+        return self.transport._get_last_read_id(stream)
 
     def _set_last_read_id(self, stream, read_id):
-        """
-        Thread-safe setter for last read ID.
-
-        Parameters
-        ----------
-        stream : str
-            Stream name
-        read_id : str
-            New read ID
-        """
-        with self._stream_lock:
-            self._last_read_ids[stream] = read_id
-
-    def reset(self):
-        """
-        Reset the EigsepRedis client by clearing all data streams and
-        resetting the last read ids.
-
-        """
-        self.r.flushdb()
-        with self._stream_lock:
-            self._last_read_ids.clear()
-            self._last_read_ids["stream:status"] = "$"
+        return self.transport._set_last_read_id(stream, read_id)
 
     def _streams_from_set(self, set_name):
-        """
-        Build a ``{stream_name: last_read_id}`` dict from a Redis set of
-        stream names. If no entry has been read, the value is '$',
-        indicating the read should start from the newest message.
-        """
-        members = self.r.smembers(set_name)
-        with self._stream_lock:
-            d = {}
-            for s in members:
-                try:
-                    last = self._last_read_ids[s.decode()]
-                except KeyError:
-                    try:
-                        last = self.r.xinfo_stream(s.decode())[
-                            "last-generated-id"
-                        ]
-                    except KeyError:
-                        # default to "$" for newly created streams
-                        last = "$"
-                d[s.decode()] = last
-            return d
+        return self.transport._streams_from_set(set_name)
+
+    def reset(self):
+        return self.transport.reset()
+
+    def add_raw(self, key, value, ex=None):
+        return self.transport.add_raw(key, value, ex=ex)
+
+    def get_raw(self, key):
+        return self.transport.get_raw(key)
+
+    def _upload_dict(self, d, key):
+        return self.transport._upload_dict(d, key)
+
+    def is_connected(self):
+        return self.transport.is_connected()
+
+    def close(self):
+        return self.transport.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    # ---- stream indices (property view into Redis sets) ----
 
     @property
     def data_streams(self):
@@ -159,416 +116,20 @@ class EigsepRedis:
         """
         return self._streams_from_set("data_streams")
 
-    @property
-    def metadata_streams(self):
-        """
-        Dictionary of metadata streams only (i.e. streams registered by
-        ``add_metadata``, excluding corr/vna raw-data streams). Same
-        shape as ``data_streams``.
-
-        Returns
-        -------
-        d : dict
-
-        """
-        return self._streams_from_set("metadata_streams")
-
-    @property
-    def status_stream(self):
-        return {"stream:status": self._get_last_read_id("stream:status")}
-
-    # ------------------- configs -------------------
-
-    def add_raw(self, key, value, ex=None):
-        """
-        Update redis database with raw data in bytes.
-
-        Parameters
-        ----------
-        key : str
-            Data key.
-        value : bytes
-            Data value.
-        ex : int
-            Optional expiration time in seconds. If provided, the key will
-            expire after this time.
-
-        """
-        return self.r.set(key, value, ex=ex)
-
-    def get_raw(self, key):
-        """
-        Get raw bytes from Redis.
-
-        Parameters
-        ----------
-        key : str
-            Data key.
-
-        """
-        return self.r.get(key)
-
-    def _upload_dict(self, d, key):
-        """
-        Helper function for uploading dictionaries to Redis.
-
-        Parameters
-        ----------
-        d : dict
-        key : str
-            Redis key under which the configuration will be stored.
-
-        """
-        d = d.copy()
-        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        d["upload_time"] = now
-        self.add_raw(key, json.dumps(d).encode("utf-8"))
-
-    def upload_config(self, config, from_file=True):
-        """
-        Upload the Eigsep configuration to Redis.
-
-        Parameters
-        ----------
-        config : str or dict
-            Path to the configuration file if `from_file` is True, or a
-            dictionary containing the configuration data if `from_file`
-            is False.
-        from_file : bool
-
-        """
-        if from_file:
-            with open(config, "r") as f:
-                config = yaml.safe_load(f)
-        self._upload_dict(config, "config")
-
-    def get_config(self):
-        """
-        Get the configuration file from Redis. This is used to retrieve
-        the yaml configuration file for the Eigsep system.
-
-        Returns
-        -------
-        config : dict
-            Dictionary containing the configuration data.
-
-        Raises
-        ------
-        ValueError
-            If no configuration is found in Redis.
-
-        """
-        raw = self.get_raw("config")
-        if raw is None:
-            raise ValueError("No configuration found in Redis.")
-        return json.loads(raw)
-
     # ------------------- metadata -----------------
 
     def add_metadata(self, key, value):
         """
-        Add metadata to Redis. This both streams values and adds the current
-        value to a metadata hash.
+        Deprecated shim for picohost only. Prefer ``self.metadata.add``.
 
-        Parameters
-        ----------
-        key : str
-            Metadata key.
-        value : JSON serializable object
-            Metadata value.
-
-        Raises
-        ------
-        TypeError
-            If key is not a string.
-        ValueError
-            If key is empty or contains invalid characters.
+        TODO(monorepo): delete once picohost joins the monorepo and its
+        producers have migrated to ``MetadataWriter.add``.
         """
-        # Validate inputs
-        if not isinstance(key, str):
-            raise TypeError("key must be a string")
-        if not key or not key.strip():
-            raise ValueError("key cannot be empty or whitespace only")
-        if ":" in key:
-            raise ValueError(
-                "key cannot contain ':' character (reserved for Redis)"
-            )
-
-        try:
-            payload = json.dumps(value).encode("utf-8")
-        except (TypeError, ValueError) as e:
-            raise ValueError(f"value is not JSON serializable: {e}")
-
-        # hash (for live updates)
-        self.r.hset("metadata", key, payload)
-        ts = datetime.now(timezone.utc).isoformat()  # XXX unreliable
-        self.r.hset("metadata", f"{key}_ts", json.dumps(ts).encode("utf-8"))
-        # stream (for file metadata)
-        self.r.xadd(
-            f"stream:{key}",
-            {"value": payload},
-            maxlen=self.maxlen["data"],
-            approximate=True,
+        warnings.warn(
+            "EigsepRedis.add_metadata is deprecated; use "
+            "redis.metadata.add(key, value). This shim will be removed "
+            "once picohost joins the monorepo.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        # add the stream to both the general data streams set and the
-        # metadata-only set (the latter is what get_metadata() defaults
-        # to, so raw-data streams like stream:corr / stream:vna never
-        # end up there)
-        self.r.sadd("data_streams", f"stream:{key}")
-        self.r.sadd("metadata_streams", f"stream:{key}")
-
-    def get_live_metadata(self, keys=None):
-        """
-        Get live metadata from Redis, i.e. the current values stored
-        in the metadata hash.
-
-        This is the **snapshot** path. It is used by ``PandaClient``
-        when packaging VNA measurements (client.py): a VNA reading
-        is point-in-time, taken at ~1/hour cadence, and the right
-        metadata semantics are "what was the latest sensor reading
-        at the moment the VNA was triggered." Use this for any
-        consumer that wants a current snapshot rather than a
-        cadence-matched average. **Do not use this for the corr
-        loop** — corr metadata is averaged over the integration via
-        ``get_metadata`` instead (see that method's docstring).
-
-        Caveat: ``get_live_metadata`` reads the latest hash values
-        with no freshness check. If a sensor stopped updating an
-        hour ago, you silently get the stale value. The VNA file
-        header includes ``metadata_snapshot_unix`` (set by
-        PandaClient) to let downstream detect this at inspection
-        time, but there is no runtime warning today.
-
-        Parameters
-        ----------
-        keys : str or list of str
-            Metadata key(s). If None, return all metadata.
-
-        Returns
-        -------
-        m : dict or any
-            Dictionary of metadata. If keys is None, return all metadata.
-            If keys is a string, return the value for that key.
-            If keys is a list, return a dictionary with the requested keys.
-
-        Raises
-        ------
-        TypeError
-            If keys is not a string or a list of strings.
-
-        """
-        if keys is not None and not isinstance(keys, (str, list)):
-            raise TypeError("Keys must be a string or a list of strings.")
-        if isinstance(keys, list) and not all(
-            isinstance(k, str) for k in keys
-        ):
-            raise TypeError("All keys in the list must be strings.")
-        m = {}
-        metadata = self.r.hgetall("metadata")
-        for k, v in metadata.items():
-            m[k.decode("utf-8")] = json.loads(v)
-        if keys is None:
-            return m
-        elif isinstance(keys, str):
-            return m[keys]
-        else:
-            filtered_m = {}
-            for k in keys:
-                filtered_m[k] = m[k]
-            return filtered_m
-
-    def get_metadata(self, stream_keys=None):
-        """
-        Get all metadata from redis stream for file writing.
-
-        This is the **streaming** path. It is used by
-        ``EigObserver.record_corr_data`` per integration: corr
-        spectra are an *integration* over a sub-second window, and
-        the right metadata semantics are "average all sensor
-        readings that happened during this integration." Each call
-        drains the stream since the last call (advances a per-stream
-        position pointer) and returns a list of dicts that the
-        caller averages down to one entry per spectrum via
-        ``io.avg_metadata``. **Do not use this for VNA** — VNA wants
-        a point-in-time snapshot, not a drain since the previous
-        VNA an hour ago (see ``get_live_metadata``).
-
-        Because ``get_metadata`` advances the position pointer,
-        only one consumer per ``EigsepRedis`` instance can call it
-        per stream — otherwise consumers race for stream entries.
-        Today only the corr loop calls it.
-
-        Parameters
-        ----------
-        stream_keys : str or list of str
-            Redis stream key. If a list, return the requested streams.
-            If None, return all registered metadata streams.
-
-        Returns
-        -------
-        redis_hdr : dict
-            Dictionary of stream data. Each key is a stream name, and the
-            value is a list of data values.
-
-        Notes
-        -----
-        This grabs updated metadata from the Redis streams. If a stream
-        has not been updated, it will not be included in the output.
-
-        With ``stream_keys=None`` this reads only streams registered
-        via ``add_metadata`` (tracked in the Redis ``metadata_streams``
-        set), so raw-data streams like ``stream:corr`` / ``stream:vna``
-        — whose payloads are not JSON — are excluded by construction.
-
-        """
-        if stream_keys is None:
-            streams = self.metadata_streams
-        else:
-            if isinstance(stream_keys, str):
-                stream_keys = [stream_keys]
-            streams = {
-                k: self.data_streams[k]
-                for k in stream_keys
-                if k in self.data_streams
-            }
-
-        # non-blocking read: correlator loop runs at ~4 Hz, so we
-        # must not stall here. Picos push at 200 ms, so data will
-        # accumulate between calls and be averaged by the caller.
-        # Note: block=None (omit) = return immediately; block=0 =
-        # block forever.
-        redis_hdr = {}
-        if not streams:  # no streams to read
-            return redis_hdr
-        resp = self.r.xread(streams)
-        for stream, dat in resp:
-            stream = stream.decode()  # decode stream name
-            out = []
-            # stream is a list of tuples (id, data)
-            for eid, d in dat:
-                value = json.loads(d[b"value"])
-                out.append(value)
-                # update the stream id
-                self._set_last_read_id(stream, eid)
-            redis_hdr[stream] = out
-        return redis_hdr
-
-    # ------------------- heartbeat and status -----------------
-
-    def client_heartbeat_set(self, ex=None, alive=True):
-        """
-        Set the client heartbeat key in Redis. This is used to keep
-        track of whether the client is alive or not.
-
-        Parameters
-        ----------
-        ex : int
-            Expiration time in seconds.
-        alive : bool
-            If True, set the key to 1, otherwise set it to 0 (not alive).
-
-        """
-        self.add_raw("heartbeat:client", int(alive), ex=ex)
-
-    def client_heartbeat_check(self):
-        """
-        Check if client is alive by checking the heartbeat.
-
-        Returns
-        -------
-        alive : bool
-            True if client is alive, False otherwise.
-
-        """
-        raw = self.get_raw("heartbeat:client")
-        if raw is None:
-            return False
-        return int(raw) == 1
-
-    def send_status(self, level=logging.INFO, status=None):
-        """
-        Publish status message to Redis. Used by client.
-
-        Parameters
-        ----------
-        level : int
-            Log level.
-        status : str
-            Status message.
-
-        """
-        self.r.xadd(
-            "stream:status",
-            {"level": level, "status": status},
-            maxlen=self.maxlen["status"],
-        )
-
-    def read_status(self, timeout=None):
-        """
-        Read status stream from Redis. Used by server.
-
-        Parameters
-        ----------
-        timeout : int, optional
-            Timeout in seconds for blocking read. If None, blocks indefinitely.
-
-        Returns
-        -------
-        level : int
-            Log level of the status message.
-        status : str
-            Status message. If None, no message was received.
-
-        """
-        # blocking read with optional timeout
-        block_time = 0 if timeout is None else int(timeout * 1000)
-        msg = self.r.xread(self.status_stream, count=1, block=block_time)
-        if not msg:
-            return None, None
-        entry_id, status_dict = msg[0][1][0]
-        self._set_last_read_id(
-            "stream:status", entry_id
-        )  # update the stream id
-        status = status_dict.get(b"status").decode("utf-8")
-        raw_level = status_dict.get(b"level")
-        if raw_level is None:
-            level = logging.INFO  # default to info
-        else:
-            level = int(raw_level.decode("utf-8"))
-        return level, status
-
-    def is_connected(self):
-        """
-        Check if Redis connection is active.
-
-        Returns
-        -------
-        bool
-            True if connected, False otherwise
-        """
-        try:
-            return self.r.ping()
-        except (
-            redis.exceptions.ConnectionError,
-            redis.exceptions.TimeoutError,
-        ):
-            return False
-
-    def close(self):
-        """
-        Close the Redis connection and clean up resources.
-        """
-        try:
-            if hasattr(self.r, "close"):
-                self.r.close()
-            self.logger.info("Redis connection closed")
-        except Exception as e:
-            self.logger.warning(f"Error closing Redis connection: {e}")
-
-    def __enter__(self):
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit."""
-        self.close()
+        self.metadata.add(key, value)

--- a/src/eigsep_redis/heartbeat.py
+++ b/src/eigsep_redis/heartbeat.py
@@ -1,0 +1,49 @@
+from .keys import HEARTBEAT_KEY
+
+
+class HeartbeatWriter:
+    """
+    Set/clear the client-liveness heartbeat.
+
+    The panda-side ``PandaClient`` calls ``set`` periodically (with a
+    short ``ex`` TTL) to prove it's still running; it calls
+    ``set(alive=False)`` on graceful shutdown. The ground-side observer
+    reads the heartbeat via :class:`HeartbeatReader.check`.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def set(self, ex=None, alive=True):
+        """
+        Publish a heartbeat tick.
+
+        Parameters
+        ----------
+        ex : int or None
+            Optional TTL in seconds. Typical pattern: set with
+            ``ex=60`` on a ~1 Hz cadence so a crashed client is
+            detected within 60s.
+        alive : bool
+            ``True`` to mark the client alive, ``False`` to mark it
+            down (shutdown).
+        """
+        self.transport.add_raw(HEARTBEAT_KEY, int(alive), ex=ex)
+
+
+class HeartbeatReader:
+    """Read-only view of the client-liveness heartbeat."""
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def check(self):
+        """
+        Return ``True`` if the client is alive, ``False`` otherwise.
+
+        A missing key (TTL expired, never set) returns ``False``.
+        """
+        raw = self.transport.get_raw(HEARTBEAT_KEY)
+        if raw is None:
+            return False
+        return int(raw) == 1

--- a/src/eigsep_redis/keys.py
+++ b/src/eigsep_redis/keys.py
@@ -1,0 +1,16 @@
+"""
+Central registry of Redis keys owned by ``eigsep_redis``.
+
+Every key/stream/set constant touched by this package lives here so
+that collisions are visible at import time and new names can be
+audited in one place. Observer-side keys (corr, vna) live in
+``eigsep_observing.keys``; both modules are checked for cross-package
+uniqueness by ``tests/test_key_uniqueness.py``.
+"""
+
+METADATA_HASH = "metadata"
+METADATA_STREAMS_SET = "metadata_streams"
+DATA_STREAMS_SET = "data_streams"
+STATUS_STREAM = "stream:status"
+CONFIG_KEY = "config"
+HEARTBEAT_KEY = "heartbeat:client"

--- a/src/eigsep_redis/metadata.py
+++ b/src/eigsep_redis/metadata.py
@@ -1,0 +1,198 @@
+from datetime import datetime, timezone
+import json
+import logging
+
+from .keys import DATA_STREAMS_SET, METADATA_HASH, METADATA_STREAMS_SET
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataWriter:
+    """
+    Publish sensor metadata to Redis.
+
+    Each call to ``add`` writes to the live snapshot hash **and** the
+    per-key stream as a single logical operation, and registers the
+    stream in the metadata-only and generic stream-index sets. The two
+    destinations back the two readers (snapshot vs streaming) — splitting
+    them would let the readers drift out of sync.
+    """
+
+    maxlen = 5000
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def add(self, key, value):
+        """
+        Publish ``value`` under ``key``.
+
+        Parameters
+        ----------
+        key : str
+            Metadata key. Must be a non-empty string without ':'.
+        value : JSON-serializable object
+
+        Raises
+        ------
+        TypeError
+            If ``key`` is not a string.
+        ValueError
+            If ``key`` is empty/whitespace, contains ':', or ``value``
+            is not JSON-serializable.
+        """
+        if not isinstance(key, str):
+            raise TypeError("key must be a string")
+        if not key or not key.strip():
+            raise ValueError("key cannot be empty or whitespace only")
+        if ":" in key:
+            raise ValueError(
+                "key cannot contain ':' character (reserved for Redis)"
+            )
+        try:
+            payload = json.dumps(value).encode("utf-8")
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"value is not JSON serializable: {e}")
+
+        r = self.transport.r
+        # hash (snapshot path)
+        r.hset(METADATA_HASH, key, payload)
+        ts = datetime.now(timezone.utc).isoformat()
+        r.hset(METADATA_HASH, f"{key}_ts", json.dumps(ts).encode("utf-8"))
+        # stream (drain path for corr-cadence averaging)
+        r.xadd(
+            f"stream:{key}",
+            {"value": payload},
+            maxlen=self.maxlen,
+            approximate=True,
+        )
+        # register the stream so the metadata-only default for
+        # MetadataStreamReader.drain() excludes raw-data streams like
+        # stream:corr / stream:vna by construction
+        r.sadd(DATA_STREAMS_SET, f"stream:{key}")
+        r.sadd(METADATA_STREAMS_SET, f"stream:{key}")
+
+
+class MetadataSnapshotReader:
+    """
+    Snapshot-semantic metadata reader.
+
+    Reads the latest values written by :class:`MetadataWriter` from
+    the live hash. No position pointer, no draining — each call sees
+    the same "latest" until the writer publishes something new. Used
+    by VNA (point-in-time capture) and any other consumer that wants
+    the current sensor state. **Do not use for the corr loop** — see
+    :class:`MetadataStreamReader` for cadence-matched averaging.
+
+    Caveat: no freshness check. If a sensor has stopped updating, a
+    stale value is silently returned. Callers that care should record
+    a snapshot timestamp alongside the read (see PandaClient's
+    ``metadata_snapshot_unix`` header field).
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def get(self, keys=None):
+        """
+        Fetch metadata from the live hash.
+
+        Parameters
+        ----------
+        keys : str or list of str or None
+            If ``None``, return the full metadata dict. If a string,
+            return the single value at that key. If a list, return a
+            dict restricted to those keys.
+
+        Raises
+        ------
+        TypeError
+            If ``keys`` is not ``None``, a string, or a list of strings.
+        """
+        if keys is not None and not isinstance(keys, (str, list)):
+            raise TypeError("Keys must be a string or a list of strings.")
+        if isinstance(keys, list) and not all(
+            isinstance(k, str) for k in keys
+        ):
+            raise TypeError("All keys in the list must be strings.")
+        raw = self.transport.r.hgetall(METADATA_HASH)
+        m = {k.decode("utf-8"): json.loads(v) for k, v in raw.items()}
+        if keys is None:
+            return m
+        if isinstance(keys, str):
+            return m[keys]
+        return {k: m[k] for k in keys}
+
+
+class MetadataStreamReader:
+    """
+    Streaming-semantic metadata reader.
+
+    Each call to ``drain`` advances the per-stream position pointer
+    and returns every value pushed since the previous call. Used by
+    ``EigObserver.record_corr_data`` to average sensor readings over
+    an integration window.
+
+    Because the pointer advances, only one consumer per ``Transport``
+    may call ``drain`` per stream — otherwise consumers race for
+    entries. Today only the corr loop calls it.
+
+    The default ``drain()`` (no arguments) reads only streams
+    registered in ``metadata_streams``, so raw-data streams like
+    ``stream:corr`` / ``stream:vna`` — whose payloads are not JSON —
+    are excluded by construction.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    @property
+    def streams(self):
+        """``{stream_name: last_read_id}`` over registered metadata streams."""
+        return self.transport._streams_from_set(METADATA_STREAMS_SET)
+
+    def drain(self, stream_keys=None):
+        """
+        Drain metadata streams since the last call.
+
+        Parameters
+        ----------
+        stream_keys : str or list of str or None
+            If ``None``, drain every registered metadata stream. If
+            given, drain only the listed streams (skipping any that
+            aren't registered).
+
+        Returns
+        -------
+        dict
+            ``{stream_name: [value, ...]}`` for each stream that had
+            entries since the last call. Streams with no new entries
+            are omitted.
+        """
+        if stream_keys is None:
+            streams = self.streams
+        else:
+            if isinstance(stream_keys, str):
+                stream_keys = [stream_keys]
+            all_streams = self.transport._streams_from_set(
+                METADATA_STREAMS_SET
+            )
+            streams = {
+                k: all_streams[k] for k in stream_keys if k in all_streams
+            }
+
+        # non-blocking read: correlator loop runs at ~4 Hz, so we
+        # must not stall here. Picos push at 200 ms, so data will
+        # accumulate between calls and be averaged by the caller.
+        out = {}
+        if not streams:
+            return out
+        resp = self.transport.r.xread(streams)
+        for stream, dat in resp:
+            stream = stream.decode()
+            values = []
+            for eid, d in dat:
+                values.append(json.loads(d[b"value"]))
+                self.transport._set_last_read_id(stream, eid)
+            out[stream] = values
+        return out

--- a/src/eigsep_redis/status.py
+++ b/src/eigsep_redis/status.py
@@ -1,0 +1,84 @@
+import logging
+
+from .keys import STATUS_STREAM
+
+logger = logging.getLogger(__name__)
+
+
+class StatusWriter:
+    """
+    Publish status messages onto the status stream.
+
+    Producers call ``send(level, status)`` to emit a human-readable
+    status line tagged with a Python logging level. The stream is
+    bounded via ``maxlen`` so a dead consumer can't grow it without
+    limit.
+    """
+
+    maxlen = 5
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def send(self, status, level=logging.INFO):
+        """
+        Publish a status message.
+
+        Parameters
+        ----------
+        status : str
+            Status message.
+        level : int
+            Python logging level.
+        """
+        self.transport.r.xadd(
+            STATUS_STREAM,
+            {"level": level, "status": status},
+            maxlen=self.maxlen,
+        )
+
+
+class StatusReader:
+    """
+    Consume status messages from the status stream.
+
+    ``read`` is a blocking XREAD scoped to ``stream:status`` only; it
+    cannot be coerced to read any other stream (the stream name is
+    hard-coded in :data:`STATUS_STREAM`).
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    @property
+    def stream(self):
+        """``{STATUS_STREAM: last_read_id}`` — view, used for blocking reads."""
+        return {STATUS_STREAM: self.transport._get_last_read_id(STATUS_STREAM)}
+
+    def read(self, timeout=None):
+        """
+        Blocking read of the next status message.
+
+        Parameters
+        ----------
+        timeout : float or None
+            Timeout in seconds. ``None`` blocks indefinitely.
+
+        Returns
+        -------
+        (level, status) : tuple
+            ``(int, str)`` on success, ``(None, None)`` on timeout.
+        """
+        block_time = 0 if timeout is None else int(timeout * 1000)
+        msg = self.transport.r.xread(self.stream, count=1, block=block_time)
+        if not msg:
+            return None, None
+        entry_id, status_dict = msg[0][1][0]
+        self.transport._set_last_read_id(STATUS_STREAM, entry_id)
+        status = status_dict.get(b"status").decode("utf-8")
+        raw_level = status_dict.get(b"level")
+        if raw_level is None:
+            level = logging.INFO
+        else:
+            level = int(raw_level.decode("utf-8"))
+        return level, status

--- a/src/eigsep_redis/testing/__init__.py
+++ b/src/eigsep_redis/testing/__init__.py
@@ -1,3 +1,4 @@
 from .eig_redis import DummyEigsepRedis
+from .transport import DummyTransport
 
-__all__ = ["DummyEigsepRedis"]
+__all__ = ["DummyEigsepRedis", "DummyTransport"]

--- a/src/eigsep_redis/testing/eig_redis.py
+++ b/src/eigsep_redis/testing/eig_redis.py
@@ -1,12 +1,6 @@
-import fakeredis
-
 from ..eig_redis import EigsepRedis
+from .transport import DummyTransport
 
 
 class DummyEigsepRedis(EigsepRedis):
-    def _make_redis(self, *args, **kwargs):
-        """
-        Create a fake Redis instance for testing purposes. Overrides
-        the parent class method.
-        """
-        return fakeredis.FakeRedis(decode_responses=False)
+    transport_cls = DummyTransport

--- a/src/eigsep_redis/testing/transport.py
+++ b/src/eigsep_redis/testing/transport.py
@@ -1,0 +1,10 @@
+import fakeredis
+
+from ..transport import Transport
+
+
+class DummyTransport(Transport):
+    """In-process ``Transport`` backed by fakeredis for tests."""
+
+    def _make_redis(self, host, port):
+        return fakeredis.FakeRedis(decode_responses=False)

--- a/src/eigsep_redis/transport.py
+++ b/src/eigsep_redis/transport.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timezone
+import json
+import logging
+import threading
+
+import redis
+import redis.exceptions
+
+logger = logging.getLogger(__name__)
+
+
+class Transport:
+    """
+    Shared Redis transport: connection, last-read-id bookkeeping,
+    raw K/V, and lifecycle.
+
+    Owns nothing bus-specific. Writer and reader classes are
+    constructed with a ``Transport`` and share the connection and
+    last-read-id state through it. Subclass and override
+    ``_make_redis`` to swap the underlying client (e.g. fakeredis
+    for testing).
+    """
+
+    def __init__(self, host="localhost", port=6379):
+        self.logger = logger
+        self.host = host
+        self.port = port
+        self._stream_lock = threading.RLock()
+        self._last_read_ids = {}
+        self.r = self._make_redis(host, port)
+
+    def _make_redis(self, host, port):
+        try:
+            r = redis.Redis(
+                host=host,
+                port=port,
+                decode_responses=False,
+                socket_timeout=None,
+                socket_connect_timeout=None,
+                retry_on_timeout=False,
+            )
+            r.ping()
+            self.logger.info(f"Connected to Redis at {host}:{port}")
+        except redis.exceptions.ConnectionError as e:
+            self.logger.error(
+                f"Failed to connect to Redis at {host}:{port}: {e}"
+            )
+            raise
+        except Exception as e:
+            self.logger.error(f"Unexpected error connecting to Redis: {e}")
+            raise
+        return r
+
+    def _get_last_read_id(self, stream):
+        with self._stream_lock:
+            if stream in self._last_read_ids:
+                return self._last_read_ids[stream]
+            try:
+                return self.r.xinfo_stream(stream)["last-generated-id"]
+            except redis.exceptions.ResponseError:
+                return "$"
+
+    def _set_last_read_id(self, stream, read_id):
+        with self._stream_lock:
+            self._last_read_ids[stream] = read_id
+
+    def _streams_from_set(self, set_name):
+        """
+        Build a ``{stream_name: last_read_id}`` dict from a Redis set
+        of stream names. Missing entries default to the last generated
+        ID if available, otherwise falls back to '$' (newest after read).
+        """
+        members = self.r.smembers(set_name)
+        with self._stream_lock:
+            d = {}
+            for s in members:
+                key = s.decode()
+                if key in self._last_read_ids:
+                    d[key] = self._last_read_ids[key]
+                    continue
+                try:
+                    d[key] = self.r.xinfo_stream(key)["last-generated-id"]
+                except redis.exceptions.ResponseError:
+                    d[key] = "$"
+            return d
+
+    def reset(self):
+        """Flush the whole Redis DB and reset last-read-id state."""
+        self.r.flushdb()
+        with self._stream_lock:
+            self._last_read_ids.clear()
+
+    def add_raw(self, key, value, ex=None):
+        return self.r.set(key, value, ex=ex)
+
+    def get_raw(self, key):
+        return self.r.get(key)
+
+    def _upload_dict(self, d, key):
+        """Serialize ``d`` as JSON (with ``upload_time`` injected) under ``key``."""
+        d = d.copy()
+        d["upload_time"] = datetime.now(timezone.utc).isoformat(
+            timespec="seconds"
+        )
+        self.add_raw(key, json.dumps(d).encode("utf-8"))
+
+    def is_connected(self):
+        try:
+            return self.r.ping()
+        except (
+            redis.exceptions.ConnectionError,
+            redis.exceptions.TimeoutError,
+        ):
+            return False
+
+    def close(self):
+        try:
+            if hasattr(self.r, "close"):
+                self.r.close()
+            self.logger.info("Redis connection closed")
+        except Exception as e:
+            self.logger.warning(f"Error closing Redis connection: {e}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,7 +44,7 @@ def client(redis, dummy_cfg):
 
 def test_client(client):
     # client is initialized with redis commands
-    assert client.redis.client_heartbeat_check()  # check heartbeat
+    assert client.redis.heartbeat_reader.check()  # check heartbeat
     # sw_proxy is always created as a generic PicoProxy
     assert client.sw_proxy is not None
     assert isinstance(client.sw_proxy, PicoProxy)
@@ -61,7 +61,7 @@ def test_get_cfg(caplog, dummy_cfg):
     # should be no config in redis at start
     r = DummyEigsepObsRedis(port=6380)  # different port to avoid conflicts
     with pytest.raises(ValueError):
-        r.get_config()
+        r.config.get()
     client2 = DummyPandaClient(r, default_cfg={})
     client3 = None
     try:
@@ -74,7 +74,7 @@ def test_get_cfg(caplog, dummy_cfg):
         assert "upload_time" in cfg_in_redis
 
         # upload the dummy config to client2's redis
-        client2.redis.upload_config(dummy_cfg, from_file=False)
+        client2.redis.config.upload(dummy_cfg, from_file=False)
 
         # check that they're the same
         retrieved_cfg = client2._get_cfg()

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -96,9 +96,9 @@ class TestEigsepFpga:
         caplog.set_level(logging.DEBUG)
 
         with patch.object(
-            fpga_instance.redis,
-            "upload_corr_config",
-            wraps=fpga_instance.redis.upload_corr_config,
+            fpga_instance.redis.corr_config,
+            "upload_config",
+            wraps=fpga_instance.redis.corr_config.upload_config,
         ) as spy:
             fpga_instance.upload_config(validate=True)
 
@@ -116,9 +116,9 @@ class TestEigsepFpga:
                 wraps=fpga_instance.validate_config,
             ) as validate_spy,
             patch.object(
-                fpga_instance.redis,
-                "upload_corr_config",
-                wraps=fpga_instance.redis.upload_corr_config,
+                fpga_instance.redis.corr_config,
+                "upload_config",
+                wraps=fpga_instance.redis.corr_config.upload_config,
             ) as upload_spy,
         ):
             fpga_instance.upload_config(validate=False)
@@ -137,9 +137,9 @@ class TestEigsepFpga:
                 side_effect=RuntimeError("Config invalid"),
             ),
             patch.object(
-                fpga_instance.redis,
-                "upload_corr_config",
-                wraps=fpga_instance.redis.upload_corr_config,
+                fpga_instance.redis.corr_config,
+                "upload_config",
+                wraps=fpga_instance.redis.corr_config.upload_config,
             ) as upload_spy,
         ):
             with pytest.raises(
@@ -151,15 +151,15 @@ class TestEigsepFpga:
         upload_spy.assert_not_called()
 
     def test_synchronize(self, fpga_instance):
-        """synchronize writes corr_sync_time and it round-trips through redis."""
+        """synchronize sets sync_time on the corr header and uploads it."""
         # Spy on the real Sync block so we observe the high-level
         # sequence (set_delay / arm_sync / sw_sync) without stubbing
         # out the register writes — the wraps= keeps DummyFpga state
-        # in sync with what real hardware would see. add_metadata is
-        # also wraps=, so the value actually lands in fakeredis and we
-        # can read it back via the production get_live_metadata path —
-        # this is the writer↔reader contract guard for the metadata
-        # serialization round-trip.
+        # in sync with what real hardware would see. upload_corr_header
+        # is wraps=, so the value actually lands in fakeredis and we
+        # can read it back via the production get_corr_header path —
+        # this is the writer↔reader contract guard for the corr header
+        # round-trip (sync_time lives on the header, not metadata).
         sync = fpga_instance.sync
         with (
             patch.object(
@@ -174,44 +174,37 @@ class TestEigsepFpga:
                 return_value=1234567890.0,
             ),
             patch.object(
-                fpga_instance.redis,
-                "add_metadata",
-                wraps=fpga_instance.redis.add_metadata,
-            ) as spy_add_metadata,
+                fpga_instance.redis.corr_config,
+                "upload_header",
+                wraps=fpga_instance.redis.corr_config.upload_header,
+            ) as spy_upload_header,
         ):
             fpga_instance.synchronize(delay=5)
 
         spy_set_delay.assert_called_once_with(5)
         spy_arm_sync.assert_called_once()
         assert spy_sw_sync.call_count == 3
-        spy_add_metadata.assert_called_once()
-        assert spy_add_metadata.call_args[0][0] == "corr_sync_time"
+        # synchronize() pushes the header once so consumers see fresh
+        # sync_time without waiting for the observe loop's periodic
+        # upload.
+        spy_upload_header.assert_called_once()
 
-        # Round-trip: read corr_sync_time back through the production
-        # get_live_metadata path and confirm the value survived the
-        # hset/json-encode → hgetall/json-decode pipeline intact.
-        metadata = fpga_instance.redis.get_live_metadata("corr_sync_time")
-        assert metadata["sync_time_unix"] == 1234567890.0
-        assert "sync_date" in metadata
+        # Round-trip: read corr_header back through the production
+        # get_corr_header path and confirm sync_time survived the
+        # json-encode → json-decode pipeline intact.
+        header = fpga_instance.redis.corr_config.get_header()
+        assert header["sync_time"] == 1234567890.0
 
     def test_synchronize_default_delay(self, fpga_instance):
-        """Test synchronize with default delay."""
-        with patch.object(
-            fpga_instance.redis,
-            "add_metadata",
-            wraps=fpga_instance.redis.add_metadata,
-        ) as spy_add_metadata:
+        """synchronize() with default delay still publishes sync_time on the header."""
+        with patch(
+            "eigsep_observing.fpga.time.time",
+            return_value=1111111111.0,
+        ):
             fpga_instance.synchronize()
 
-        # Verify that redis.add_metadata was called
-        spy_add_metadata.assert_called_once()
-
-        # Verify metadata structure
-        call_args = spy_add_metadata.call_args
-        assert call_args[0][0] == "corr_sync_time"
-        metadata = call_args[0][1]
-        assert "sync_time_unix" in metadata
-        assert "sync_date" in metadata
+        header = fpga_instance.redis.corr_config.get_header()
+        assert header["sync_time"] == 1111111111.0
 
     def test_initialize_all_enabled(self, fpga_instance, caplog):
         """initialize() with sync=True calls synchronize and logs."""
@@ -242,25 +235,6 @@ class TestEigsepFpga:
 
             # Verify that synchronize was called even with initialize_adc=False
             mock_sync.assert_called_once()
-
-    def test_update_redis(self, fpga_instance):
-        """update_redis forwards (data, cnt, dtype) to redis.add_corr_data."""
-        # Bytes match what fpga.read_data(unpack=False) actually returns
-        # in production — the prior list-of-int fixture diverged from
-        # the producer contract and only worked because the spy was a
-        # bare Mock that never ran the real xadd path.
-        test_data = {"0": b"\x00\x01\x02\x03", "1": b"\x04\x05\x06\x07"}
-        test_cnt = 42
-        expected_dtype = fpga_instance.cfg["dtype"]
-
-        with patch.object(
-            fpga_instance.redis,
-            "add_corr_data",
-            wraps=fpga_instance.redis.add_corr_data,
-        ) as spy:
-            fpga_instance.update_redis(test_data, test_cnt)
-
-        spy.assert_called_once_with(test_data, test_cnt, dtype=expected_dtype)
 
     def test_read_integrations_no_new_data(self, fpga_instance):
         """No new cnt → loop exits via pre-set event, queue stays empty."""
@@ -411,7 +385,7 @@ class TestEigsepFpga:
     def test_observe_basic_functionality(self, fpga_instance):
         """Test basic observe functionality."""
         fpga_instance.upload_config = Mock()
-        fpga_instance.update_redis = Mock()
+        expected_dtype = fpga_instance.cfg["dtype"]
 
         pairs = ["0"]
 
@@ -429,24 +403,30 @@ class TestEigsepFpga:
             {"data": d2, "cnt": 2},
             None,
         ]
-        with _patch_observe_thread(fpga_instance, items):
+        with (
+            patch.object(fpga_instance.redis.corr, "add") as mock_add,
+            _patch_observe_thread(fpga_instance, items),
+        ):
             fpga_instance.observe(pairs=pairs, timeout=10)
 
         fpga_instance.upload_config.assert_called_once_with(validate=True)
-        assert fpga_instance.update_redis.call_count == 2
-        fpga_instance.update_redis.assert_any_call(d1, 1)
-        fpga_instance.update_redis.assert_any_call(d2, 2)
+        assert mock_add.call_count == 2
+        mock_add.assert_any_call(d1, 1, dtype=expected_dtype)
+        mock_add.assert_any_call(d2, 2, dtype=expected_dtype)
 
     def test_observe_default_pairs(self, fpga_instance, caplog):
         """observe() with no pairs arg defaults to self.pairs."""
-        fpga_instance.update_redis = Mock()
+        expected_dtype = fpga_instance.cfg["dtype"]
 
         d1 = utils.generate_data(
             ntimes=1, raw=True, reshape=False, return_time_freq=False
         )
         items = [{"data": d1, "cnt": 1}, None]
         caplog.set_level(logging.INFO)
-        with _patch_observe_thread(fpga_instance, items) as mock_thread_cls:
+        with (
+            patch.object(fpga_instance.redis.corr, "add") as mock_add,
+            _patch_observe_thread(fpga_instance, items) as mock_thread_cls,
+        ):
             fpga_instance.observe()  # no pairs arg → defaults to self.pairs
 
         # Producer thread was constructed with self.pairs
@@ -461,7 +441,7 @@ class TestEigsepFpga:
             in caplog.text
         )
         # Data still drained normally
-        fpga_instance.update_redis.assert_called_once_with(d1, 1)
+        mock_add.assert_called_once_with(d1, 1, dtype=expected_dtype)
 
     def test_observe_timeout_immediate(self, fpga_instance, caplog):
         """
@@ -474,13 +454,14 @@ class TestEigsepFpga:
         producer-side no-data path is covered separately by
         test_read_integrations_no_new_data.
         """
-        fpga_instance.update_redis = Mock()
-
         caplog.set_level(logging.INFO)
-        with _patch_observe_thread(fpga_instance, [None]):
+        with (
+            patch.object(fpga_instance.redis.corr, "add") as mock_add,
+            _patch_observe_thread(fpga_instance, [None]),
+        ):
             fpga_instance.observe(pairs=["0"], timeout=1)
 
-        fpga_instance.update_redis.assert_not_called()
+        mock_add.assert_not_called()
         assert "End of queue, processing finished." in caplog.text
 
     def test_observe_logging(self, fpga_instance, caplog):
@@ -506,14 +487,18 @@ class TestEigsepFpga:
         Consumer drains every queued integration, in order, before
         exiting on the sentinel.
         """
-        fpga_instance.update_redis = Mock()
+        expected_dtype = fpga_instance.cfg["dtype"]
 
         items = [{"data": {"0": [i]}, "cnt": 10 + i} for i in range(5)]
         items.append(None)
-        with _patch_observe_thread(fpga_instance, items):
+        with (
+            patch.object(fpga_instance.redis.corr, "add") as mock_add,
+            _patch_observe_thread(fpga_instance, items),
+        ):
             fpga_instance.observe(pairs=["0", "1"], timeout=10)
 
-        assert fpga_instance.update_redis.call_count == 5
+        assert mock_add.call_count == 5
         # Order matters — assert via call_args_list, not assert_any_call.
-        for i, call in enumerate(fpga_instance.update_redis.call_args_list):
+        for i, call in enumerate(mock_add.call_args_list):
             assert call.args == ({"0": [i]}, 10 + i)
+            assert call.kwargs == {"dtype": expected_dtype}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,7 @@ Integration tests for the emulator-backed pico pipeline.
 
 Tests that sensor data flows from pico emulators (running inside an
 in-process PicoManager) through picohost reader threads into
-FakeRedis, and is retrievable via get_live_metadata().
+FakeRedis, and is retrievable via ``MetadataSnapshotReader.get``.
 """
 
 import time
@@ -55,7 +55,7 @@ def test_sensor_metadata_in_redis(client, redis):
     """Emulators generate status that flows through redis_handler to Redis."""
     time.sleep(0.5)
 
-    metadata = redis.get_live_metadata()
+    metadata = redis.metadata_snapshot.get()
 
     expected_sensors = {
         "tempctrl",
@@ -76,7 +76,7 @@ def test_metadata_has_expected_fields(client, redis):
     """Verify that metadata values contain the expected sensor fields."""
     time.sleep(0.5)
 
-    metadata = redis.get_live_metadata()
+    metadata = redis.metadata_snapshot.get()
 
     # Check tempctrl LNA/LOAD channels
     tempctrl = metadata.get("tempctrl", {})
@@ -110,9 +110,9 @@ def test_metadata_has_expected_fields(client, redis):
     assert potmon["pot_az_angle"] is None
 
 
-def test_get_live_metadata_single_key(client, redis):
-    """get_live_metadata with a single key returns just that sensor's data."""
+def test_metadata_snapshot_single_key(client, redis):
+    """metadata_snapshot.get(key) returns just that sensor's data."""
     time.sleep(0.5)
-    lidar = redis.get_live_metadata("lidar")
+    lidar = redis.metadata_snapshot.get("lidar")
     assert isinstance(lidar, dict)
     assert "distance_m" in lidar

--- a/tests/test_key_uniqueness.py
+++ b/tests/test_key_uniqueness.py
@@ -1,0 +1,52 @@
+"""
+Cross-package Redis-key uniqueness guard.
+
+Every Redis key/stream/set this repo writes to lives in
+``eigsep_redis.keys`` or ``eigsep_observing.keys``. Two constants
+resolving to the same string would silently cross buses (e.g. a
+status writer stomping on a metadata stream). This test asserts that
+never happens.
+
+If this test fails, pick a new name — do not "fix" it by deleting one
+of the duplicates. The right fix depends on which key is actually in
+use at runtime.
+"""
+
+from eigsep_observing import keys as obs_keys
+from eigsep_redis import keys as redis_keys
+
+
+def _public_string_constants(mod):
+    return {
+        name: value
+        for name, value in vars(mod).items()
+        if name.isupper()
+        and not name.startswith("_")
+        and isinstance(value, str)
+    }
+
+
+def test_redis_keys_module_unique():
+    consts = _public_string_constants(redis_keys)
+    values = list(consts.values())
+    assert len(values) == len(set(values)), (
+        f"duplicate values in eigsep_redis.keys: {consts}"
+    )
+
+
+def test_observing_keys_module_unique():
+    consts = _public_string_constants(obs_keys)
+    values = list(consts.values())
+    assert len(values) == len(set(values)), (
+        f"duplicate values in eigsep_observing.keys: {consts}"
+    )
+
+
+def test_no_cross_package_collisions():
+    redis_consts = _public_string_constants(redis_keys)
+    obs_consts = _public_string_constants(obs_keys)
+    overlap = set(redis_consts.values()) & set(obs_consts.values())
+    assert not overlap, (
+        f"keys defined in both packages collide: {overlap}. "
+        "Rename one side or move the constant to eigsep_redis.keys."
+    )

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -14,26 +14,29 @@ from eigsep_observing.testing.utils import generate_data
 
 @pytest.fixture
 def redis_snap():
-    """Mock Redis connection for SNAP correlator."""
+    """DummyEigsepObsRedis seeded with a correlator config."""
     redis = DummyEigsepObsRedis()
-    # Mock correlator config
-    redis.get_corr_config = Mock(
-        return_value={
+    redis.corr_config.upload_config(
+        {
             "integration_time": 1.0,
             "pairs": ["0", "1", "2", "3", "02", "13"],
-        }
+        },
+        from_file=False,
     )
     return redis
 
 
 @pytest.fixture
 def redis_panda():
-    """Mock Redis connection for LattePanda."""
-    redis = DummyEigsepObsRedis()
+    """DummyEigsepObsRedis seeded with a panda config and a live heartbeat.
 
-    # Mock config
-    redis.get_config = Mock(
-        return_value={
+    The real ``ConfigStore`` / ``HeartbeatReader`` / ``StatusReader``
+    run against fakeredis via ``DummyTransport``; per-test behavior is
+    applied with ``patch.object`` in the tests that need it.
+    """
+    redis = DummyEigsepObsRedis()
+    redis.config.upload(
+        {
             "switch_schedule": {"sky": 0.05, "load": 0.02, "noise": 0.02},
             "vna_settings": {
                 "ip": "127.0.0.1",
@@ -43,13 +46,10 @@ def redis_panda():
             },
             "vna_save_dir": "/tmp/test_vna",
             "vna_interval": 0.5,
-        }
+        },
+        from_file=False,
     )
-    # Mock client heartbeat check
-    redis.client_heartbeat_check = Mock(return_value=True)
-    redis.read_status = Mock(
-        return_value=(None, None)
-    )  # Default return to avoid thread warnings
+    redis.heartbeat.set(alive=True)
     return redis
 
 
@@ -129,7 +129,7 @@ def test_panda_connected_property(
     assert observer_none.panda_connected is False
 
     # Test when heartbeat check fails
-    redis_panda.client_heartbeat_check.return_value = False
+    redis_panda.heartbeat.set(alive=False)
     assert observer_panda_only.panda_connected is False
 
     # clean up
@@ -142,15 +142,19 @@ def test_record_corr_data(mock_file_class, observer_snap_only, redis_snap):
     """Test record_corr_data method."""
     observer = observer_snap_only
 
+    # Upload a header with sync_time so record_corr_data can proceed
+    sync_time = 1713200000.0
+    redis_snap.corr_config.upload_header({"sync_time": sync_time})
+
     # Mock file instance
     mock_file = Mock()
+    mock_file.counter = 0
     mock_file.__len__ = Mock(return_value=0)
     mock_file.add_data = Mock(return_value=None)  # No file written yet
     mock_file_class.return_value = mock_file
 
     # Mock correlator data
     mock_data = generate_data(ntimes=1)
-    redis_snap.read_corr_data = Mock(return_value=(123, 0, mock_data))
 
     # Start recording in a thread and stop it quickly
     stop_event = observer.stop_event
@@ -162,7 +166,10 @@ def test_record_corr_data(mock_file_class, observer_snap_only, redis_snap):
     stop_thread = threading.Thread(target=stop_after_delay)
     stop_thread.start()
 
-    observer.record_corr_data("/tmp/test", timeout=5)
+    with patch.object(
+        redis_snap.corr_reader, "read", return_value=(123, mock_data)
+    ) as mock_read:
+        observer.record_corr_data("/tmp/test", timeout=5)
     stop_thread.join()
 
     # Verify File was created with correct parameters
@@ -174,8 +181,10 @@ def test_record_corr_data(mock_file_class, observer_snap_only, redis_snap):
     )
 
     # Verify data was read and added
-    redis_snap.read_corr_data.assert_called()
-    mock_file.add_data.assert_called_with(123, 0, mock_data, metadata=None)
+    mock_read.assert_called()
+    mock_file.add_data.assert_called_with(
+        123, sync_time, mock_data, metadata=None
+    )
 
 
 def test_record_corr_data_no_snap():
@@ -189,8 +198,10 @@ def test_status_logger(observer_panda_only, redis_panda, caplog):
     """Test status_logger method.
 
     The observer's status_logger thread is already running (started in
-    __init__). Feed it messages via the mock, then signal the stop event
-    once all messages are consumed and join the thread.
+    __init__) and calling the real ``StatusReader.read`` against an
+    empty fakeredis stream. Scope a ``patch.object`` to this test to
+    feed it a sequence of messages, then signal the stop event once
+    all messages are consumed and join the thread.
     """
     caplog.set_level(logging.INFO)
 
@@ -208,10 +219,10 @@ def test_status_logger(observer_panda_only, redis_panda, caplog):
         observer_panda_only.stop_event.set()
         return (None, None)
 
-    redis_panda.read_status.side_effect = read_status_effect
-
-    # Wait for the status_logger thread to finish processing
-    observer_panda_only.status_thread.join(timeout=2)
+    with patch.object(
+        redis_panda.status_reader, "read", side_effect=read_status_effect
+    ):
+        observer_panda_only.status_thread.join(timeout=2)
 
     assert "Test status 1" in caplog.text
     assert "Test status 2" in caplog.text
@@ -256,8 +267,8 @@ def test_record_vna_data(
     s11, header, metadata = _make_vna_payload(dummy_vna)
 
     # Push data into the Redis stream and reset read position so
-    # read_vna_data picks it up on the first call.
-    redis_panda.add_vna_data(s11, header=header, metadata=metadata)
+    # the VNA reader picks it up on the first call.
+    redis_panda.vna.add(s11, header=header, metadata=metadata)
     redis_panda._set_last_read_id("stream:vna", "0-0")
 
     def stop_after_read():
@@ -283,10 +294,10 @@ def test_record_vna_data_timeout(observer_panda_only, redis_panda):
     """Test record_vna_data retries on timeout (no data in stream)."""
     observer = observer_panda_only
 
-    # No data pushed — read_vna_data returns (None, None, None) because
+    # No data pushed — vna_reader.read returns (None, None, None) because
     # the stream doesn't exist yet. After two None responses, stop.
     call_count = [0]
-    real_read = redis_panda.read_vna_data
+    real_read = redis_panda.vna_reader.read
 
     def counting_read(timeout=0):
         call_count[0] += 1
@@ -294,9 +305,10 @@ def test_record_vna_data_timeout(observer_panda_only, redis_panda):
             observer.stop_event.set()
         return real_read(timeout=timeout)
 
-    redis_panda.read_vna_data = counting_read
-
-    observer.record_vna_data("/tmp/test_vna", timeout=1)
+    with patch.object(
+        redis_panda.vna_reader, "read", side_effect=counting_read
+    ):
+        observer.record_vna_data("/tmp/test_vna", timeout=1)
 
     assert call_count[0] >= 2
 
@@ -313,10 +325,6 @@ def test_record_vna_data_disconnect(observer_panda_only, redis_panda):
             return False  # disconnected
         return True  # reconnected
 
-    redis_panda.client_heartbeat_check = Mock(
-        side_effect=heartbeat_side_effect
-    )
-
     def stop_after_delay():
         time.sleep(0.3)
         observer.stop_event.set()
@@ -324,11 +332,16 @@ def test_record_vna_data_disconnect(observer_panda_only, redis_panda):
     stop_thread = threading.Thread(target=stop_after_delay)
     stop_thread.start()
 
-    observer.record_vna_data("/tmp/test_vna", timeout=1)
+    with patch.object(
+        redis_panda.heartbeat_reader,
+        "check",
+        side_effect=heartbeat_side_effect,
+    ) as mock_check:
+        observer.record_vna_data("/tmp/test_vna", timeout=1)
     stop_thread.join()
 
     # Verify heartbeat was checked multiple times
-    assert redis_panda.client_heartbeat_check.call_count >= 2
+    assert mock_check.call_count >= 2
 
 
 def test_record_vna_data_stop_event(observer_panda_only, redis_panda):
@@ -336,7 +349,7 @@ def test_record_vna_data_stop_event(observer_panda_only, redis_panda):
     observer = observer_panda_only
 
     # Panda not connected — will enter the initial wait loop
-    redis_panda.client_heartbeat_check = Mock(return_value=False)
+    redis_panda.heartbeat.set(alive=False)
 
     def stop_after_delay():
         time.sleep(0.1)

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -7,8 +7,20 @@ from concurrent.futures import ThreadPoolExecutor
 from cmt_vna.testing import DummyVNA
 from picohost.testing import DummyPicoRFSwitch
 
+from eigsep_observing.corr import CorrConfigStore, CorrReader, CorrWriter
 from eigsep_observing.testing.utils import compare_dicts, generate_data
 from eigsep_observing.testing import DummyEigsepObsRedis
+from eigsep_observing.vna import VnaReader, VnaWriter
+from eigsep_redis import (
+    ConfigStore,
+    HeartbeatReader,
+    HeartbeatWriter,
+    MetadataSnapshotReader,
+    MetadataStreamReader,
+    MetadataWriter,
+    StatusReader,
+    StatusWriter,
+)
 from eigsep_redis.testing import DummyEigsepRedis
 
 
@@ -20,7 +32,9 @@ def server():
 @pytest.fixture
 def client(server):
     c = DummyEigsepRedis()
-    c.r = server.r
+    # share the underlying fakeredis so both clients talk to the
+    # same in-memory DB but keep independent last-read-id state
+    c.transport.r = server.transport.r
     return c
 
 
@@ -32,7 +46,7 @@ def obs_server():
 @pytest.fixture
 def obs_client(obs_server):
     c = DummyEigsepObsRedis()
-    c.r = obs_server.r
+    c.transport.r = obs_server.transport.r
     return c
 
 
@@ -42,17 +56,17 @@ def test_metadata(server, client):
 
     # Test live metadata functionality - this is the primary use case
     for acc_cnt in range(10):
-        client.add_metadata("acc_cnt", acc_cnt)
+        client.metadata.add("acc_cnt", acc_cnt)
         assert client.r.smembers("data_streams") == {b"stream:acc_cnt"}
         assert server.r.smembers("data_streams") == {b"stream:acc_cnt"}
         if acc_cnt == 0:  # data stream should be created on first call
             assert "stream:acc_cnt" in server.data_streams
         # live metadata should be updated
-        assert server.get_live_metadata(keys="acc_cnt") == acc_cnt
-        assert server.get_live_metadata(keys=["acc_cnt"]) == {
+        assert server.metadata_snapshot.get(keys="acc_cnt") == acc_cnt
+        assert server.metadata_snapshot.get(keys=["acc_cnt"]) == {
             "acc_cnt": acc_cnt
         }
-        live = server.get_live_metadata()
+        live = server.metadata_snapshot.get()
         # can't expect the exact timestamp - live metadata uses string keys
         assert "acc_cnt_ts" in live
         ts = live.pop("acc_cnt_ts")
@@ -61,13 +75,13 @@ def test_metadata(server, client):
 
     # Test stream reading behavior - with current API, reads start from $
     # which means only new messages after stream is established
-    metadata = server.get_metadata(stream_keys="acc_cnt")
+    metadata = server.metadata_stream.drain(stream_keys="acc_cnt")
     assert metadata == {}  # No new messages since stream starts at $
 
     # Test multiple streams
     test_date = "2025-06-02T16:25:15.089640"
-    client.add_metadata("update_date", test_date)
-    live = server.get_live_metadata()
+    client.metadata.add("update_date", test_date)
+    live = server.metadata_snapshot.get()
     assert "acc_cnt_ts" in live
     assert "update_date_ts" in live
     assert "update_date" in live
@@ -76,9 +90,9 @@ def test_metadata(server, client):
         "stream:update_date",
     }
 
-    # test typeerror in live_metadata
+    # test typeerror on malformed keys
     with pytest.raises(TypeError):
-        server.get_live_metadata(keys=[1])  # keys must be str or list of str
+        server.metadata_snapshot.get(keys=[1])
 
     # test reset
     server.reset()
@@ -95,11 +109,11 @@ def test_raw(server):
     compare_dicts(data, data_back)
 
 
-def test_get_metadata_ignores_vna_stream(obs_server, obs_client):
-    """get_metadata() with no args must skip stream:vna even when it's
+def test_metadata_stream_drain_ignores_vna_stream(obs_server, obs_client):
+    """MetadataStreamReader.drain() must skip stream:vna even when it's
     present on the same Redis.
 
-    Regression guard: historically ``get_metadata()`` defaulted to the
+    Regression guard: historically the streaming read defaulted to the
     full ``data_streams`` set, which includes ``stream:vna`` /
     ``stream:corr``. Those carry raw numpy payloads, not JSON, so the
     default path would raise on ``json.loads``. Metadata is now tracked
@@ -109,8 +123,8 @@ def test_get_metadata_ignores_vna_stream(obs_server, obs_client):
     """
     # Producer-side: push sensor metadata and a VNA measurement to the
     # same Redis that the consumer will query.
-    obs_client.add_metadata("acc_cnt", 7)
-    obs_client.add_metadata("temp", 25.5)
+    obs_client.metadata.add("acc_cnt", 7)
+    obs_client.metadata.add("temp", 25.5)
 
     switch = DummyPicoRFSwitch(port="/dev/null", name="switch")
     vna = DummyVNA(switch_fn=switch.switch)
@@ -119,7 +133,7 @@ def test_get_metadata_ignores_vna_stream(obs_server, obs_client):
     header = dict(vna.header)
     header["freqs"] = header["freqs"].tolist()
     header["mode"] = "ant"
-    obs_client.add_vna_data(s11, header=header, metadata={"temp": 25.5})
+    obs_client.vna.add(s11, header=header, metadata={"temp": 25.5})
 
     # Both stream families are registered in data_streams...
     assert b"stream:vna" in obs_server.r.smembers("data_streams")
@@ -134,12 +148,165 @@ def test_get_metadata_ignores_vna_stream(obs_server, obs_client):
     obs_server._set_last_read_id("stream:acc_cnt", "0-0")
     obs_server._set_last_read_id("stream:temp", "0-0")
 
-    # Default get_metadata() must not touch stream:vna (would raise on
+    # Default drain() must not touch stream:vna (would raise on
     # json.loads of the numpy payload) and must return the metadata.
-    out = obs_server.get_metadata()
+    out = obs_server.metadata_stream.drain()
     assert set(out.keys()) == {"stream:acc_cnt", "stream:temp"}
     assert out["stream:acc_cnt"] == [7]
     assert out["stream:temp"] == [25.5]
+
+    # Explicit-keys path must also refuse non-metadata streams. If
+    # the explicit path resolved against ``data_streams`` it would
+    # find ``stream:vna`` and try to ``json.loads`` the numpy payload.
+    out_explicit = obs_server.metadata_stream.drain(["stream:vna"])
+    assert out_explicit == {}
+
+
+def test_metadata_writer_has_no_cross_bus_methods():
+    """Structural guard: the metadata writer surface must not expose any
+    method or attribute that could be used to write a corr or VNA payload.
+
+    This is the whole point of the writer/reader split — wrong-stream
+    writes should be unrepresentable at the type level, not runtime-
+    checked. If someone adds a method here in the future, this test
+    fails and forces the split to be revisited.
+    """
+    # The only public writer method is add().
+    public = {
+        name for name in vars(MetadataWriter) if not name.startswith("_")
+    }
+    assert public == {"add", "maxlen"}, (
+        f"MetadataWriter surface has grown: {public}"
+    )
+    # Negative guards — the old god-class methods must not reappear.
+    for forbidden in (
+        "add_corr_data",
+        "add_vna_data",
+        "send_status",
+        "upload_config",
+        "upload_corr_config",
+        "upload_corr_header",
+    ):
+        assert not hasattr(MetadataWriter, forbidden), (
+            f"MetadataWriter should not expose {forbidden!r}"
+        )
+
+
+def test_metadata_readers_have_no_cross_bus_methods():
+    """Structural guard: metadata readers only read metadata, nothing else."""
+    for cls, expected in (
+        (MetadataSnapshotReader, {"get"}),
+        (MetadataStreamReader, {"drain", "streams"}),
+    ):
+        public = {name for name in vars(cls) if not name.startswith("_")}
+        assert public == expected, (
+            f"{cls.__name__} surface has grown: {public}"
+        )
+        for forbidden in (
+            "read_corr_data",
+            "read_vna_data",
+            "read_status",
+            "get_corr_config",
+            "get_corr_header",
+        ):
+            assert not hasattr(cls, forbidden), (
+                f"{cls.__name__} should not expose {forbidden!r}"
+            )
+
+
+def test_metadata_writer_rejects_non_json_payload(server):
+    """Contract: the writer is the JSON-serialization boundary.
+
+    A payload that can't be JSON-encoded is a producer bug; the writer
+    must surface it as ValueError rather than silently write a broken
+    stream entry.
+    """
+
+    class Unserializable:
+        pass
+
+    with pytest.raises(ValueError):
+        server.metadata.add("broken", Unserializable())
+
+
+def test_metadata_writer_rejects_bad_keys(server):
+    """Contract: keys are strings, non-empty, no ':' (Redis separator)."""
+    with pytest.raises(TypeError):
+        server.metadata.add(123, "value")
+    with pytest.raises(ValueError):
+        server.metadata.add("", "value")
+    with pytest.raises(ValueError):
+        server.metadata.add("   ", "value")
+    with pytest.raises(ValueError):
+        server.metadata.add("a:b", "value")
+
+
+def test_bus_classes_have_no_cross_bus_methods():
+    """Structural guard for every writer/reader class across all buses.
+
+    Each class should expose only the surface for its own bus. The
+    forbidden list is deliberately broad — it catches the original
+    god-class methods (add_metadata, add_corr_data, read_corr_data,
+    …) reappearing on any of these smaller classes.
+    """
+    cross_bus_methods = (
+        "add_metadata",
+        "get_live_metadata",
+        "get_metadata",
+        "add_corr_data",
+        "read_corr_data",
+        "add_vna_data",
+        "read_vna_data",
+        "upload_corr_config",
+        "get_corr_config",
+        "upload_corr_header",
+        "get_corr_header",
+        "send_status",
+        "read_status",
+        "upload_config",
+        "get_config",
+        "client_heartbeat_set",
+        "client_heartbeat_check",
+    )
+    surfaces = {
+        StatusWriter: {"send", "maxlen"},
+        StatusReader: {"read", "stream"},
+        HeartbeatWriter: {"set"},
+        HeartbeatReader: {"check"},
+        ConfigStore: {"upload", "get"},
+        CorrWriter: {"add", "maxlen"},
+        CorrReader: {"read", "seek"},
+        CorrConfigStore: {
+            "upload_config",
+            "get_config",
+            "upload_header",
+            "get_header",
+        },
+        VnaWriter: {"add", "maxlen"},
+        VnaReader: {"read"},
+    }
+    # CorrConfigStore legitimately owns upload_config/get_config/
+    # upload_header/get_header — those are its surface, not cross-bus.
+    # Scope the forbidden check to each class's non-own methods.
+    for cls, expected in surfaces.items():
+        public = {name for name in vars(cls) if not name.startswith("_")}
+        assert public == expected, (
+            f"{cls.__name__} surface has grown: {public}"
+        )
+        for forbidden in cross_bus_methods:
+            if forbidden in expected:
+                continue  # the class legitimately owns this name
+            assert not hasattr(cls, forbidden), (
+                f"{cls.__name__} should not expose {forbidden!r}"
+            )
+
+
+def test_add_metadata_shim_emits_deprecation_warning(server):
+    """The picohost shim must be loud — it should disappear at the monorepo cutover."""
+    with pytest.warns(DeprecationWarning, match="redis.metadata.add"):
+        server.add_metadata("via_shim", 42)
+    # The shim still writes correctly in the meantime.
+    assert server.metadata_snapshot.get("via_shim") == 42
 
 
 def test_int32_redis_round_trip(obs_server, obs_client):
@@ -154,25 +321,23 @@ def test_int32_redis_round_trip(obs_server, obs_client):
     raw = {p: d[0].tobytes() for p, d in data.items()}
     dtype = ">i4"
     pairs = list(data.keys())
-    # Seed corr_sync_time so read_corr_data can retrieve it.
-    # Must be a dict with "sync_time_unix" — matches fpga.py's format.
-    obs_client.add_metadata(
-        "corr_sync_time", {"sync_time_unix": 1748732903.42}
-    )
     # In production, the FPGA is already running when the observer
     # starts reading — stream:corr exists and has at least one entry.
     # Seed the stream so read_corr_data doesn't bail on the
     # "no stream" guard, mirroring the production startup order.
-    obs_client.add_corr_data(raw, cnt=0, dtype=dtype)
+    # sync_time now rides on corr_header (tested separately in
+    # test_fpga.py:test_synchronize) — this test only exercises the
+    # raw corr payload round-trip.
+    obs_client.corr.add(raw, cnt=0, dtype=dtype)
     # Consumer blocks first (like EigObserver), producer writes after
     # (like EigsepFpga) — same pattern as test_status.
     with ThreadPoolExecutor(max_workers=1) as executor:
         read_future = executor.submit(
-            obs_server.read_corr_data, pairs=pairs, unpack=True
+            obs_server.corr_reader.read, pairs=pairs, unpack=True
         )
         time.sleep(0.1)  # let consumer block
-        obs_client.add_corr_data(raw, cnt=42, dtype=dtype)
-        acc_cnt, _, read_data = read_future.result(timeout=5.0)
+        obs_client.corr.add(raw, cnt=42, dtype=dtype)
+        acc_cnt, read_data = read_future.result(timeout=5.0)
     assert acc_cnt == 42
     for p in pairs:
         original = np.frombuffer(raw[p], dtype=dtype)
@@ -183,42 +348,97 @@ def test_int32_redis_round_trip(obs_server, obs_client):
         np.testing.assert_array_equal(read_back, original)
 
 
+def test_corr_reader_skips_producer_backlog(obs_server, obs_client):
+    """Tier-2 guard: when the producer has pushed to stream:corr before
+    the consumer ever reads, the consumer must skip that backlog. The
+    blocking read returns the *next* entry pushed, not the oldest
+    backlog entry.
+
+    Pins the "only pull data after observer is on" guarantee implemented
+    by ``Transport._streams_from_set`` falling back to
+    ``XINFO last-generated-id`` on cache miss.
+    """
+    data = generate_data(ntimes=1, reshape=False)
+    raw = {p: d[0].tobytes() for p, d in data.items()}
+    pairs = list(data.keys())
+    # Seed a backlog; cnt=1 would be returned first if tier 2 regressed.
+    obs_client.corr.add(raw, cnt=1, dtype=">i4")
+    obs_client.corr.add(raw, cnt=2, dtype=">i4")
+    # Start the reader blocking first, then push. If tier 2 works the
+    # read blocks past the backlog and returns the post-start entry.
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        fut = executor.submit(obs_server.corr_reader.read, pairs=pairs)
+        time.sleep(0.1)  # let reader block
+        obs_client.corr.add(raw, cnt=99, dtype=">i4")
+        acc_cnt, _ = fut.result(timeout=5.0)
+    assert acc_cnt == 99
+
+
+def test_vna_reader_skips_producer_backlog(obs_server, obs_client):
+    """Tier-2 guard for stream:vna — same rationale as the corr test."""
+    old = {"ant": np.array([1 + 2j], dtype=np.complex128)}
+    new = {"ant": np.array([9 + 9j], dtype=np.complex128)}
+    obs_client.vna.add(old, metadata={"marker": "old-1"})
+    obs_client.vna.add(old, metadata={"marker": "old-2"})
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        fut = executor.submit(obs_server.vna_reader.read)
+        time.sleep(0.1)  # let reader block
+        obs_client.vna.add(new, metadata={"marker": "new"})
+        _, _, metadata = fut.result(timeout=5.0)
+    assert metadata["marker"] == "new"
+
+
+def test_metadata_drain_skips_producer_backlog(server, client):
+    """Tier-2 guard for metadata streams: a consumer whose cache is
+    empty must see a producer-first backlog as "past" and return an
+    empty drain, not replay the backlog.
+
+    Narrower than the corr/vna tests because ``drain()`` is
+    non-blocking — it returns immediately rather than waiting for the
+    next entry. The guarantee under test is just "backlog skipped."
+    """
+    for i in range(5):
+        client.metadata.add("acc_cnt", i)
+    # Fresh reader (empty cache) must not drain the backlog.
+    assert server.metadata_stream.drain() == {}
+
+
 def test_is_alive(server, client):
     # Test heartbeat functionality with current API
     # initially, both should be empty
-    assert server.client_heartbeat_check() is False
+    assert server.heartbeat_reader.check() is False
     # set client alive (server checks client heartbeat)
-    client.client_heartbeat_set(ex=1, alive=True)
-    assert server.client_heartbeat_check() is True
+    client.heartbeat.set(ex=1, alive=True)
+    assert server.heartbeat_reader.check() is True
     time.sleep(1.1)  # wait for expiration
-    assert server.client_heartbeat_check() is False
+    assert server.heartbeat_reader.check() is False
     # turn on/off
-    client.client_heartbeat_set(ex=100, alive=True)
-    assert server.client_heartbeat_check() is True
-    client.client_heartbeat_set(ex=100, alive=False)  # turn off
-    assert server.client_heartbeat_check() is False
+    client.heartbeat.set(ex=100, alive=True)
+    assert server.heartbeat_reader.check() is True
+    client.heartbeat.set(ex=100, alive=False)  # turn off
+    assert server.heartbeat_reader.check() is False
     # test reset
-    client.client_heartbeat_set(ex=100, alive=True)
-    assert server.client_heartbeat_check() is True
+    client.heartbeat.set(ex=100, alive=True)
+    assert server.heartbeat_reader.check() is True
     server.reset()
-    assert server.client_heartbeat_check() is False
+    assert server.heartbeat_reader.check() is False
 
 
 def test_status(server, client):
     # initial state
-    assert client.status_stream == {"stream:status": "$"}
+    assert client.status_reader.stream == {"stream:status": "$"}
 
     # Test blocking reads using ThreadPoolExecutor
     with ThreadPoolExecutor(max_workers=2) as executor:
         # Start reading in background thread (will block until message arrives)
-        read_future = executor.submit(server.read_status)
+        read_future = executor.submit(server.status_reader.read)
 
         # Give the read thread a moment to start
         time.sleep(0.1)
 
         # Send status message
         msg = "test"
-        client.send_status(status=msg)
+        client.status.send(msg)
 
         # Get the result from the read
         level, status = read_future.result(timeout=2.0)
@@ -228,23 +448,23 @@ def test_status(server, client):
     # Send many statuses and read them
     messages = [f"status {i}" for i in range(5)]
     for msg in messages:
-        client.send_status(status=msg)
+        client.status.send(msg)
 
     # Read all statuses
     for expected_msg in messages:
-        level, status = server.read_status()
+        level, status = server.status_reader.read()
         assert status == expected_msg
         assert level == 20
 
     # test specific statuses
-    client.send_status(status="VNA_COMPLETE")
-    level, status = server.read_status()
+    client.status.send("VNA_COMPLETE")
+    level, status = server.status_reader.read()
     assert status == "VNA_COMPLETE"
 
-    client.send_status(status="VNA_ERROR")
-    level, status = server.read_status()
+    client.status.send("VNA_ERROR")
+    level, status = server.status_reader.read()
     assert status == "VNA_ERROR"
 
-    client.send_status(status="VNA_TIMEOUT")
-    level, status = server.read_status()
+    client.status.send("VNA_TIMEOUT")
+    level, status = server.status_reader.read()
     assert status == "VNA_TIMEOUT"


### PR DESCRIPTION
## Context

Motivated by the VNA-leak bug caught in a Copilot PR review (fixed in b8cc1ed / ba42f1f): VNA data could leak into the metadata reader because every bus shared one god-class surface. Runtime checks caught it, but the root cause was structural — any coding mistake on the god-class can cross buses.

This PR replaces runtime checks with **structural impossibility**: separate writer/reader classes per bus, each with a surface that only accepts its own payload shape. A ``MetadataWriter`` with no ``add_vna_data`` method cannot be coerced into leaking VNA data — the type system rules it out.

Full plan lives in ``~/.claude/plans/buzzing-questing-tarjan.md``.

## What's in this PR

Six commits mapping to six plan steps:

1. **Transport extraction** — new ``eigsep_redis.transport.Transport`` owns connection, last-read-id bookkeeping, raw K/V, and lifecycle. ``EigsepRedis`` composes it via a ``transport_cls`` class attribute. Dummies override via ``transport_cls = DummyTransport``.
2. **Metadata split + picohost shim** — new ``MetadataWriter`` / ``MetadataSnapshotReader`` / ``MetadataStreamReader``. Deleted ``add_metadata`` / ``get_live_metadata`` / ``get_metadata`` from ``EigsepRedis``. Kept a one-line ``add_metadata`` shim on ``EigsepRedis`` with ``DeprecationWarning`` and ``TODO(monorepo)`` — narrow bridge for picohost's single external call site. In-tree callers all migrated.
3. **Status / heartbeat / config split** — new ``StatusWriter`` / ``StatusReader`` / ``HeartbeatWriter`` / ``HeartbeatReader`` / ``ConfigStore``. Deleted the corresponding god-class methods. Callers migrated.
4. **``corr_sync_time`` moves to corr header** — the one behavior change. ``sync_time`` is a per-sync invariant, not a per-integration reading; it belongs on the header. ``fpga.synchronize`` now publishes the header (eliminating a timing window); ``CorrReader.read`` returns ``(acc_cnt, data)`` instead of ``(acc_cnt, sync_time, data)``; ``EigObserver`` caches ``sync_time`` from the header at file start. Removes the last cross-bus read inside a reader.
5. **Corr / VNA split** — new ``CorrConfigStore`` / ``CorrWriter`` / ``CorrReader`` / ``VnaWriter`` / ``VnaReader`` (in ``eigsep_observing.corr`` / ``.vna``). Deleted all 8 god-class corr/VNA methods. ``EigsepObsRedis`` is now 35 lines of pure composition. Public ``CorrReader.seek`` replaces the linearity script's reach into private ``_set_last_read_id``.
6. **CLAUDE.md update** — drop stale ``stream:ctrl`` reference, document new class layout, document ``sync_time`` living on the corr header.

## Structural-impossibility tests

``tests/test_redis.py`` gains guard tests that enumerate every writer/reader class's public surface and assert (a) it matches the expected per-bus methods exactly, (b) it does **not** expose any of the old god-class method names. If someone ever re-introduces ``add_corr_data`` on ``MetadataWriter``, the test fails at CI time.

- ``test_metadata_writer_has_no_cross_bus_methods``
- ``test_metadata_readers_have_no_cross_bus_methods``
- ``test_bus_classes_have_no_cross_bus_methods`` (covers Status, Heartbeat, Config, Corr, Vna)
- ``test_metadata_writer_rejects_non_json_payload`` / ``test_metadata_writer_rejects_bad_keys`` — writer is the validation boundary
- ``test_add_metadata_shim_emits_deprecation_warning`` — guards the bounded-shim contract
- ``test_metadata_stream_drain_ignores_vna_stream`` — preserved runtime regression guard from the original bug fix

## Deferred to a follow-up PR

**Step 6 — role factories** (``make_panda_writers`` / ``make_snap_writers`` / ``make_ground_readers``) is deferred. The core goal (wrong-stream writes are structurally impossible) is fully achieved without it; role factories would prevent a different, much less likely bug class ("panda code accidentally writes corr data") at the cost of rewiring every construction site and all Dummy classes. Better to ship the high-value structural fix with a reviewable diff and come back to role factories alongside the monorepo merge (when the ``add_metadata`` shim also retires).

## Test plan

- [x] ``pytest`` green — 156 passed (was 150; +6 new structural / shim tests)
- [x] ``ruff check .`` and ``ruff format --check .`` clean
- [ ] Smoke-run ``scripts/observe.py`` on a dev rig before merge
- [x] Coordinate picohost update (either keep the shim until the monorepo merge, or land a picohost PR in parallel and drop the shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)