### PR TITLE
Close attach-path validation gap via Redis-as-truth

### DIFF
--- a/scripts/fpga_init.py
+++ b/scripts/fpga_init.py
@@ -91,6 +91,8 @@ else:
 if args.reinit:
     # Fresh observing block: full init + sync.
     fpga.initialize(initialize_adc=True, initialize_fpga=True, sync=True)
+    # Validate cfg against freshly-initialized hardware and publish.
+    fpga.upload_config(validate=True)
 else:
     # Attach path: SNAP is already running; recover sync_time from the
     # header so CorrWriter.add doesn't drop every integration.
@@ -100,9 +102,15 @@ else:
             "No valid sync_time on corr header; refusing to attach. "
             "Run with --reinit to start a fresh observing block."
         )
-
-# validate config and upload to redis
-fpga.upload_config(validate=True)
+    # validate_config against hardware is vacuous on attach (the
+    # header echoes cfg for blocks this process didn't initialize).
+    # Use Redis as source of truth: a cfg diff means the yaml was
+    # edited without a matching reinit — refuse rather than silently
+    # push the edited cfg to Redis.
+    try:
+        fpga.assert_config_matches_redis()
+    except RuntimeError as e:
+        parser.error(str(e))
 
 # start observing
 logger.info("Starting observation.")

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -45,6 +45,35 @@ default_config_file = get_config_path("corr_config.yaml")
 default_config = load_config(default_config_file)
 
 
+def _cfg_diff_summary(disk_cfg, redis_cfg):
+    """
+    Produce a human-readable summary of differences between two
+    configuration dicts. Used by ``assert_config_matches_redis`` to
+    make "re-run with --reinit" errors debuggable.
+
+    Recurses into nested dicts and reports dotted paths; non-dict
+    leaves are compared with ``!=``.
+    """
+    lines = []
+
+    def _walk(a, b, path):
+        for key in sorted(set(a) | set(b)):
+            sub = f"{path}.{key}" if path else key
+            if key not in a:
+                lines.append(f"  {sub}: <missing on disk> vs {b[key]!r}")
+            elif key not in b:
+                lines.append(f"  {sub}: {a[key]!r} vs <missing in Redis>")
+            elif isinstance(a[key], dict) and isinstance(b[key], dict):
+                _walk(a[key], b[key], sub)
+            elif a[key] != b[key]:
+                lines.append(
+                    f"  {sub}: {a[key]!r} (disk) vs {b[key]!r} (Redis)"
+                )
+
+    _walk(disk_cfg, redis_cfg, "")
+    return "\n".join(lines) if lines else "  <identical>"
+
+
 class EigsepFpga:
     def __init__(self, cfg=default_config, program=False):
         """
@@ -274,6 +303,50 @@ class EigsepFpga:
             raise RuntimeError(
                 "Configuration does not match hardware setup: "
                 + ", ".join(fails)
+            )
+
+    def assert_config_matches_redis(self) -> None:
+        """
+        Attach-path assertion: ``self.cfg`` must match the config
+        already in Redis.
+
+        The attach path (``fpga_init.py`` without ``--reinit``) does
+        not re-initialize the hardware, so ``validate_config`` — which
+        compares ``self.cfg`` against ``self.header`` — is vacuous for
+        fields that the header echoes from ``self.cfg`` when a block's
+        ``_initialized`` flag is False (ADC ``sample_rate`` /
+        ``adc_gain``, PAM ``atten``). On attach, the cfg already in
+        Redis is the authoritative record of the running hardware's
+        intended configuration (written by the prior reinit run), so
+        the safe check is "the cfg I'm about to attach with matches
+        the cfg already in Redis."
+
+        Raises
+        ------
+        RuntimeError
+            If there is no config in Redis (cold boot — caller should
+            run with ``--reinit``), or if ``self.cfg`` differs from
+            the Redis-resident cfg (yaml was edited without a matching
+            reinit; either revert the yaml or re-run with ``--reinit``
+            to apply).
+        """
+        try:
+            redis_cfg = self.redis.corr_config.get_config()
+        except ValueError:
+            raise RuntimeError(
+                "No corr config in Redis; cannot attach. "
+                "Run with --reinit to initialize from this config."
+            )
+        # Transport injects ``upload_time`` on every publish; it's not
+        # part of the config contract and always differs.
+        redis_cfg.pop("upload_time", None)
+        if self.cfg != redis_cfg:
+            diff = _cfg_diff_summary(self.cfg, redis_cfg)
+            raise RuntimeError(
+                "Config on disk differs from Redis-resident config:\n"
+                f"{diff}\n"
+                "Re-run with --reinit to apply the new config, or "
+                "revert the yaml to match the running hardware."
             )
 
     def upload_config(self, validate: bool = True) -> None:

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -152,6 +152,41 @@ class TestEigsepFpga:
         assert "Configuration validation failed: Config invalid" in caplog.text
         upload_spy.assert_not_called()
 
+    def test_assert_config_matches_redis_match(self, fpga_instance):
+        """assert_config_matches_redis is a no-op when cfg matches Redis."""
+        fpga_instance.redis.corr_config.upload_config(
+            fpga_instance.cfg, from_file=False
+        )
+        fpga_instance.assert_config_matches_redis()
+
+    def test_assert_config_matches_redis_missing(self, fpga_instance):
+        """Cold boot (no cfg in Redis) → caller must run with --reinit."""
+        with pytest.raises(RuntimeError, match="No corr config in Redis"):
+            fpga_instance.assert_config_matches_redis()
+
+    def test_assert_config_matches_redis_mismatch(self, fpga_instance):
+        """
+        cfg differs from Redis → refuse with a diff. Simulates the
+        real-world failure: user edited the yaml and attached without
+        --reinit.
+        """
+        fpga_instance.redis.corr_config.upload_config(
+            fpga_instance.cfg, from_file=False
+        )
+        # Perturb a scalar and a nested field to exercise the recursive
+        # diff summary.
+        fpga_instance.cfg["sample_rate"] = fpga_instance.cfg["sample_rate"] / 2
+        first_ant = next(iter(fpga_instance.cfg["rf_chain"]["ants"]))
+        fpga_instance.cfg["rf_chain"]["ants"][first_ant]["pam"]["atten"] += 1
+
+        with pytest.raises(RuntimeError) as exc:
+            fpga_instance.assert_config_matches_redis()
+
+        msg = str(exc.value)
+        assert "sample_rate" in msg
+        assert f"rf_chain.ants.{first_ant}.pam.atten" in msg
+        assert "--reinit" in msg
+
     def test_synchronize(self, fpga_instance):
         """synchronize sets sync_time on the corr header and uploads it."""
         # Spy on the real Sync block so we observe the high-level


### PR DESCRIPTION
## Summary

- `EigsepFpga.validate_config` compares `self.cfg` against `self.header`, but on the attach path (`fpga_init.py` without `--reinit`) the ADC and PAM blocks are uninitialized, and `header` echoes cfg values for `sample_rate`/`adc_gain`/PAM `atten`. Validation for those fields is a tautology — a user could edit the yaml, attach, and have the (unapplied) cfg silently pushed to Redis, misleading every downstream consumer.
- Adds `EigsepFpga.assert_config_matches_redis()`: attach-path assertion that `self.cfg` equals the cfg already in Redis (written by the prior `--reinit` run). Uses a recursive dotted-path diff helper so the "re-run with --reinit" error names exactly which fields differ.
- Updates `scripts/fpga_init.py` so the attach path calls the new assertion instead of `upload_config(validate=True)`. `upload_config` now only runs on the reinit path, against freshly-initialized hardware.

Reinit path is unchanged — `validate_config` is still meaningful there because `initialize()` sets the `_initialized` flags and `header` reads real hardware values.

## Why Redis-as-truth and not hardware-as-truth

Considered reading ADC/PAM hardware unconditionally in `header` to make `validate_config` honest on attach. Problem: `self.adc.sample_rate` and `self.adc.gain` (fpga.py) are plain Python attributes stashed at `initialize_adc` time — `casperfpga.SnapAdc` has no hardware getter for them. A full hardware-truth fix would need new register-readback plumbing in casperfpga. PAMs would work, but ADC fields would stay silently unvalidated.

Redis-as-truth catches the real-world failure ("user edited yaml and forgot `--reinit`") in one shot and doesn't require touching casperfpga. Hardware-drift scenarios are not realistic — if the hardware and Redis disagree, something much worse is happening than a stale cfg.

## Test plan

- [x] `pytest tests/test_fpga.py` — 29 passed (3 new: match / missing / mismatch-with-diff)
- [x] `pytest` — 178 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [ ] Manual: on a real SNAP, run `fpga_init.py --reinit`, then without `--reinit` (should attach clean), then edit `corr_config.yaml` and attach again (should refuse with diff naming the edited field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)