### PR TITLE
fix(panda-client): drop dead VNA poll, stop mutating cfg, add stop()

### DIFF
--- a/scripts/panda_observe.py
+++ b/scripts/panda_observe.py
@@ -47,7 +47,7 @@ try:
 except KeyboardInterrupt:
     logger.info("Keyboard interrupt received, stopping threads")
 finally:
-    client.stop_client.set()
+    client.stop()
     for name, t in thds.items():
         logger.info(f"Joining thread {name}")
         t.join()

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -128,6 +128,23 @@ class PandaClient:
             self.stop_client.wait(1.0)
         self.redis.heartbeat.set(alive=False)
 
+    def stop(self, timeout=5.0):
+        """
+        Signal all client loops to stop and wait for the heartbeat
+        thread to emit its ``alive=False`` farewell.
+
+        Idempotent — safe to call more than once. Caller-managed
+        threads (``switch_loop``, ``vna_loop``) observe ``stop_client``
+        and must be joined separately.
+        """
+        self.stop_client.set()
+        if self.heartbeat_thd.is_alive():
+            self.heartbeat_thd.join(timeout=timeout)
+            if self.heartbeat_thd.is_alive():
+                self.logger.warning(
+                    f"Heartbeat thread did not exit within {timeout}s."
+                )
+
     def init_VNA(self):
         """
         Initialize the VNA instance using the configuration from Redis.
@@ -215,8 +232,9 @@ class PandaClient:
                 f"{sorted(VALID_SWITCH_STATES)}."
             )
             return
-        # Validate that all wait_time values are positive numbers
-        remove_modes = []
+        # Validate wait_time values and drop zero-wait modes into a
+        # local schedule — do not mutate self.cfg["switch_schedule"].
+        active_schedule = {}
         for mode, wait_time in schedule.items():
             if not isinstance(wait_time, (int, float)) or wait_time < 0:
                 self.logger.warning(
@@ -228,11 +246,10 @@ class PandaClient:
                 self.logger.info(
                     f"Zero wait_time for mode {mode}: skipping this mode."
                 )
-                remove_modes.append(mode)
-        for mode in remove_modes:
-            del schedule[mode]
+                continue
+            active_schedule[mode] = wait_time
         while not self.stop_client.is_set():
-            for mode, wait_time in schedule.items():
+            for mode, wait_time in active_schedule.items():
                 if mode == "RFANT":
                     with self.switch_lock:
                         self.logger.info(f"Switching to {mode} measurements")
@@ -318,11 +335,11 @@ class PandaClient:
         """
         Observe with VNA and write data to files.
         """
-        while self.vna is None:
+        if self.vna is None:
             self.logger.warning(
                 "VNA not initialized. Cannot execute VNA commands."
             )
-            threading.Event().wait(5)
+            return
         while not self.stop_client.is_set():
             with self.switch_lock:
                 prev_mode = self.current_switch_state

--- a/src/eigsep_observing/testing/client.py
+++ b/src/eigsep_observing/testing/client.py
@@ -94,8 +94,9 @@ class DummyPandaClient(PandaClient):
         kwargs["power_dBm"] = kwargs["power_dBm"]["ant"]
         self.vna.setup(**kwargs)
 
-    def stop(self):
-        """Stop the embedded PicoManager and all dummy devices."""
+    def stop(self, timeout=5.0):
+        """Stop client loops, then the embedded PicoManager."""
+        super().stop(timeout=timeout)
         if hasattr(self, "_manager") and self._manager:
             self._manager.stop()
             self._manager = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,7 @@
+import copy
 import json
+import time
+
 import pytest
 import yaml
 
@@ -119,3 +122,40 @@ def test_pico_manager_devices_visible(client):
         "motor",
     }
     assert names == expected
+
+
+def test_vna_loop_returns_when_vna_is_none(caplog, client):
+    """vna_loop must return promptly when self.vna is None — no
+    polling. Regression for a bare `threading.Event().wait(5)` that
+    ignored stop_client."""
+    caplog.set_level("WARNING")
+    assert client.vna is None  # dummy_config has use_vna: false
+    t0 = time.monotonic()
+    client.vna_loop()
+    elapsed = time.monotonic() - t0
+    assert elapsed < 1.0, f"vna_loop did not return promptly ({elapsed}s)"
+    assert any("VNA not initialized" in r.getMessage() for r in caplog.records)
+
+
+def test_switch_loop_does_not_mutate_cfg_schedule(client):
+    """switch_loop must not mutate self.cfg['switch_schedule'] when
+    filtering out zero-wait modes. Regression for `del schedule[mode]`
+    on the live cfg reference."""
+    original = copy.deepcopy(client.cfg["switch_schedule"])
+    assert any(v == 0 for v in original.values()), (
+        "test needs a zero-wait mode in dummy_config to exercise the filter"
+    )
+    client.stop_client.set()  # bypass the main while loop after validation
+    client.switch_loop()
+    assert client.cfg["switch_schedule"] == original
+
+
+def test_stop_joins_heartbeat_and_emits_goodbye(client):
+    """stop() sets stop_client, joins the heartbeat thread, and the
+    thread's final alive=False is visible to readers. Idempotent."""
+    assert client.heartbeat_thd.is_alive()
+    assert client.redis.heartbeat_reader.check() is True
+    client.stop()
+    assert not client.heartbeat_thd.is_alive()
+    assert client.redis.heartbeat_reader.check() is False
+    client.stop()  # idempotent — must not raise


### PR DESCRIPTION
## Summary

Three shutdown/hygiene bugs found on a fresh read of `PandaClient`. One PR since they're all lifecycle-adjacent and small.

- **`vna_loop` dead poll**: `while self.vna is None: threading.Event().wait(5)` allocated a fresh never-set event each iteration, ignored `stop_client`, and polled a value nothing in the codebase ever transitions after construction. Restored pre-`5e7a6d7` early-return semantics — log loudly and exit if `self.vna is None`. A future hot re-init would need real wiring (catch `init_VNA` failures, retry with a sensible interval, coordinate with `switch_loop` / `measure_s11`), not a phantom poll.
- **`switch_loop` cfg mutation**: `del schedule[mode]` ran on the live `self.cfg["switch_schedule"]` reference. Build a local `active_schedule` dict instead.
- **No `PandaClient.stop()`**: heartbeat thread ran until daemon-exit, `alive=False` farewell never sent, tests leaked heartbeat threads across the fixture pool. Added idempotent `stop()` that sets `stop_client` and joins the heartbeat thread with a timeout. `DummyPandaClient.stop` now calls super before tearing down the embedded PicoManager. `scripts/panda_observe.py` calls `client.stop()` in its finally block.

Regression tests added for each.

## Test plan

- [x] `pytest tests/test_client.py -x` — 7 passed (4 existing + 3 new)
- [x] `pytest` — full suite: 189 passed
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)