### PR TITLE
feat(fpga-init): collapse init flags into --reinit, rehydrate sync_time on attach

### DIFF
--- a/scripts/fpga_init.py
+++ b/scripts/fpga_init.py
@@ -12,7 +12,13 @@ from eigsep_observing.testing import DummyEigsepFpga  # noqa: E402
 from eigsep_observing.utils import get_config_path, load_config  # noqa: E402
 
 parser = argparse.ArgumentParser(
-    description="Snap observing with Eigsep FPGA",
+    description=(
+        "SNAP observing with Eigsep FPGA. "
+        "With no flags, attach to a SNAP that is already running and "
+        "synced (sync_time is rehydrated from the corr header). "
+        "Use --reinit for a fresh observing block (ADC + FPGA regs + "
+        "sync); add -p/-P to also (re)program the bitstream."
+    ),
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 parser.add_argument(
@@ -20,35 +26,24 @@ parser.add_argument(
     dest="program",
     action="store_true",
     default=False,
-    help="Program Eigsep correlator.",
+    help="Program Eigsep correlator (requires --reinit).",
 )
 parser.add_argument(
     "-P",
     dest="force_program",
     action="store_true",
     default=False,
-    help="Force program Eigsep correlator.",
+    help="Force program Eigsep correlator (requires --reinit).",
 )
 parser.add_argument(
-    "-a",
-    dest="initialize_adc",
+    "--reinit",
+    dest="reinit",
     action="store_true",
     default=False,
-    help="Initialize ADCs.",
-)
-parser.add_argument(
-    "-f",
-    dest="initialize_fpga",
-    action="store_true",
-    default=False,
-    help="Initialize Eigsep correlator.",
-)
-parser.add_argument(
-    "-s",
-    dest="sync",
-    action="store_true",
-    default=False,
-    help="Sync Eigsep correlator.",
+    help=(
+        "Full re-init: ADC + FPGA registers + sync. Starts a fresh "
+        "observing block and invalidates any prior sync_time."
+    ),
 )
 parser.add_argument(
     "--config_file",
@@ -71,6 +66,13 @@ parser.add_argument(
     help="Drop into an IPython shell with live access to the fpga object.",
 )
 args = parser.parse_args()
+
+if (args.program or args.force_program) and not args.reinit:
+    parser.error(
+        "-p/-P requires --reinit: a fresh bitstream leaves all FPGA "
+        "registers at zero and needs a full init + sync."
+    )
+
 cfg = load_config(args.config_file)
 
 if args.force_program:
@@ -86,12 +88,18 @@ else:
     logger.info(f"Connecting to Eigsep correlator at {snap_ip}.")
     fpga = EigsepFpga(cfg=cfg, program=program)
 
-# initialize SNAP
-fpga.initialize(
-    initialize_adc=args.initialize_adc,
-    initialize_fpga=args.initialize_fpga,
-    sync=args.sync,
-)
+if args.reinit:
+    # Fresh observing block: full init + sync.
+    fpga.initialize(initialize_adc=True, initialize_fpga=True, sync=True)
+else:
+    # Attach path: SNAP is already running; recover sync_time from the
+    # header so CorrWriter.add doesn't drop every integration.
+    logger.info("Attaching to running SNAP (no --reinit).")
+    if not fpga.rehydrate_sync_from_header():
+        parser.error(
+            "No valid sync_time on corr header; refusing to attach. "
+            "Run with --reinit to start a fresh observing block."
+        )
 
 # validate config and upload to redis
 fpga.upload_config(validate=True)

--- a/scripts/observe.py
+++ b/scripts/observe.py
@@ -104,15 +104,8 @@ else:
 
 thds = {}
 thds["status"] = observer.status_thread
-# Corr data is sacred — every other data product (VNA, switch
-# schedule, sensors) is supporting context for the corr stream. If
-# the corr thread dies for any reason (bounded-wait watchdog raising
-# RuntimeError, TimeoutError from CorrReader.read after SNAP dies
-# mid-run, any unanticipated failure), the rest of the system should
-# stop too: collecting hours of VNA files with no corr data to pair
-# them against is worse than exiting loudly. threading.Thread swallows
-# target exceptions by default, so wrap the target to convert any
-# Exception into stop_event + non-zero exit.
+
+# crash observing if the corr thread dies for any reason
 corr_crashed = [False]
 
 

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -320,6 +320,15 @@ class EigsepFpga:
         sync : bool
             Synchronize the correlator clock.
 
+        Raises
+        ------
+        ValueError
+            If ``initialize_fpga=True`` and ``sync=False``. Rewriting
+            the correlator registers (``corr_acc_len``, etc.) restarts
+            the accumulation counter, so any previously-published
+            ``sync_time`` is stale — the hardware must be re-synced or
+            ``acc_cnt`` cannot be converted to a valid wallclock.
+
         Notes
         -----
         This is a convenience method that calls the methods
@@ -330,6 +339,12 @@ class EigsepFpga:
         in the specified order with their default parameters.
 
         """
+        if initialize_fpga and not sync:
+            raise ValueError(
+                "initialize_fpga=True requires sync=True: re-initializing "
+                "the FPGA registers resets acc_cnt and invalidates the "
+                "previous sync_time."
+            )
         if initialize_adc:
             self.logger.debug("Initializing ADCs.")
             self.initialize_adc()
@@ -340,6 +355,47 @@ class EigsepFpga:
         if sync:
             self.logger.debug("Synchronizing correlator clock.")
             self.synchronize()
+
+    def rehydrate_sync_from_header(self):
+        """
+        Restore ``sync_time`` / ``is_synchronized`` from the corr header.
+
+        Intended for the attach path — reconnecting to a SNAP that is
+        already running and synced from a previous process. Without
+        this, ``self.sync_time=0`` on startup and ``CorrWriter.add``
+        would drop every integration until the next ``synchronize()``
+        call (see :mod:`eigsep_observing.corr`). The header is the
+        authoritative persisted record of the last sync; it's
+        re-uploaded by the observe loop roughly every ~100 integrations
+        so it should always be present while the SNAP is producing
+        data.
+
+        Returns
+        -------
+        bool
+            ``True`` if a valid ``sync_time`` was found on the header
+            and restored. ``False`` if the header is missing or
+            ``sync_time`` is falsy (cold boot — the caller should
+            synchronize explicitly).
+        """
+        try:
+            header = self.redis.corr_config.get_header()
+        except ValueError:
+            self.logger.warning(
+                "No corr header in Redis; cannot rehydrate sync_time. "
+                "This is expected on a cold boot — run with --reinit."
+            )
+            return False
+        sync_time = header.get("sync_time", 0)
+        if not sync_time:
+            self.logger.warning(
+                "Corr header present but sync_time=0; not rehydrating."
+            )
+            return False
+        self.sync_time = sync_time
+        self.is_synchronized = True
+        self.logger.info(f"Rehydrated sync_time={sync_time} from corr header.")
+        return True
 
     def _run_adc_test(self, test, n_tries):
         """

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -495,22 +495,25 @@ class EigsepFpga:
 
     def set_input(self):
         """
-        Set the input to either noise or ADC based on the configuration.
-        This method is called after initializing the ADC and FPGA.
+        Point the input mux at noise or ADC based on ``cfg["use_noise"]``.
+
+        This only configures the mux and the noise seed; it does not arm
+        the sync / noise generator or issue any ``sw_sync`` pulses. The
+        arming happens in :meth:`synchronize`, which branches on the
+        same config flag so that noise mode arms the noise generator and
+        ADC mode arms the external sync path.
 
         Notes
         -----
-        This is called by `initialize`. Can be called separately
-        to change the input after initialization.
+        Called by :meth:`initialize`. Switching inputs post-init changes
+        the data product (digital noise vs sky) and should be done by
+        re-running ``initialize`` with the updated config, not by
+        calling this directly.
         """
         self.noise.set_seed(stream=None, seed=0)
         if self.cfg["use_noise"]:
             self.logger.warning("Switching to noise input.")
             self.inp.use_noise(stream=None)
-            self.sync.arm_noise()
-            for i in range(3):
-                self.sync.sw_sync()
-            self.logger.info("Synchronized noise")
         else:
             self.logger.info("Switching to ADC input.")
             self.inp.use_adc(stream=None)
@@ -641,19 +644,29 @@ class EigsepFpga:
         """
         Synchronize the correlator clock and publish sync time to Redis.
 
+        Branches on ``cfg["use_noise"]``: noise mode arms the noise
+        generator; ADC mode arms the external sync path after setting
+        the pulse-to-trigger delay. Both paths then issue three
+        ``sw_sync`` pulses, record ``sync_time``, and upload the fresh
+        header so ``CorrWriter.add`` stops gating.
+
         Parameters
         ----------
         delay : int
             Delay in FPGA clock ticks between arrival of an external
-            sync pulse and the issuing of an internal trigger.
+            sync pulse and the issuing of an internal trigger. Only
+            used in ADC mode.
 
         """
-        self.sync.set_delay(delay)
-        self.sync.arm_sync()
-        for i in range(3):
+        if self.cfg["use_noise"]:
+            self.sync.arm_noise()
+        else:
+            self.sync.set_delay(delay)
+            self.sync.arm_sync()
+        for _ in range(3):
             self.sync.sw_sync()
-            sync_time = time.time()  # not an int unless 1PPS is provided
-            self.logger.info(f"Synchronized at {sync_time}.")
+        sync_time = time.time()  # not an int unless 1PPS is provided
+        self.logger.info(f"Synchronized at {sync_time}.")
         self.sync_time = sync_time
         self.is_synchronized = True
         # update header in redis with fresh sync time

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -220,14 +220,23 @@ class TestEigsepFpga:
 
         assert "Synchronizing correlator clock." in caplog.text
 
-    def test_initialize_sync_disabled(self, fpga_instance):
-        """Test initialize with sync disabled."""
-        # Track calls to synchronize method
+    def test_initialize_sync_disabled_attach_path(self, fpga_instance):
+        """initialize(initialize_fpga=False, sync=False) is the attach
+        path: set_input runs but synchronize does not."""
         with patch.object(fpga_instance, "synchronize") as mock_sync:
-            fpga_instance.initialize(sync=False)
-
-            # Verify that synchronize was NOT called when sync=False
+            fpga_instance.initialize(
+                initialize_adc=False, initialize_fpga=False, sync=False
+            )
             mock_sync.assert_not_called()
+
+    def test_initialize_fpga_without_sync_raises(self, fpga_instance):
+        """Re-initializing FPGA registers invalidates the prior
+        sync_time, so initialize_fpga=True with sync=False must raise
+        rather than silently leave a stale sync anchor."""
+        with pytest.raises(ValueError, match="requires sync=True"):
+            fpga_instance.initialize(
+                initialize_adc=False, initialize_fpga=True, sync=False
+            )
 
     def test_initialize_adc_disabled(self, fpga_instance):
         """Test initialize with ADC initialization disabled."""
@@ -237,6 +246,53 @@ class TestEigsepFpga:
 
             # Verify that synchronize was called even with initialize_adc=False
             mock_sync.assert_called_once()
+
+    def test_rehydrate_sync_from_header_restores_state(
+        self, fpga_instance, caplog
+    ):
+        """A header with a non-zero sync_time rehydrates
+        self.sync_time / self.is_synchronized without hitting the
+        hardware sync path."""
+        caplog.set_level(logging.INFO)
+        with patch(
+            "eigsep_observing.fpga.time.time",
+            return_value=2222222222.0,
+        ):
+            fpga_instance.synchronize()
+        # Fresh instance semantics: reset the in-process state so we
+        # prove the rehydrate path does the work.
+        fpga_instance.sync_time = 0
+        fpga_instance.is_synchronized = False
+
+        assert fpga_instance.rehydrate_sync_from_header() is True
+        assert fpga_instance.sync_time == 2222222222.0
+        assert fpga_instance.is_synchronized is True
+        assert "Rehydrated sync_time" in caplog.text
+
+    def test_rehydrate_sync_from_header_no_header(self, fpga_instance, caplog):
+        """Cold-boot case: no header in Redis → returns False, warns,
+        and leaves state untouched."""
+        caplog.set_level(logging.WARNING)
+        fpga_instance.sync_time = 0
+        fpga_instance.is_synchronized = False
+
+        assert fpga_instance.rehydrate_sync_from_header() is False
+        assert fpga_instance.sync_time == 0
+        assert fpga_instance.is_synchronized is False
+        assert "cold boot" in caplog.text
+
+    def test_rehydrate_sync_from_header_zero_sync_time(
+        self, fpga_instance, caplog
+    ):
+        """Header present but sync_time=0 → refuse to rehydrate."""
+        caplog.set_level(logging.WARNING)
+        fpga_instance.redis.corr_config.upload_header({"sync_time": 0})
+        fpga_instance.sync_time = 0
+        fpga_instance.is_synchronized = False
+
+        assert fpga_instance.rehydrate_sync_from_header() is False
+        assert fpga_instance.is_synchronized is False
+        assert "sync_time=0" in caplog.text
 
     def test_read_integrations_no_new_data(self, fpga_instance):
         """No new cnt → loop exits via pre-set event, queue stays empty."""

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -208,6 +208,38 @@ class TestEigsepFpga:
         header = fpga_instance.redis.corr_config.get_header()
         assert header["sync_time"] == 1111111111.0
 
+    def test_synchronize_noise_mode(self, fpga_instance):
+        """In noise mode, synchronize() arms the noise generator (not
+        the external sync path) and skips set_delay — but still records
+        sync_time and uploads the header so CorrWriter.add un-gates."""
+        fpga_instance.cfg["use_noise"] = True
+        sync = fpga_instance.sync
+        with (
+            patch.object(
+                sync, "set_delay", wraps=sync.set_delay
+            ) as spy_set_delay,
+            patch.object(
+                sync, "arm_sync", wraps=sync.arm_sync
+            ) as spy_arm_sync,
+            patch.object(
+                sync, "arm_noise", wraps=sync.arm_noise
+            ) as spy_arm_noise,
+            patch.object(sync, "sw_sync", wraps=sync.sw_sync) as spy_sw_sync,
+            patch(
+                "eigsep_observing.fpga.time.time",
+                return_value=2222222222.0,
+            ),
+        ):
+            fpga_instance.synchronize(delay=5)
+
+        spy_arm_noise.assert_called_once()
+        spy_arm_sync.assert_not_called()
+        spy_set_delay.assert_not_called()
+        assert spy_sw_sync.call_count == 3
+        assert fpga_instance.is_synchronized is True
+        header = fpga_instance.redis.corr_config.get_header()
+        assert header["sync_time"] == 2222222222.0
+
     def test_initialize_all_enabled(self, fpga_instance, caplog):
         """initialize() with sync=True calls synchronize and logs."""
         caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
## Summary

- Collapse `-a` / `-f` / `-s` on `fpga_init.py` into a single `--reinit` flag. The three-way combination had silently-wrong states (e.g. `-f` without `-s` leaves a stale `sync_time`; `set_input` can re-sync the hardware in noise mode without updating `self.sync_time`; re-initing FPGA registers restarts `acc_cnt` either way).
- Validate that `-p` / `-P` require `--reinit` — a fresh bitstream leaves all correlator registers at zero, so a partial init is incoherent.
- In `EigsepFpga.initialize`, raise `ValueError` when `initialize_fpga=True` and `sync=False` as a lower-layer guard for any other caller (tests, future scripts).
- New `EigsepFpga.rehydrate_sync_from_header()` restores `sync_time` / `is_synchronized` from the persisted corr header. The no-flags path is now the explicit attach case: reconnect to an already-running SNAP and recover sync state from Redis. Without this, post-#47 every attach after a crash would silently publish zero data because `CorrWriter.add` drops pre-sync integrations.
- `fpga_init.py` refuses to attach if the header has no valid `sync_time` — loud over silent.

Stacked on #48.

## Operational modes after this PR

| invocation | meaning |
|-----------|---------|
| (none) | attach to running SNAP; rehydrate `sync_time` from corr header |
| `--reinit` | full re-init: ADC + FPGA regs + sync. Starts a fresh observing block. |
| `-p --reinit` / `-P --reinit` | (re)program bitstream, then full re-init |
| `-p` alone | argparse error |

## Test plan

- [x] `pytest` — 174/174 pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] New tests: initialize guard, three rehydrate cases (success / missing header / zero sync_time), attach-equivalent path

🤖 Generated with [Claude Code](https://claude.com/claude-code)