### PR TITLE
feat(corr): gate CorrWriter.add on sync_time

### DIFF
--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -26,15 +26,18 @@ def _log_unsynced_drop(cnt):
     Logs at most once per ``_UNSYNCED_LOG_THROTTLE_S`` seconds. The
     throttle state is module-level so it survives across calls; tests
     that need to exercise the throttle can reset
-    ``_last_unsynced_log[0]``.
+    ``_last_unsynced_log[0]``. This message intentionally avoids
+    hard-coding a specific ``sync_time`` value because callers may drop
+    integrations for any falsy or missing ``sync_time``.
     """
     now = time.time()
     if now - _last_unsynced_log[0] < _UNSYNCED_LOG_THROTTLE_S:
         return
     _last_unsynced_log[0] = now
     logger.error(
-        f"SNAP not synchronized (sync_time=0); dropping corr integration "
-        f"cnt={cnt}. Data without a sync anchor has no valid timestamps."
+        f"SNAP not synchronized (sync_time is falsy or missing); "
+        f"dropping corr integration cnt={cnt}. Data without a sync "
+        f"anchor has no valid timestamps."
     )
 
 

--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 
 import numpy as np
 
@@ -14,6 +15,27 @@ from .keys import (
 from .utils import load_config
 
 logger = logging.getLogger(__name__)
+
+_UNSYNCED_LOG_THROTTLE_S = 60.0
+_last_unsynced_log = [0.0]
+
+
+def _log_unsynced_drop(cnt):
+    """Throttled ERROR log for a pre-sync corr integration drop.
+
+    Logs at most once per ``_UNSYNCED_LOG_THROTTLE_S`` seconds. The
+    throttle state is module-level so it survives across calls; tests
+    that need to exercise the throttle can reset
+    ``_last_unsynced_log[0]``.
+    """
+    now = time.time()
+    if now - _last_unsynced_log[0] < _UNSYNCED_LOG_THROTTLE_S:
+        return
+    _last_unsynced_log[0] = now
+    logger.error(
+        f"SNAP not synchronized (sync_time=0); dropping corr integration "
+        f"cnt={cnt}. Data without a sync anchor has no valid timestamps."
+    )
 
 
 class CorrConfigStore:
@@ -90,7 +112,7 @@ class CorrWriter:
     def __init__(self, transport):
         self.transport = transport
 
-    def add(self, data, cnt, dtype=">i4"):
+    def add(self, data, cnt, sync_time, dtype=">i4"):
         """
         Publish one integration.
 
@@ -100,9 +122,21 @@ class CorrWriter:
             Keys are correlation pair names, values are raw bytes.
         cnt : int
             Accumulation count from SNAP.
+        sync_time : float or int
+            Unix wallclock of SNAP synchronization. ``0`` (or any
+            falsy value) means the SNAP is not synchronized yet and
+            the integration is dropped, because without a sync anchor
+            downstream cannot compute valid timestamps from
+            ``acc_cnt``. Pre-sync drops are logged at ERROR
+            (throttled) — dropped data would be unusable, and it's
+            better to fail loud on a real sync problem than to let
+            days of untimestamped integrations accumulate.
         dtype : str
             NumPy dtype string for unpacking downstream.
         """
+        if not sync_time:
+            _log_unsynced_drop(cnt)
+            return
         redis_data = {p.encode("utf-8"): d for p, d in data.items()}
         r = self.transport.r
         r.sadd(CORR_PAIRS_SET, *redis_data.keys())

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -845,4 +845,5 @@ class EigsepFpga:
                     continue
             data = d["data"]
             cnt = d["cnt"]
-            self.redis.corr.add(data, cnt, dtype=self.cfg["dtype"])
+            sync_time = self.sync_time if self.is_synchronized else 0
+            self.redis.corr.add(data, cnt, sync_time, dtype=self.cfg["dtype"])

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -7,6 +7,8 @@ import pytest
 from unittest.mock import Mock, patch
 
 from eigsep_observing import EigsepFpga
+from eigsep_observing import corr as corr_mod
+from eigsep_observing.keys import CORR_STREAM
 from eigsep_observing.testing import DummyEigsepFpga, utils
 
 
@@ -411,8 +413,11 @@ class TestEigsepFpga:
 
         fpga_instance.upload_config.assert_called_once_with(validate=True)
         assert mock_add.call_count == 2
-        mock_add.assert_any_call(d1, 1, dtype=expected_dtype)
-        mock_add.assert_any_call(d2, 2, dtype=expected_dtype)
+        # Not synchronized in this test → sync_time=0; the gate only
+        # fires inside the real CorrWriter.add (which is mocked out
+        # here), so the call is still made with sync_time=0.
+        mock_add.assert_any_call(d1, 1, 0, dtype=expected_dtype)
+        mock_add.assert_any_call(d2, 2, 0, dtype=expected_dtype)
 
     def test_observe_default_pairs(self, fpga_instance, caplog):
         """observe() with no pairs arg defaults to self.pairs."""
@@ -441,7 +446,7 @@ class TestEigsepFpga:
             in caplog.text
         )
         # Data still drained normally
-        mock_add.assert_called_once_with(d1, 1, dtype=expected_dtype)
+        mock_add.assert_called_once_with(d1, 1, 0, dtype=expected_dtype)
 
     def test_observe_timeout_immediate(self, fpga_instance, caplog):
         """
@@ -500,5 +505,50 @@ class TestEigsepFpga:
         assert mock_add.call_count == 5
         # Order matters — assert via call_args_list, not assert_any_call.
         for i, call in enumerate(mock_add.call_args_list):
-            assert call.args == ({"0": [i]}, 10 + i)
+            assert call.args == ({"0": [i]}, 10 + i, 0)
             assert call.kwargs == {"dtype": expected_dtype}
+
+    def test_observe_passes_sync_time_when_synced(self, fpga_instance):
+        """After synchronize(), observe() passes the real sync_time to
+        the writer so downstream can derive valid timestamps.
+        """
+        expected_dtype = fpga_instance.cfg["dtype"]
+
+        with patch(
+            "eigsep_observing.fpga.time.time", return_value=1713200000.0
+        ):
+            fpga_instance.synchronize(delay=5)
+
+        d1 = utils.generate_data(
+            ntimes=1, raw=True, reshape=False, return_time_freq=False
+        )
+        items = [{"data": d1, "cnt": 1}, None]
+        with (
+            patch.object(fpga_instance.redis.corr, "add") as mock_add,
+            _patch_observe_thread(fpga_instance, items),
+        ):
+            fpga_instance.observe(pairs=["0"], timeout=10)
+
+        mock_add.assert_called_once_with(
+            d1, 1, 1713200000.0, dtype=expected_dtype
+        )
+
+    def test_observe_skips_corr_stream_when_unsynced(self, fpga_instance):
+        """End-to-end with the real CorrWriter: unsynced SNAP → stream
+        stays empty. Structural guarantee that pre-sync integrations
+        cannot be consumed downstream.
+        """
+        corr_mod._last_unsynced_log[0] = 0.0
+        assert fpga_instance.is_synchronized is False
+
+        d1 = utils.generate_data(
+            ntimes=1, raw=True, reshape=False, return_time_freq=False
+        )
+        items = [{"data": d1, "cnt": 1}, {"data": d1, "cnt": 2}, None]
+        with _patch_observe_thread(fpga_instance, items):
+            fpga_instance.observe(pairs=["0"], timeout=10)
+
+        # Real CorrWriter.add with sync_time=0 → dropped; nothing on
+        # the stream.
+        r = fpga_instance.redis.transport.r
+        assert r.xlen(CORR_STREAM) == 0

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import logging
 import numpy as np
 import pytest
 import time
@@ -7,7 +8,9 @@ from concurrent.futures import ThreadPoolExecutor
 from cmt_vna.testing import DummyVNA
 from picohost.testing import DummyPicoRFSwitch
 
+from eigsep_observing import corr as corr_mod
 from eigsep_observing.corr import CorrConfigStore, CorrReader, CorrWriter
+from eigsep_observing.keys import CORR_STREAM
 from eigsep_observing.testing.utils import compare_dicts, generate_data
 from eigsep_observing.testing import DummyEigsepObsRedis
 from eigsep_observing.vna import VnaReader, VnaWriter
@@ -328,7 +331,7 @@ def test_int32_redis_round_trip(obs_server, obs_client):
     # sync_time now rides on corr_header (tested separately in
     # test_fpga.py:test_synchronize) — this test only exercises the
     # raw corr payload round-trip.
-    obs_client.corr.add(raw, cnt=0, dtype=dtype)
+    obs_client.corr.add(raw, cnt=0, sync_time=1713200000.0, dtype=dtype)
     # Consumer blocks first (like EigObserver), producer writes after
     # (like EigsepFpga) — same pattern as test_status.
     with ThreadPoolExecutor(max_workers=1) as executor:
@@ -336,7 +339,7 @@ def test_int32_redis_round_trip(obs_server, obs_client):
             obs_server.corr_reader.read, pairs=pairs, unpack=True
         )
         time.sleep(0.1)  # let consumer block
-        obs_client.corr.add(raw, cnt=42, dtype=dtype)
+        obs_client.corr.add(raw, cnt=42, sync_time=1713200000.0, dtype=dtype)
         acc_cnt, read_data = read_future.result(timeout=5.0)
     assert acc_cnt == 42
     for p in pairs:
@@ -362,16 +365,58 @@ def test_corr_reader_skips_producer_backlog(obs_server, obs_client):
     raw = {p: d[0].tobytes() for p, d in data.items()}
     pairs = list(data.keys())
     # Seed a backlog; cnt=1 would be returned first if tier 2 regressed.
-    obs_client.corr.add(raw, cnt=1, dtype=">i4")
-    obs_client.corr.add(raw, cnt=2, dtype=">i4")
+    obs_client.corr.add(raw, cnt=1, sync_time=1713200000.0, dtype=">i4")
+    obs_client.corr.add(raw, cnt=2, sync_time=1713200000.0, dtype=">i4")
     # Start the reader blocking first, then push. If tier 2 works the
     # read blocks past the backlog and returns the post-start entry.
     with ThreadPoolExecutor(max_workers=1) as executor:
         fut = executor.submit(obs_server.corr_reader.read, pairs=pairs)
         time.sleep(0.1)  # let reader block
-        obs_client.corr.add(raw, cnt=99, dtype=">i4")
+        obs_client.corr.add(raw, cnt=99, sync_time=1713200000.0, dtype=">i4")
         acc_cnt, _ = fut.result(timeout=5.0)
     assert acc_cnt == 99
+
+
+def test_corr_writer_drops_unsynced_zero(obs_client, caplog):
+    """sync_time=0 means SNAP not synced; the integration must be
+    dropped at the writer so downstream never sees untimestamped data.
+    """
+    corr_mod._last_unsynced_log[0] = 0.0  # reset throttle
+    data = generate_data(ntimes=1, reshape=False)
+    raw = {p: d[0].tobytes() for p, d in data.items()}
+    with caplog.at_level(logging.ERROR, logger="eigsep_observing.corr"):
+        obs_client.corr.add(raw, cnt=5, sync_time=0, dtype=">i4")
+    assert obs_client.transport.r.xlen(CORR_STREAM) == 0
+    assert any("SNAP not synchronized" in r.message for r in caplog.records)
+
+
+def test_corr_writer_drops_unsynced_none(obs_client, caplog):
+    """sync_time=None (missing key on the caller side) is treated the
+    same as 0 — drop the integration."""
+    corr_mod._last_unsynced_log[0] = 0.0
+    data = generate_data(ntimes=1, reshape=False)
+    raw = {p: d[0].tobytes() for p, d in data.items()}
+    with caplog.at_level(logging.ERROR, logger="eigsep_observing.corr"):
+        obs_client.corr.add(raw, cnt=5, sync_time=None, dtype=">i4")
+    assert obs_client.transport.r.xlen(CORR_STREAM) == 0
+    assert any("SNAP not synchronized" in r.message for r in caplog.records)
+
+
+def test_corr_writer_unsynced_log_throttled(obs_client, caplog):
+    """At ~4Hz corr cadence, a persistent pre-sync state must not
+    drown the log file — the throttle collapses to one ERROR per
+    window.
+    """
+    corr_mod._last_unsynced_log[0] = 0.0
+    data = generate_data(ntimes=1, reshape=False)
+    raw = {p: d[0].tobytes() for p, d in data.items()}
+    with caplog.at_level(logging.ERROR, logger="eigsep_observing.corr"):
+        for _ in range(10):
+            obs_client.corr.add(raw, cnt=5, sync_time=0, dtype=">i4")
+    records = [
+        r for r in caplog.records if "SNAP not synchronized" in r.message
+    ]
+    assert len(records) == 1
 
 
 def test_vna_reader_skips_producer_backlog(obs_server, obs_client):


### PR DESCRIPTION
## Summary

- Drop pre-sync corr integrations at the producer. Without a valid `sync_time`, `acc_cnt` cannot be converted to a wallclock, so silently letting them accumulate on the stream (maxlen=5000 → ~20 min backlog at ~4 Hz) would eventually surface as hours of untimestamped data after a real SNAP sync failure.
- `CorrWriter.add` now takes a required `sync_time` arg; `0` or `None` drops the integration and emits a throttled ERROR (60 s window, mirrors the `io._log_invariant_disagreement` pattern).
- `EigsepFpga.observe` passes `self.sync_time if self.is_synchronized else 0` — the producer already knows its sync state, so the gate decision lives on that side while `CorrWriter` stays a dumb bus-pure writer.

Stacked on #46. This is part 1 of splitting the two conflated failure modes in `EigObserver.record_corr_data`; part 2 (observer-side header caching + watchdog + re-sync handling) will follow in a separate PR.

## Test plan

- [x] `pytest` — 166/166 pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] New `test_redis.py` tests cover `sync_time=0`, `sync_time=None`, and throttle collapse at ~4 Hz cadence
- [x] New `test_fpga.py` tests cover the synced path (real sync_time forwarded) and the unsynced path end-to-end through the real `CorrWriter` + fakeredis (stream stays empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)