### PR TITLE
feat(observer): unify SNAP liveness under single deadline in record_corr_data

### DIFF
--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -7,6 +7,41 @@ from . import io
 logger = logging.getLogger(__name__)
 
 
+def _tick_liveness_deadline(deadline, liveness_timeout, reason):
+    """Advance the SNAP-liveness deadline; raise if expired.
+
+    Parameters
+    ----------
+    deadline : float or None
+        Current deadline (``time.monotonic()`` seconds), or ``None``
+        if no failure has been seen since the last successful write.
+    liveness_timeout : float
+        Tolerated duration without a complete corr row, in seconds.
+    reason : str
+        What triggered this tick; surfaced in the ``RuntimeError``.
+
+    Returns
+    -------
+    float
+        Updated deadline. Set to ``monotonic() + liveness_timeout`` on
+        the first failure since the last clear; unchanged thereafter.
+
+    Raises
+    ------
+    RuntimeError
+        If ``deadline`` is in the past.
+    """
+    now = time.monotonic()
+    if deadline is None:
+        return now + liveness_timeout
+    if now > deadline:
+        raise RuntimeError(
+            f"SNAP has not produced a complete corr row for "
+            f"{liveness_timeout}s: {reason}"
+        )
+    return deadline
+
+
 class EigObserver:
     def __init__(self, redis_snap=None, redis_panda=None):
         """
@@ -96,7 +131,7 @@ class EigObserver:
                 self.logger.log(level, status)
 
     def record_corr_data(
-        self, save_dir, ntimes=240, timeout=20, header_wait_timeout=300
+        self, save_dir, ntimes=240, timeout=20, liveness_timeout=300
     ):
         """
         Read data from the SNAP correlator via Redis and write it to
@@ -110,37 +145,44 @@ class EigObserver:
             Number of spectra per file.
         timeout : int
             The time in seconds to wait for data from the correlator.
-        header_wait_timeout : float
-            Bounded wait, in seconds, when we cannot obtain a valid
-            corr header with a non-zero ``sync_time`` — either because
-            the fetch is failing with ``ValueError`` and we have no
-            cached header, or because the fetch succeeds but reports
-            ``sync_time=0`` (SNAP never synchronized). Exceeding this
-            deadline raises ``RuntimeError`` so the process crashes
-            visibly rather than silently accumulating days of
-            untimestamped data.
+        liveness_timeout : float
+            Bounded wait, in seconds, for the SNAP to produce a
+            complete corr row (valid header with non-zero
+            ``sync_time`` *and* an entry on the corr stream).
+            Exceeding this deadline raises ``RuntimeError`` so the
+            process crashes visibly rather than silently accumulating
+            unusable data.
 
         Notes
         -----
-        Two failure modes are handled separately:
+        Every failure mode that means "SNAP is not producing a
+        complete corr row right now" shares a single watchdog:
 
-        1. **Transient header-fetch failure** (``ValueError`` from
-           ``get_header``) when we have a cached header from a prior
-           successful fetch: fall back to the cache, log at WARNING,
-           and save the incoming corr data. Data on the stream has
-           valid timestamps; the metadata-path blip must not block
-           corr writes ("corr data is sacred").
-        2. **No sync anchor** (``sync_time=0`` from a successful
-           fetch, or ``ValueError`` with no cache): start a bounded
-           wait and crash via ``RuntimeError`` once
-           ``header_wait_timeout`` elapses. The writer-side gate in
-           ``CorrWriter.add`` keeps the stream empty in this state,
-           so the watchdog is the structural guard that prevents
-           silent long-term unusable data.
+        - ``ValueError`` from ``get_header`` with no cached header
+        - ``sync_time == 0`` on a fetched header
+        - ``TimeoutError`` from ``corr_reader.read``
+        - ``(None, {})`` from ``corr_reader.read`` (stream absent)
+
+        The deadline starts on the first such failure and is cleared
+        when ``file.add_data`` completes. Crossing it raises
+        ``RuntimeError``. The consumer only cares *whether* a row
+        arrived, not *why* it did not — duck-typing on "did I get a
+        complete row?" is more trustworthy than classifying header vs.
+        stream failures, because ``get_header`` reads a persistent
+        Redis hash and a stale header can survive a dead SNAP.
+
+        A ``ValueError`` from ``get_header`` *with* a cached header
+        is treated as a transient metadata-path blip: the cached
+        header is used, the loop proceeds to read/write the next row,
+        and the deadline is cleared on the next successful write.
+        Corr data on the stream has valid timestamps; the blip must
+        not block corr writes ("corr data is sacred").
 
         A valid ``sync_time`` that differs from the cached one is
         treated as a mid-run SNAP re-sync: the current file is closed
-        and a new one is opened with the new anchor.
+        and a new one is opened with the new anchor. This is a
+        legitimate state change, not a failure, so the deadline is
+        untouched.
         """
         pairs = self.corr_cfg["pairs"]
         t_int = self.corr_cfg["integration_time"]
@@ -161,7 +203,7 @@ class EigObserver:
         file = io.File(save_dir, pairs, ntimes, self.corr_cfg)
         cached_header = None
         cached_sync_time = None
-        no_header_deadline = None
+        last_write_deadline = None
         try:
             while not self.stop_event.is_set():
                 if file.counter == 0:
@@ -174,17 +216,12 @@ class EigObserver:
                                 "Using cached corr header."
                             )
                             file.set_header(header=cached_header)
-                            no_header_deadline = None
                         else:
-                            if no_header_deadline is None:
-                                no_header_deadline = (
-                                    time.monotonic() + header_wait_timeout
-                                )
-                            if time.monotonic() > no_header_deadline:
-                                raise RuntimeError(
-                                    f"No corr header available after "
-                                    f"{header_wait_timeout}s: {e}"
-                                )
+                            last_write_deadline = _tick_liveness_deadline(
+                                last_write_deadline,
+                                liveness_timeout,
+                                f"header fetch failed: {e}",
+                            )
                             self.logger.error(
                                 f"Error reading header from SNAP: {e}. "
                                 "Waiting for a valid header."
@@ -195,15 +232,11 @@ class EigObserver:
                     else:
                         new_sync_time = header.get("sync_time")
                         if not new_sync_time:
-                            if no_header_deadline is None:
-                                no_header_deadline = (
-                                    time.monotonic() + header_wait_timeout
-                                )
-                            if time.monotonic() > no_header_deadline:
-                                raise RuntimeError(
-                                    f"SNAP never synchronized within "
-                                    f"{header_wait_timeout}s (sync_time=0)."
-                                )
+                            last_write_deadline = _tick_liveness_deadline(
+                                last_write_deadline,
+                                liveness_timeout,
+                                "sync_time=0 (SNAP not synchronized)",
+                            )
                             self.logger.error(
                                 "No sync_time in corr header. Cannot "
                                 "derive accurate timestamps. Waiting "
@@ -227,11 +260,31 @@ class EigObserver:
                             )
                         cached_header = header
                         cached_sync_time = new_sync_time
-                        no_header_deadline = None
                         file.set_header(header=header)
-                acc_cnt, data = self.redis_snap.corr_reader.read(
-                    pairs=pairs, timeout=timeout, unpack=True
-                )
+                try:
+                    acc_cnt, data = self.redis_snap.corr_reader.read(
+                        pairs=pairs, timeout=timeout, unpack=True
+                    )
+                except TimeoutError:
+                    last_write_deadline = _tick_liveness_deadline(
+                        last_write_deadline,
+                        liveness_timeout,
+                        f"no corr entry within {timeout}s",
+                    )
+                    self.logger.error(
+                        f"No correlation data received within {timeout}s. "
+                        "Waiting for SNAP to produce data."
+                    )
+                    continue
+                if acc_cnt is None:
+                    last_write_deadline = _tick_liveness_deadline(
+                        last_write_deadline,
+                        liveness_timeout,
+                        "corr stream does not exist yet",
+                    )
+                    if self.stop_event.wait(1):
+                        return
+                    continue
                 self.logger.info(f"{acc_cnt=}")
                 if self.panda_connected:
                     metadata = self.redis_panda.metadata_stream.drain()
@@ -240,6 +293,7 @@ class EigObserver:
                 file.add_data(
                     acc_cnt, cached_sync_time, data, metadata=metadata
                 )
+                last_write_deadline = None
         finally:
             file.close()
 

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -193,13 +193,6 @@ class EigObserver:
             f"File time: {file_time} s"
         )
 
-        while not self.snap_connected:
-            self.logger.warning(
-                "Waiting for SNAP Redis connection to be established."
-            )
-            if self.stop_event.wait(1):
-                return
-
         file = io.File(save_dir, pairs, ntimes, self.corr_cfg)
         cached_header = None
         cached_sync_time = None

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -611,8 +611,10 @@ def test_record_vna_data(
     assert call_args[1]["save_dir"] == "/tmp/test_vna"
 
 
-def test_record_vna_data_timeout(observer_panda_only, redis_panda):
-    """Test record_vna_data retries on timeout (no data in stream)."""
+def test_record_vna_data_stream_absent(observer_panda_only, redis_panda):
+    """When no VNA data has ever been published, ``vna_reader.read``
+    returns ``(None, None, None)`` and the loop retries after a wait.
+    """
     observer = observer_panda_only
 
     # No data pushed — vna_reader.read returns (None, None, None) because
@@ -628,6 +630,29 @@ def test_record_vna_data_timeout(observer_panda_only, redis_panda):
 
     with patch.object(
         redis_panda.vna_reader, "read", side_effect=counting_read
+    ):
+        observer.record_vna_data("/tmp/test_vna", timeout=1)
+
+    assert call_count[0] >= 2
+
+
+def test_record_vna_data_timeout(observer_panda_only, redis_panda):
+    """``TimeoutError`` from ``vna_reader.read`` is expected during idle
+    windows between hourly VNA triggers — bare ``continue``, no log, no
+    watchdog. The loop simply retries.
+    """
+    observer = observer_panda_only
+
+    call_count = [0]
+
+    def timeout_read(timeout=0):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            observer.stop_event.set()
+        raise TimeoutError("no VNA entry")
+
+    with patch.object(
+        redis_panda.vna_reader, "read", side_effect=timeout_read
     ):
         observer.record_vna_data("/tmp/test_vna", timeout=1)
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -464,6 +464,50 @@ def test_record_corr_data_read_timeout_then_success_resets_deadline(
     assert mock_file.add_data.call_count >= 1
 
 
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_panda_connected_drains_metadata(
+    mock_file_class, observer_both, redis_snap, redis_panda
+):
+    """When the panda is connected, the metadata stream is drained and
+    forwarded to ``file.add_data``; when not, ``metadata=None`` is passed
+    (covered by ``test_record_corr_data``). This exercises the only
+    success-path branch that touches cross-class logic.
+    """
+    observer = observer_both
+    sync_time = 1713200000.0
+    redis_snap.corr_config.upload_header({"sync_time": sync_time})
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    mock_data = generate_data(ntimes=1)
+
+    # Push one sensor reading onto the panda metadata stream via the
+    # real MetadataWriter (runs against fakeredis in DummyEigsepObsRedis).
+    sample = {"temp_c": 23.5, "status": "update"}
+    redis_panda.metadata.add("sensor_a", sample)
+    # Rewind last-read-id so drain() picks up the entry we just pushed
+    # (xread skips entries at/before the last-generated-id by default).
+    redis_panda._set_last_read_id("stream:sensor_a", "0-0")
+
+    def read_side_effect(*a, **kw):
+        observer.stop_event.set()
+        return (123, mock_data)
+
+    with patch.object(
+        redis_snap.corr_reader, "read", side_effect=read_side_effect
+    ):
+        observer.record_corr_data("/tmp/test", ntimes=1, timeout=5)
+
+    # add_data received the drained metadata, keyed by the stream name
+    # MetadataWriter.add uses (``stream:<key>``).
+    mock_file.add_data.assert_called_once()
+    call_kwargs = mock_file.add_data.call_args.kwargs
+    assert call_kwargs["metadata"] == {"stream:sensor_a": [sample]}
+
+
 def test_record_corr_data_no_snap():
     """Test record_corr_data without snap connection raises AttributeError."""
     observer = EigObserver()

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -260,9 +260,11 @@ def test_record_corr_data_unsynced_watchdog_crashes(
 
     redis_snap.corr_config.upload_header({"sync_time": 0})
 
-    with pytest.raises(RuntimeError, match="SNAP never synchronized"):
+    with pytest.raises(
+        RuntimeError, match="SNAP has not produced a complete corr row"
+    ):
         observer.record_corr_data(
-            "/tmp/test", ntimes=1, timeout=5, header_wait_timeout=0.2
+            "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
         )
 
     # No data should have been read or written — no sync anchor.
@@ -289,10 +291,12 @@ def test_record_corr_data_no_header_ever_crashes(
             "get_header",
             side_effect=ValueError("no header"),
         ),
-        pytest.raises(RuntimeError, match="No corr header"),
+        pytest.raises(
+            RuntimeError, match="SNAP has not produced a complete corr row"
+        ),
     ):
         observer.record_corr_data(
-            "/tmp/test", ntimes=1, timeout=5, header_wait_timeout=0.2
+            "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
         )
 
     mock_file.add_data.assert_not_called()
@@ -351,6 +355,113 @@ def test_record_corr_data_resync_rolls_file(
     assert mock_file_class.call_count == 2
     file_mocks[0].close.assert_called()
     assert "SNAP re-synchronized" in caplog.text
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_read_timeout_watchdog_crashes(
+    mock_file_class, observer_snap_only, redis_snap
+):
+    """Persistent ``TimeoutError`` from ``corr_reader.read`` → bounded
+    wait → ``RuntimeError``. Unified with the header-side watchdog:
+    the consumer only cares whether complete rows arrive.
+    """
+    observer = observer_snap_only
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    redis_snap.corr_config.upload_header({"sync_time": 1713200000.0})
+
+    with (
+        patch.object(
+            redis_snap.corr_reader,
+            "read",
+            side_effect=TimeoutError("no data"),
+        ),
+        pytest.raises(
+            RuntimeError, match="SNAP has not produced a complete corr row"
+        ),
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=0.05, liveness_timeout=0.2
+        )
+
+    mock_file.add_data.assert_not_called()
+    mock_file.close.assert_called()
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_read_stream_absent_watchdog_crashes(
+    mock_file_class, observer_snap_only, redis_snap
+):
+    """Persistent ``(None, {})`` from ``corr_reader.read`` (stream not
+    created yet) → bounded wait → ``RuntimeError``.
+    """
+    observer = observer_snap_only
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    redis_snap.corr_config.upload_header({"sync_time": 1713200000.0})
+
+    with (
+        patch.object(redis_snap.corr_reader, "read", return_value=(None, {})),
+        pytest.raises(
+            RuntimeError, match="SNAP has not produced a complete corr row"
+        ),
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
+        )
+
+    mock_file.add_data.assert_not_called()
+    mock_file.close.assert_called()
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_read_timeout_then_success_resets_deadline(
+    mock_file_class, observer_snap_only, redis_snap
+):
+    """A single read timeout followed by a successful read must not
+    crash. ``file.add_data`` clears ``last_write_deadline`` so the
+    next failure starts a fresh watchdog instead of inheriting the
+    prior one.
+    """
+    observer = observer_snap_only
+    sync_time = 1713200000.0
+    redis_snap.corr_config.upload_header({"sync_time": sync_time})
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    mock_data = generate_data(ntimes=1)
+
+    calls = [0]
+
+    def read_side_effect(*a, **kw):
+        calls[0] += 1
+        if calls[0] == 1:
+            raise TimeoutError("transient")
+        if calls[0] >= 3:
+            observer.stop_event.set()
+        return (100 + calls[0], mock_data)
+
+    with patch.object(
+        redis_snap.corr_reader, "read", side_effect=read_side_effect
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=0.05, liveness_timeout=0.05
+        )
+
+    # At least one successful write happened; the first-call timeout
+    # did not crash the loop because the follow-up write cleared it.
+    assert mock_file.add_data.call_count >= 1
 
 
 def test_record_corr_data_no_snap():


### PR DESCRIPTION
## Summary

Collapse the four *"SNAP isn't producing a complete corr row right now"* failure modes in `EigObserver.record_corr_data` into a single duck-typed `last_write_deadline` watchdog:

- `ValueError` from `get_header()` with no cached header
- `sync_time == 0` on a fetched header
- `TimeoutError` from `corr_reader.read`
- `(None, {})` from `corr_reader.read` (stream absent)

The deadline starts on the first such failure, resets on each successful `file.add_data`, and raises `RuntimeError` when exceeded. The consumer only cares *whether* a complete row arrived, not *why* it didn't — duck-typing is more trustworthy than classifying header vs. stream failures, because `get_header()` reads a persistent Redis hash and a stale header can survive a dead SNAP.

Preserved from before:
- Cached-header fallback on transient `ValueError` — proceeds to a real write, so the deadline clears naturally on success (*corr data is sacred*).
- Re-sync rollover — legitimate state change, not a failure; deadline untouched.

## Rename

`header_wait_timeout` → `liveness_timeout`, since the scope is no longer header-only. The sole in-tree caller (`scripts/observe.py:114`) does not pass the kwarg.

## Why this follows #48

#48 narrowly split the header-fetch failure modes; this PR extends the same watchdog idea to the data path. Sketched on #48 in response to a Copilot comment about the `(None, {})` return from `CorrReader.read`. Kept separate so the control-flow rewrite didn't widen the review surface of #48.

## Out of scope

The stale-header problem itself (flushing `CORR_HEADER_KEY` on observer shutdown, or adding a publish-timestamp and treating old ones as absent) is a separate follow-up.

## Base branch

Targeting `feat/fpga-init-reinit-flag` (PR #49) until that merges. Retarget to `main` before merge.

## Test plan

- [x] `pytest tests/test_observer.py` — 21 passed (5 watchdog-path tests: existing 2 updated for new error message + kwarg rename, 3 new for unified read-path failure modes and deadline reset-on-write)
- [x] `pytest` full suite — 177 passed
- [x] `ruff check .` + `ruff format --check .` clean
- [ ] Visual inspection of the observer loop on a live SNAP before merging (maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)