### PR TITLE
refactor: consistent ConfigStore/CorrConfigStore surface, drop from_file

### DIFF
--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -47,7 +47,7 @@ class PandaClient:
             self.logger.warning(
                 "No configuration found in Redis, using default config."
             )
-            self.redis.config.upload(default_cfg, from_file=False)
+            self.redis.config.upload(default_cfg)
             cfg = self._get_cfg()
         self.cfg = json.loads(json.dumps(cfg))
 

--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -54,7 +54,7 @@ class CorrConfigStore:
     def __init__(self, transport):
         self.transport = transport
 
-    def upload_config(self, config, from_file=False):
+    def upload(self, config, from_file=False):
         """
         Upload the SNAP configuration.
 
@@ -62,13 +62,17 @@ class CorrConfigStore:
         ----------
         config : str or dict
             Path to a YAML file if ``from_file`` is True, else a dict.
+            When loading from a file, ``integration_time`` is computed
+            and injected via :func:`utils.load_config` — the corr
+            config contract requires it, which is why this path differs
+            from :class:`ConfigStore.upload`.
         from_file : bool
         """
         if from_file:
             config = load_config(config)
         self.transport._upload_dict(config, CORR_CONFIG_KEY)
 
-    def get_config(self):
+    def get(self):
         """
         Return the SNAP configuration.
 

--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -12,7 +12,6 @@ from .keys import (
     CORR_PAIRS_SET,
     CORR_STREAM,
 )
-from .utils import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -54,22 +53,20 @@ class CorrConfigStore:
     def __init__(self, transport):
         self.transport = transport
 
-    def upload(self, config, from_file=False):
+    def upload(self, config):
         """
         Upload the SNAP configuration.
 
+        YAML file loading is the caller's responsibility — the corr
+        contract requires ``integration_time`` to be injected
+        (``utils.load_config`` does this), and keeping that step at
+        the entry point avoids coupling this store to the observing
+        utils.
+
         Parameters
         ----------
-        config : str or dict
-            Path to a YAML file if ``from_file`` is True, else a dict.
-            When loading from a file, ``integration_time`` is computed
-            and injected via :func:`utils.load_config` — the corr
-            config contract requires it, which is why this path differs
-            from :class:`ConfigStore.upload`.
-        from_file : bool
+        config : dict
         """
-        if from_file:
-            config = load_config(config)
         self.transport._upload_dict(config, CORR_CONFIG_KEY)
 
     def get(self):

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -331,7 +331,7 @@ class EigsepFpga:
             to apply).
         """
         try:
-            redis_cfg = self.redis.corr_config.get_config()
+            redis_cfg = self.redis.corr_config.get()
         except ValueError:
             raise RuntimeError(
                 "No corr config in Redis; cannot attach. "
@@ -373,7 +373,7 @@ class EigsepFpga:
                 self.logger.error(f"Configuration validation failed: {e}")
                 raise RuntimeError("Configuration validation failed") from e
         self.logger.debug("Uploading configuration to Redis.")
-        self.redis.corr_config.upload(self.cfg, from_file=False)
+        self.redis.corr_config.upload(self.cfg)
 
     def initialize(
         self,

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -373,7 +373,7 @@ class EigsepFpga:
                 self.logger.error(f"Configuration validation failed: {e}")
                 raise RuntimeError("Configuration validation failed") from e
         self.logger.debug("Uploading configuration to Redis.")
-        self.redis.corr_config.upload_config(self.cfg, from_file=False)
+        self.redis.corr_config.upload(self.cfg, from_file=False)
 
     def initialize(
         self,

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -77,7 +77,7 @@ class EigObserver:
         self.redis_panda = redis_panda
 
         if self.redis_snap is not None:
-            self.corr_cfg = self.redis_snap.corr_config.get_config()
+            self.corr_cfg = self.redis_snap.corr_config.get()
         if self.redis_panda is not None:
             self.cfg = self.redis_panda.config.get()
 

--- a/src/eigsep_observing/plot.py
+++ b/src/eigsep_observing/plot.py
@@ -89,7 +89,7 @@ class LivePlotter:
         self.poll_interval = poll_interval
 
         # Get configuration from Redis
-        self.corr_cfg = self.redis.corr_config.get_config()
+        self.corr_cfg = self.redis.corr_config.get()
         self.nchan = self.corr_cfg.get("n_chans", 1024)
         self.sample_rate = self.corr_cfg.get("sample_rate", 500)
 

--- a/src/eigsep_observing/testing/observer.py
+++ b/src/eigsep_observing/testing/observer.py
@@ -1,5 +1,7 @@
 import logging
 
+import yaml
+
 from .. import EigObserver, utils
 
 logger = logging.getLogger(__name__)
@@ -11,12 +13,13 @@ CFG_PATH = utils.get_config_path("dummy_config.yaml")
 class DummyEigObserver(EigObserver):
     def __init__(self, redis_snap=None, redis_panda=None):
         """
-        Override constrcutor to use dummy configs.
+        Override constructor to use dummy configs.
         """
         # upload corr config to redis, parent class will read it
         if redis_snap is not None:
-            redis_snap.corr_config.upload(CORR_CFG_PATH, from_file=True)
+            redis_snap.corr_config.upload(utils.load_config(CORR_CFG_PATH))
         if redis_panda is not None:
-            redis_panda.config.upload(CFG_PATH, from_file=True)
+            with open(CFG_PATH, "r") as f:
+                redis_panda.config.upload(yaml.safe_load(f))
         # call parent constructor
         super().__init__(redis_snap=redis_snap, redis_panda=redis_panda)

--- a/src/eigsep_observing/testing/observer.py
+++ b/src/eigsep_observing/testing/observer.py
@@ -15,7 +15,7 @@ class DummyEigObserver(EigObserver):
         """
         # upload corr config to redis, parent class will read it
         if redis_snap is not None:
-            redis_snap.corr_config.upload_config(CORR_CFG_PATH, from_file=True)
+            redis_snap.corr_config.upload(CORR_CFG_PATH, from_file=True)
         if redis_panda is not None:
             redis_panda.config.upload(CFG_PATH, from_file=True)
         # call parent constructor

--- a/src/eigsep_redis/config.py
+++ b/src/eigsep_redis/config.py
@@ -18,7 +18,7 @@ class ConfigStore:
     def __init__(self, transport):
         self.transport = transport
 
-    def upload(self, config, from_file=True):
+    def upload(self, config, from_file=False):
         """
         Upload the panda configuration to Redis.
 

--- a/src/eigsep_redis/config.py
+++ b/src/eigsep_redis/config.py
@@ -1,36 +1,33 @@
 import json
 
-import yaml
-
 from .keys import CONFIG_KEY
 
 
 class ConfigStore:
     """
-    Persistent single-key store for the panda-side YAML configuration.
+    Persistent single-key store for the panda-side configuration.
 
     ``upload`` serializes the config (plus an ``upload_time``) under a
     well-known Redis key; ``get`` reads it back. This is the generic
     panda config — the SNAP-side correlator config lives in a separate
     store in ``eigsep_observing``.
+
+    YAML file loading is the caller's responsibility. Keeping the store
+    dict-only means it has no dependency on ``eigsep_observing.utils``
+    and no divergence in how the two stores parse files.
     """
 
     def __init__(self, transport):
         self.transport = transport
 
-    def upload(self, config, from_file=False):
+    def upload(self, config):
         """
         Upload the panda configuration to Redis.
 
         Parameters
         ----------
-        config : str or dict
-            Path to a YAML file if ``from_file`` is True, else a dict.
-        from_file : bool
+        config : dict
         """
-        if from_file:
-            with open(config, "r") as f:
-                config = yaml.safe_load(f)
         self.transport._upload_dict(config, CONFIG_KEY)
 
     def get(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,7 @@ def test_get_cfg(caplog, dummy_cfg):
         assert "upload_time" in cfg_in_redis
 
         # upload the dummy config to client2's redis
-        client2.redis.config.upload(dummy_cfg, from_file=False)
+        client2.redis.config.upload(dummy_cfg)
 
         # check that they're the same
         retrieved_cfg = client2._get_cfg()

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -99,8 +99,8 @@ class TestEigsepFpga:
 
         with patch.object(
             fpga_instance.redis.corr_config,
-            "upload_config",
-            wraps=fpga_instance.redis.corr_config.upload_config,
+            "upload",
+            wraps=fpga_instance.redis.corr_config.upload,
         ) as spy:
             fpga_instance.upload_config(validate=True)
 
@@ -119,8 +119,8 @@ class TestEigsepFpga:
             ) as validate_spy,
             patch.object(
                 fpga_instance.redis.corr_config,
-                "upload_config",
-                wraps=fpga_instance.redis.corr_config.upload_config,
+                "upload",
+                wraps=fpga_instance.redis.corr_config.upload,
             ) as upload_spy,
         ):
             fpga_instance.upload_config(validate=False)
@@ -140,8 +140,8 @@ class TestEigsepFpga:
             ),
             patch.object(
                 fpga_instance.redis.corr_config,
-                "upload_config",
-                wraps=fpga_instance.redis.corr_config.upload_config,
+                "upload",
+                wraps=fpga_instance.redis.corr_config.upload,
             ) as upload_spy,
         ):
             with pytest.raises(

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -106,7 +106,7 @@ class TestEigsepFpga:
 
         # Implicit success: if validate_config had raised, the upload
         # below would never have happened.
-        spy.assert_called_once_with(fpga_instance.cfg, from_file=False)
+        spy.assert_called_once_with(fpga_instance.cfg)
         assert "Uploading configuration to Redis." in caplog.text
 
     def test_upload_config_without_validation(self, fpga_instance):
@@ -126,7 +126,7 @@ class TestEigsepFpga:
             fpga_instance.upload_config(validate=False)
 
         validate_spy.assert_not_called()
-        upload_spy.assert_called_once_with(fpga_instance.cfg, from_file=False)
+        upload_spy.assert_called_once_with(fpga_instance.cfg)
 
     def test_upload_config_validation_failure(self, fpga_instance, caplog):
         """upload_config raises and logs when validate_config fails."""
@@ -154,9 +154,7 @@ class TestEigsepFpga:
 
     def test_assert_config_matches_redis_match(self, fpga_instance):
         """assert_config_matches_redis is a no-op when cfg matches Redis."""
-        fpga_instance.redis.corr_config.upload_config(
-            fpga_instance.cfg, from_file=False
-        )
+        fpga_instance.redis.corr_config.upload(fpga_instance.cfg)
         fpga_instance.assert_config_matches_redis()
 
     def test_assert_config_matches_redis_missing(self, fpga_instance):
@@ -170,9 +168,7 @@ class TestEigsepFpga:
         real-world failure: user edited the yaml and attached without
         --reinit.
         """
-        fpga_instance.redis.corr_config.upload_config(
-            fpga_instance.cfg, from_file=False
-        )
+        fpga_instance.redis.corr_config.upload(fpga_instance.cfg)
         # Perturb a scalar and a nested field to exercise the recursive
         # diff summary.
         fpga_instance.cfg["sample_rate"] = fpga_instance.cfg["sample_rate"] / 2

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -16,7 +16,7 @@ from eigsep_observing.testing.utils import generate_data
 def redis_snap():
     """DummyEigsepObsRedis seeded with a correlator config."""
     redis = DummyEigsepObsRedis()
-    redis.corr_config.upload_config(
+    redis.corr_config.upload(
         {
             "integration_time": 1.0,
             "pairs": ["0", "1", "2", "3", "02", "13"],

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -20,8 +20,7 @@ def redis_snap():
         {
             "integration_time": 1.0,
             "pairs": ["0", "1", "2", "3", "02", "13"],
-        },
-        from_file=False,
+        }
     )
     return redis
 
@@ -46,8 +45,7 @@ def redis_panda():
             },
             "vna_save_dir": "/tmp/test_vna",
             "vna_interval": 0.5,
-        },
-        from_file=False,
+        }
     )
     redis.heartbeat.set(alive=True)
     return redis

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -280,8 +280,8 @@ def test_bus_classes_have_no_cross_bus_methods():
         CorrWriter: {"add", "maxlen"},
         CorrReader: {"read", "seek"},
         CorrConfigStore: {
-            "upload_config",
-            "get_config",
+            "upload",
+            "get",
             "upload_header",
             "get_header",
         },

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -288,9 +288,9 @@ def test_bus_classes_have_no_cross_bus_methods():
         VnaWriter: {"add", "maxlen"},
         VnaReader: {"read"},
     }
-    # CorrConfigStore legitimately owns upload_config/get_config/
-    # upload_header/get_header — those are its surface, not cross-bus.
-    # Scope the forbidden check to each class's non-own methods.
+    # CorrConfigStore legitimately owns upload/get/upload_header/
+    # get_header — those are its surface, not cross-bus. Scope the
+    # forbidden check to each class's non-own methods.
     for cls, expected in surfaces.items():
         public = {name for name in vars(cls) if not name.startswith("_")}
         assert public == expected, (


### PR DESCRIPTION
## Summary

- Rename `CorrConfigStore.upload_config`/`get_config` → `upload`/`get` so the two stores have parallel method names. `upload_header`/`get_header` kept — those are the reason `CorrConfigStore` exists as a separate store.
- Drop the `from_file` kwarg from both stores. No production caller used `from_file=True` — every real entry point (`fpga_init.py`, `panda_observe.py` via `client.py`, `observe.py`) already loaded the YAML at the edge and passed a dict in. `DummyEigObserver` was the only `from_file=True` user and now loads the YAML itself.
- Removes the behavioural divergence between the two stores' file-loading paths (inline `yaml.safe_load` vs `utils.load_config` with `integration_time` injection). `integration_time` injection still happens — just at the call site where it belongs, keeping `ConfigStore` free of any dependency on `eigsep_observing.utils`.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] Full `pytest` suite passes (186 tests)
- [ ] Smoke test on real hardware: `fpga_init.py` uploads corr config, `panda_observe` seeds Redis from default config, `observe.py` reads panda config from Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)