### PR TITLE
feat(observer): split corr header-fetch failure modes with watchdog

### DIFF
--- a/scripts/observe.py
+++ b/scripts/observe.py
@@ -104,11 +104,15 @@ else:
 
 thds = {}
 thds["status"] = observer.status_thread
-# A RuntimeError out of record_corr_data is the "SNAP never synced /
-# no header ever available" crash path. threading.Thread swallows
-# exceptions by default, so wrap the target: surface the crash at
-# CRITICAL, signal stop_event so the VNA thread exits cleanly, and
-# record the failure so the main process exits non-zero after join.
+# Corr data is sacred — every other data product (VNA, switch
+# schedule, sensors) is supporting context for the corr stream. If
+# the corr thread dies for any reason (bounded-wait watchdog raising
+# RuntimeError, TimeoutError from CorrReader.read after SNAP dies
+# mid-run, any unanticipated failure), the rest of the system should
+# stop too: collecting hours of VNA files with no corr data to pair
+# them against is worse than exiting loudly. threading.Thread swallows
+# target exceptions by default, so wrap the target to convert any
+# Exception into stop_event + non-zero exit.
 corr_crashed = [False]
 
 
@@ -119,10 +123,8 @@ def _corr_target():
             ntimes=cfg["corr_ntimes"],
             timeout=10,
         )
-    except RuntimeError as e:
-        logger.critical(
-            f"Correlator recording crashed: {e}. Stopping observer."
-        )
+    except Exception:
+        logger.exception("Correlator recording crashed. Stopping observer.")
         corr_crashed[0] = True
         observer.stop_event.set()
 

--- a/scripts/observe.py
+++ b/scripts/observe.py
@@ -6,6 +6,7 @@ disk. The Panda runs autonomously — start it before running this script.
 
 import argparse
 import logging
+import sys
 from pathlib import Path
 import threading
 import time
@@ -103,13 +104,32 @@ else:
 
 thds = {}
 thds["status"] = observer.status_thread
+# A RuntimeError out of record_corr_data is the "SNAP never synced /
+# no header ever available" crash path. threading.Thread swallows
+# exceptions by default, so wrap the target: surface the crash at
+# CRITICAL, signal stop_event so the VNA thread exits cleanly, and
+# record the failure so the main process exits non-zero after join.
+corr_crashed = [False]
+
+
+def _corr_target():
+    try:
+        observer.record_corr_data(
+            cfg["corr_save_dir"],
+            ntimes=cfg["corr_ntimes"],
+            timeout=10,
+        )
+    except RuntimeError as e:
+        logger.critical(
+            f"Correlator recording crashed: {e}. Stopping observer."
+        )
+        corr_crashed[0] = True
+        observer.stop_event.set()
+
+
 # set up file writing: corr_thd for correlation data, panda_thd for s11
 if args.use_snap:
-    corr_thd = threading.Thread(
-        target=observer.record_corr_data,
-        args=(cfg["corr_save_dir"],),
-        kwargs={"ntimes": cfg["corr_ntimes"], "timeout": 10},
-    )
+    corr_thd = threading.Thread(target=_corr_target)
     thds["corr"] = corr_thd
     logger.info("Starting correlation file writing thread.")
     corr_thd.start()
@@ -144,3 +164,6 @@ if args.dummy:
         redis_snap.reset()
     if args.use_panda:
         redis_panda.reset()
+
+if corr_crashed[0]:
+    sys.exit(1)

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -95,7 +95,9 @@ class EigObserver:
             if status is not None:
                 self.logger.log(level, status)
 
-    def record_corr_data(self, save_dir, ntimes=240, timeout=20):
+    def record_corr_data(
+        self, save_dir, ntimes=240, timeout=20, header_wait_timeout=300
+    ):
         """
         Read data from the SNAP correlator via Redis and write it to
         file.
@@ -108,7 +110,37 @@ class EigObserver:
             Number of spectra per file.
         timeout : int
             The time in seconds to wait for data from the correlator.
+        header_wait_timeout : float
+            Bounded wait, in seconds, when we cannot obtain a valid
+            corr header with a non-zero ``sync_time`` — either because
+            the fetch is failing with ``ValueError`` and we have no
+            cached header, or because the fetch succeeds but reports
+            ``sync_time=0`` (SNAP never synchronized). Exceeding this
+            deadline raises ``RuntimeError`` so the process crashes
+            visibly rather than silently accumulating days of
+            untimestamped data.
 
+        Notes
+        -----
+        Two failure modes are handled separately:
+
+        1. **Transient header-fetch failure** (``ValueError`` from
+           ``get_header``) when we have a cached header from a prior
+           successful fetch: fall back to the cache, log at WARNING,
+           and save the incoming corr data. Data on the stream has
+           valid timestamps; the metadata-path blip must not block
+           corr writes ("corr data is sacred").
+        2. **No sync anchor** (``sync_time=0`` from a successful
+           fetch, or ``ValueError`` with no cache): start a bounded
+           wait and crash via ``RuntimeError`` once
+           ``header_wait_timeout`` elapses. The writer-side gate in
+           ``CorrWriter.add`` keeps the stream empty in this state,
+           so the watchdog is the structural guard that prevents
+           silent long-term unusable data.
+
+        A valid ``sync_time`` that differs from the cached one is
+        treated as a mid-run SNAP re-sync: the current file is closed
+        and a new one is opened with the new anchor.
         """
         pairs = self.corr_cfg["pairs"]
         t_int = self.corr_cfg["integration_time"]
@@ -118,12 +150,6 @@ class EigObserver:
             f"Integration time: {t_int} s, "
             f"File time: {file_time} s"
         )
-        file = io.File(
-            save_dir,
-            pairs,
-            ntimes,
-            self.corr_cfg,
-        )
 
         while not self.snap_connected:
             self.logger.warning(
@@ -132,38 +158,90 @@ class EigObserver:
             if self.stop_event.wait(1):
                 return
 
-        sync_time = None
-        while not self.stop_event.is_set():
-            if file.counter == 0:  # look up header in Redis once per file
-                try:
-                    header = self.redis_snap.corr_config.get_header()
-                except ValueError as e:
-                    self.logger.error(f"Error reading header from SNAP: {e}")
-                    header = None
-                if header is not None:
-                    sync_time = header.get("sync_time")
-                if sync_time is None or sync_time == 0:
-                    self.logger.error(
-                        "No sync_time in corr header. Cannot "
-                        "derive accurate timestamps. Waiting "
-                        "for SNAP to synchronize."
-                    )
-                    if self.stop_event.wait(1):
-                        return
-                    continue
-                file.set_header(header=header)
-            # blocking read from Redis
-            acc_cnt, data = self.redis_snap.corr_reader.read(
-                pairs=pairs, timeout=timeout, unpack=True
-            )
-            self.logger.info(f"{acc_cnt=}")
-            if self.panda_connected:
-                metadata = self.redis_panda.metadata_stream.drain()
-            else:
-                metadata = None
-            file.add_data(acc_cnt, sync_time, data, metadata=metadata)
-
-        file.close()
+        file = io.File(save_dir, pairs, ntimes, self.corr_cfg)
+        cached_header = None
+        cached_sync_time = None
+        no_header_deadline = None
+        try:
+            while not self.stop_event.is_set():
+                if file.counter == 0:
+                    try:
+                        header = self.redis_snap.corr_config.get_header()
+                    except ValueError as e:
+                        if cached_header is not None:
+                            self.logger.warning(
+                                f"Error reading header from SNAP: {e}. "
+                                "Using cached corr header."
+                            )
+                            file.set_header(header=cached_header)
+                            no_header_deadline = None
+                        else:
+                            if no_header_deadline is None:
+                                no_header_deadline = (
+                                    time.monotonic() + header_wait_timeout
+                                )
+                            if time.monotonic() > no_header_deadline:
+                                raise RuntimeError(
+                                    f"No corr header available after "
+                                    f"{header_wait_timeout}s: {e}"
+                                )
+                            self.logger.error(
+                                f"Error reading header from SNAP: {e}. "
+                                "Waiting for a valid header."
+                            )
+                            if self.stop_event.wait(1):
+                                return
+                            continue
+                    else:
+                        new_sync_time = header.get("sync_time")
+                        if not new_sync_time:
+                            if no_header_deadline is None:
+                                no_header_deadline = (
+                                    time.monotonic() + header_wait_timeout
+                                )
+                            if time.monotonic() > no_header_deadline:
+                                raise RuntimeError(
+                                    f"SNAP never synchronized within "
+                                    f"{header_wait_timeout}s (sync_time=0)."
+                                )
+                            self.logger.error(
+                                "No sync_time in corr header. Cannot "
+                                "derive accurate timestamps. Waiting "
+                                "for SNAP to synchronize."
+                            )
+                            if self.stop_event.wait(1):
+                                return
+                            continue
+                        if (
+                            cached_sync_time is not None
+                            and new_sync_time != cached_sync_time
+                        ):
+                            self.logger.warning(
+                                f"SNAP re-synchronized from "
+                                f"{cached_sync_time} to {new_sync_time}; "
+                                "rolling to new file."
+                            )
+                            file.close()
+                            file = io.File(
+                                save_dir, pairs, ntimes, self.corr_cfg
+                            )
+                        cached_header = header
+                        cached_sync_time = new_sync_time
+                        no_header_deadline = None
+                        file.set_header(header=header)
+                acc_cnt, data = self.redis_snap.corr_reader.read(
+                    pairs=pairs, timeout=timeout, unpack=True
+                )
+                self.logger.info(f"{acc_cnt=}")
+                if self.panda_connected:
+                    metadata = self.redis_panda.metadata_stream.drain()
+                else:
+                    metadata = None
+                file.add_data(
+                    acc_cnt, cached_sync_time, data, metadata=metadata
+                )
+        finally:
+            file.close()
 
     def record_vna_data(self, save_dir, timeout=60):
         """

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -187,6 +187,172 @@ def test_record_corr_data(mock_file_class, observer_snap_only, redis_snap):
     )
 
 
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_transient_header_blip_uses_cache(
+    mock_file_class, observer_snap_only, redis_snap, caplog
+):
+    """Transient header-fetch ValueError with a valid cache → fall
+    back to the cache and save the corr data. Non-corr failures must
+    not block corr writes.
+    """
+    observer = observer_snap_only
+    sync_time = 1713200000.0
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    mock_data = generate_data(ntimes=1)
+
+    # First header fetch succeeds; second raises ValueError (blip).
+    # After that, stop the loop.
+    read_count = [0]
+
+    def read_side_effect(*a, **kw):
+        read_count[0] += 1
+        if read_count[0] >= 2:
+            observer.stop_event.set()
+        return (100 + read_count[0], mock_data)
+
+    good_header = {"sync_time": sync_time}
+    header_calls = [good_header, ValueError("Redis blip")]
+
+    def header_side_effect():
+        val = header_calls.pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    caplog.set_level(logging.WARNING, logger="eigsep_observing.observer")
+    with (
+        patch.object(
+            redis_snap.corr_config,
+            "get_header",
+            side_effect=header_side_effect,
+        ),
+        patch.object(
+            redis_snap.corr_reader, "read", side_effect=read_side_effect
+        ),
+    ):
+        observer.record_corr_data("/tmp/test", ntimes=1, timeout=5)
+
+    # set_header called twice: once with fetched, once with cached.
+    assert mock_file.set_header.call_count == 2
+    mock_file.set_header.assert_any_call(header=good_header)
+    # add_data called on both iterations — corr data is sacred, the
+    # blip must not have blocked writes.
+    assert mock_file.add_data.call_count >= 2
+    assert "Using cached corr header" in caplog.text
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_unsynced_watchdog_crashes(
+    mock_file_class, observer_snap_only, redis_snap
+):
+    """sync_time=0 persistently → bounded wait → RuntimeError."""
+    observer = observer_snap_only
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    redis_snap.corr_config.upload_header({"sync_time": 0})
+
+    with pytest.raises(RuntimeError, match="SNAP never synchronized"):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=5, header_wait_timeout=0.2
+        )
+
+    # No data should have been read or written — no sync anchor.
+    mock_file.add_data.assert_not_called()
+    # Partial-buffer flush still runs (try/finally).
+    mock_file.close.assert_called()
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_no_header_ever_crashes(
+    mock_file_class, observer_snap_only, redis_snap
+):
+    """get_header always raises, no cache → bounded wait → RuntimeError."""
+    observer = observer_snap_only
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    with (
+        patch.object(
+            redis_snap.corr_config,
+            "get_header",
+            side_effect=ValueError("no header"),
+        ),
+        pytest.raises(RuntimeError, match="No corr header"),
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=5, header_wait_timeout=0.2
+        )
+
+    mock_file.add_data.assert_not_called()
+    mock_file.close.assert_called()
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_resync_rolls_file(
+    mock_file_class, observer_snap_only, redis_snap, caplog
+):
+    """A successful header fetch with a *different* non-zero sync_time
+    than the cached one → close current file, open new one, continue.
+    """
+    observer = observer_snap_only
+
+    # Each File() call returns a fresh mock so we can count
+    # constructions.
+    file_mocks = [Mock(), Mock(), Mock()]
+    for fm in file_mocks:
+        fm.counter = 0
+        fm.__len__ = Mock(return_value=0)
+    mock_file_class.side_effect = file_mocks
+
+    mock_data = generate_data(ntimes=1)
+
+    t1 = 1713200000.0
+    t2 = 1713300000.0
+    header_values = [{"sync_time": t1}, {"sync_time": t2}]
+
+    def header_side_effect():
+        return header_values.pop(0)
+
+    read_count = [0]
+
+    def read_side_effect(*a, **kw):
+        read_count[0] += 1
+        if read_count[0] >= 2:
+            observer.stop_event.set()
+        return (read_count[0], mock_data)
+
+    caplog.set_level(logging.WARNING, logger="eigsep_observing.observer")
+    with (
+        patch.object(
+            redis_snap.corr_config,
+            "get_header",
+            side_effect=header_side_effect,
+        ),
+        patch.object(
+            redis_snap.corr_reader, "read", side_effect=read_side_effect
+        ),
+    ):
+        observer.record_corr_data("/tmp/test", ntimes=1, timeout=5)
+
+    # Constructed File twice: initial, plus one roll after re-sync.
+    # (Final try/finally close happens on the second one.)
+    assert mock_file_class.call_count == 2
+    file_mocks[0].close.assert_called()
+    assert "SNAP re-synchronized" in caplog.text
+
+
 def test_record_corr_data_no_snap():
     """Test record_corr_data without snap connection raises AttributeError."""
     observer = EigObserver()


### PR DESCRIPTION
## Summary

- Split the two failure modes that \`record_corr_data\` previously conflated: a transient \`ValueError\` on \`get_header()\` (SNAP fine, data on the stream still valid) vs. \`sync_time=0\` or no header ever (no anchor; data unusable). The first should save data; the second should crash loudly.
- Cache \`(header, sync_time)\` across files. Transient fetch blip with a valid cache → WARN and reuse cached header — corr data is sacred, the metadata-path blip must not block writes.
- Bounded watchdog (\`header_wait_timeout=300s\`) when we can't get a usable header — \`ValueError\` without a cache, or \`sync_time=0\` from a good fetch. On timeout, raise \`RuntimeError\` so the process crashes visibly instead of silently accumulating days of junk.
- Detect mid-run SNAP re-sync (successful fetch, new \`sync_time\` != cached non-zero one) by closing the current file and rolling a new one.
- Wrap the main loop in \`try/finally\` so \`io.File.close()\` flushes the partial buffer when \`RuntimeError\` unwinds.
- \`scripts/observe.py\`: \`threading.Thread\` swallows exceptions, so wrap \`record_corr_data\` in a target that catches \`RuntimeError\`, logs CRITICAL, sets \`stop_event\` (so the VNA thread exits), and exits non-zero after join.

Stacked on #47.

## Test plan

- [x] \`pytest\` — 170/170 pass
- [x] \`ruff check .\` / \`ruff format --check .\` — clean
- [x] \`test_record_corr_data_transient_header_blip_uses_cache\` — ValueError + valid cache → set_header called with cached, add_data still called
- [x] \`test_record_corr_data_unsynced_watchdog_crashes\` — persistent sync_time=0 → RuntimeError after short timeout, no writes, file.close still called
- [x] \`test_record_corr_data_no_header_ever_crashes\` — persistent ValueError with no cache → RuntimeError, file.close called
- [x] \`test_record_corr_data_resync_rolls_file\` — sync_time change mid-run → new File constructed, old one closed, WARNING logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)