### PR TITLE
feat(corr): stamp header_upload_unix, publish on every state change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,13 +117,19 @@ change needed). Tracked informally; not yet implemented.
 
 `sync_time` is a per-sync invariant (set once when the SNAP is synchronized),
 not a per-integration sensor reading. It rides on the corr header
-(`redis.corr_config.get_header()["sync_time"]`), published by
-`EigsepFpga.synchronize` and re-uploaded every ~100 integrations inside the
-observe loop. `EigObserver.record_corr_data` caches it from the header at
-file-start; a mid-file re-sync is an edge case that warrants a new file
-anyway. Historically `sync_time` was pushed through `add_metadata` and fetched
-inline by `read_corr_data` — that was the last cross-bus read inside a reader,
-removed in this refactor.
+(`redis.corr_config.get_header()["sync_time"]`), published on every
+state-changing call in `EigsepFpga` — `initialize`, `synchronize`,
+`set_pam_atten` / `set_pam_atten_all`, `set_pol_delay`. There is no periodic
+heartbeat re-upload; the header persists in Redis until overwritten by the
+next state change. Every `CorrConfigStore.upload_header` call also stamps a
+`header_upload_unix` field so file headers record when the producer last
+re-published — offline you can check consistency between `sync_time` and
+`header_upload_unix` to detect a SNAP that was reconfigured without
+re-publishing. `EigObserver.record_corr_data` caches `sync_time` from the
+header at file-start; a mid-file re-sync is an edge case that warrants a
+new file anyway. Historically `sync_time` was pushed through `add_metadata`
+and fetched inline by `read_corr_data` — that was the last cross-bus read
+inside a reader, removed in this refactor.
 
 ## Metadata averaging: per-type reduction policy
 

--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -83,8 +83,17 @@ class CorrConfigStore:
         return json.loads(raw)
 
     def upload_header(self, header):
-        """Upload the correlator header (from ``EigsepFpga.header``)."""
-        self.transport._upload_dict(header, CORR_HEADER_KEY)
+        """Upload the correlator header (from ``EigsepFpga.header``).
+
+        Stamps ``header_upload_unix`` at publication time so downstream
+        (file headers, offline inspection) can see when the producer
+        last re-published. A stale timestamp relative to ``sync_time``
+        means state on the SNAP changed without the producer
+        re-publishing — a contract violation worth investigating, not a
+        runtime failure.
+        """
+        stamped = {**header, "header_upload_unix": time.time()}
+        self.transport._upload_dict(stamped, CORR_HEADER_KEY)
 
     def get_header(self):
         """

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -355,6 +355,12 @@ class EigsepFpga:
         if sync:
             self.logger.debug("Synchronizing correlator clock.")
             self.synchronize()
+        # Explicit re-publish: initialize() is the outer state-change
+        # boundary. synchronize() also publishes, so on sync=True this
+        # is a redundant (but harmless, freshest-wins) upload; on
+        # sync=False / ADC-only paths this is the only publish that
+        # reflects the freshly-initialized state.
+        self.redis.corr_config.upload_header(self.header)
 
     def rehydrate_sync_from_header(self):
         """
@@ -365,10 +371,11 @@ class EigsepFpga:
         this, ``self.sync_time=0`` on startup and ``CorrWriter.add``
         would drop every integration until the next ``synchronize()``
         call (see :mod:`eigsep_observing.corr`). The header is the
-        authoritative persisted record of the last sync; it's
-        re-uploaded by the observe loop roughly every ~100 integrations
-        so it should always be present while the SNAP is producing
-        data.
+        authoritative persisted record of the last sync: it's
+        published on every state-changing call (``initialize``,
+        ``synchronize``, ``set_pam_atten*``, ``set_pol_delay``) and
+        persists in Redis until overwritten, so it should be present
+        whenever a SNAP has been initialized and synced.
 
         Returns
         -------
@@ -541,6 +548,7 @@ class EigsepFpga:
             self.fpga.write_int(f"pfb_pol{key}_delay", dly)
             if verify:
                 assert self.fpga.read_uint(f"pfb_pol{key}_delay") == dly
+        self.redis.corr_config.upload_header(self.header)
 
     def initialize_pams(self):
         """
@@ -595,6 +603,7 @@ class EigsepFpga:
         update_pol = self.cfg["rf_chain"]["ants"][ant]["pam"]["pol"]
         atten[update_pol] = attenuation
         pam.set_attenuation(atten["E"], atten["N"], verify=True)
+        self.redis.corr_config.upload_header(self.header)
 
     def get_pam_atten(self, ant):
         """
@@ -639,6 +648,7 @@ class EigsepFpga:
             raise RuntimeError("PAMs not initialized.")
         for pam in self.pams:
             pam.set_attenuation(attenuation, attenuation, verify=True)
+        self.redis.corr_config.upload_header(self.header)
 
     def synchronize(self, delay=0):
         """

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -187,8 +187,8 @@ class TestEigsepFpga:
         spy_arm_sync.assert_called_once()
         assert spy_sw_sync.call_count == 3
         # synchronize() pushes the header once so consumers see fresh
-        # sync_time without waiting for the observe loop's periodic
-        # upload.
+        # sync_time. The observe loop does not re-upload — header
+        # publication is state-change driven.
         spy_upload_header.assert_called_once()
 
         # Round-trip: read corr_header back through the production
@@ -325,6 +325,81 @@ class TestEigsepFpga:
         assert fpga_instance.rehydrate_sync_from_header() is False
         assert fpga_instance.is_synchronized is False
         assert "sync_time=0" in caplog.text
+
+    def test_upload_header_stamps_header_upload_unix(self, fpga_instance):
+        """Every CorrConfigStore.upload_header stamps the wallclock of
+        publication under 'header_upload_unix'. Consumers (file headers)
+        read this alongside sync_time to detect post-sync mutations
+        that weren't re-published."""
+        with patch("eigsep_observing.corr.time.time", return_value=1234.0):
+            fpga_instance.redis.corr_config.upload_header({"sync_time": 42})
+
+        header = fpga_instance.redis.corr_config.get_header()
+        assert header["sync_time"] == 42
+        assert header["header_upload_unix"] == 1234.0
+
+    def test_upload_header_does_not_mutate_caller_dict(self, fpga_instance):
+        """Stamping is done on a copy so the caller's dict (typically
+        EigsepFpga.header, a fresh dict per property access, but still)
+        is not surprised with extra keys."""
+        payload = {"sync_time": 42, "nchan": 1024}
+        fpga_instance.redis.corr_config.upload_header(payload)
+        assert payload == {"sync_time": 42, "nchan": 1024}
+
+    def test_initialize_publishes_header_at_boundary(self, fpga_instance):
+        """initialize() itself publishes once at the end, independent of
+        whichever sub-mutator (synchronize / set_pam_atten / ...) also
+        publishes. Stubbing every sub-mutator isolates this guarantee."""
+        with (
+            patch.object(fpga_instance, "initialize_adc"),
+            patch.object(fpga_instance, "initialize_fpga"),
+            patch.object(fpga_instance, "set_input"),
+            patch.object(fpga_instance, "synchronize"),
+            patch.object(
+                fpga_instance.redis.corr_config,
+                "upload_header",
+                wraps=fpga_instance.redis.corr_config.upload_header,
+            ) as spy,
+        ):
+            fpga_instance.initialize(
+                initialize_adc=True, initialize_fpga=True, sync=True
+            )
+        spy.assert_called_once()
+
+    def test_set_pam_atten_publishes_header(self, fpga_instance):
+        """set_pam_atten mutates header-relevant state (rf_chain atten),
+        so it must re-publish."""
+        fpga_instance.initialize_pams()
+        ant = next(iter(fpga_instance.cfg["rf_chain"]["ants"]))
+        with patch.object(
+            fpga_instance.redis.corr_config,
+            "upload_header",
+            wraps=fpga_instance.redis.corr_config.upload_header,
+        ) as spy:
+            fpga_instance.set_pam_atten(ant, 4)
+        spy.assert_called_once()
+
+    def test_set_pam_atten_all_publishes_header(self, fpga_instance):
+        """set_pam_atten_all mutates all PAMs at once; same contract."""
+        fpga_instance.initialize_pams()
+        with patch.object(
+            fpga_instance.redis.corr_config,
+            "upload_header",
+            wraps=fpga_instance.redis.corr_config.upload_header,
+        ) as spy:
+            fpga_instance.set_pam_atten_all(6)
+        spy.assert_called_once()
+
+    def test_set_pol_delay_publishes_header(self, fpga_instance):
+        """set_pol_delay mutates pol_delay (a top-level header field)
+        so it must re-publish."""
+        with patch.object(
+            fpga_instance.redis.corr_config,
+            "upload_header",
+            wraps=fpga_instance.redis.corr_config.upload_header,
+        ) as spy:
+            fpga_instance.set_pol_delay({"01": 3, "23": 0, "45": 0})
+        spy.assert_called_once()
 
     def test_read_integrations_no_new_data(self, fpga_instance):
         """No new cnt → loop exits via pre-set event, queue stays empty."""

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -347,24 +347,25 @@ class TestEigsepFpga:
         assert payload == {"sync_time": 42, "nchan": 1024}
 
     def test_initialize_publishes_header_at_boundary(self, fpga_instance):
-        """initialize() itself publishes once at the end, independent of
-        whichever sub-mutator (synchronize / set_pam_atten / ...) also
-        publishes. Stubbing every sub-mutator isolates this guarantee."""
-        with (
-            patch.object(fpga_instance, "initialize_adc"),
-            patch.object(fpga_instance, "initialize_fpga"),
-            patch.object(fpga_instance, "set_input"),
-            patch.object(fpga_instance, "synchronize"),
-            patch.object(
-                fpga_instance.redis.corr_config,
-                "upload_header",
-                wraps=fpga_instance.redis.corr_config.upload_header,
-            ) as spy,
-        ):
+        """initialize()'s trailing line publishes the header after all
+        sub-mutators have run, independently of which of them also
+        published. Called with initialize_adc=False / initialize_fpga=
+        False / sync=True the only other publish is synchronize(), so
+        the boundary publish is observable as the second of exactly two
+        calls (redundant but harmless, freshest-wins). A fuller
+        initialize() call additionally goes through set_pam_atten (once
+        per configured antenna) and set_pol_delay, each of which also
+        publishes — that shape is covered by the dedicated sub-mutator
+        tests below, not this one."""
+        with patch.object(
+            fpga_instance.redis.corr_config,
+            "upload_header",
+            wraps=fpga_instance.redis.corr_config.upload_header,
+        ) as spy:
             fpga_instance.initialize(
-                initialize_adc=True, initialize_fpga=True, sync=True
+                initialize_adc=False, initialize_fpga=False, sync=True
             )
-        spy.assert_called_once()
+        assert spy.call_count == 2
 
     def test_set_pam_atten_publishes_header(self, fpga_instance):
         """set_pam_atten mutates header-relevant state (rf_chain atten),


### PR DESCRIPTION
## Summary

- Make corr-header publication a **state-change contract**. Every `EigsepFpga` method that mutates header content now re-publishes: `initialize()` at the outer boundary, `set_pam_atten` / `set_pam_atten_all`, `set_pol_delay` (`synchronize()` already did).
- Stamp `header_upload_unix` once inside `CorrConfigStore.upload_header`. The timestamp rides into the file header so offline inspection can cross-check against `sync_time` — a stale upload time relative to `sync_time` means the SNAP was reconfigured without re-publishing.
- No consumer-side staleness warn or crash. Corr data is sacred; the file-header field is the diagnostic surface, not a runtime trigger.
- Fix stale docstrings in `fpga.py`, `CLAUDE.md`, and `tests/test_fpga.py` that claimed a `~100 integrations` periodic re-upload that never existed in code.

## Why this shape (not a heartbeat)

`upload_header` was historically only called inside `synchronize()`. The docstrings promised a periodic re-upload from the observe loop, but the code never did it — so a `header_upload_unix` field on its own would always equal `sync_time` and be meaningless. A heartbeat would make the stamp meaningful but is a cheap hack over the real issue: mutators can silently diverge the header from live hardware state. Fixing it at the mutator boundary makes the contract explicit at each state-change site and leaves the stamp as diagnostic data rather than a liveness trigger.

## Test plan

- [x] `ruff check .` + `ruff format --check .` clean
- [x] `pytest` — 181 passed (6 new tests added covering the stamp + each mutator site)
- [ ] Deploy to ground PC; confirm `header_upload_unix` appears on corr headers and in saved HDF5 file headers.
- [ ] Sanity-check: run `set_pam_atten` on a live SNAP and verify the Redis header's `header_upload_unix` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)