### PR TITLE
refactor(panda-client): drop sw_proxy property, collapse switch_loop, inline init_picos

### DIFF
--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -53,8 +53,6 @@ class PandaClient:
 
         # initialize proxies and VNA
         self.peltier = None
-        self._sw_proxy = None
-        self.switch_lock = None
         self._initialize()
 
     def _get_cfg(self):
@@ -76,16 +74,6 @@ class PandaClient:
         self.logger.info(f"Using config from Redis, updated at {upload_time}.")
         return cfg
 
-    @property
-    def sw_proxy(self):
-        return self._sw_proxy
-
-    @sw_proxy.setter
-    def sw_proxy(self, value):
-        self._sw_proxy = value
-        self.switch_lock = threading.Lock()
-        self.current_switch_state = None
-
     def _switch_to(self, state):
         """Route an RF switch command through PicoManager.
 
@@ -93,7 +81,7 @@ class PandaClient:
         PicoManager has not registered the rfswitch device (no-op). The
         caller treats falsy as "switch failed".
         """
-        return self._sw_proxy.send_command("switch", state=state)
+        return self.sw_proxy.send_command("switch", state=state)
 
     def _initialize(self):
         self.stop_client.clear()
@@ -188,6 +176,8 @@ class PandaClient:
         """
         r = self.redis.r
         self.sw_proxy = PicoProxy("rfswitch", r, source="panda_client")
+        self.switch_lock = threading.Lock()
+        self.current_switch_state = None
         # Log what PicoManager has registered
         available = r.smembers("picos")
         if available:
@@ -250,33 +240,34 @@ class PandaClient:
             active_schedule[mode] = wait_time
         while not self.stop_client.is_set():
             for mode, wait_time in active_schedule.items():
-                if mode == "RFANT":
-                    with self.switch_lock:
-                        self.logger.info(f"Switching to {mode} measurements")
-                        if self._switch_to(mode):
-                            self.current_switch_state = mode
-                        else:
-                            self.logger.warning(
-                                f"Failed to switch to {mode}; keeping "
-                                f"current_switch_state={self.current_switch_state}"
-                            )
-                    # release the lock during sky wait time
-                    if self.stop_client.wait(wait_time):
-                        self.logger.info("Switching stopped by event")
+                # RFANT (sky) releases the switch lock during the wait
+                # so an S11 measurement can interrupt; other modes
+                # (load, noise) hold the lock for the full wait.
+                hold_lock_during_wait = mode != "RFANT"
+                with self.switch_lock:
+                    self.logger.info(f"Switching to {mode} measurements")
+                    if self._switch_to(mode):
+                        self.current_switch_state = mode
+                    else:
+                        self.logger.warning(
+                            f"Failed to switch to {mode}; keeping "
+                            f"current_switch_state={self.current_switch_state}"
+                        )
+                    if hold_lock_during_wait and self._wait_or_stop(wait_time):
                         return
-                else:
-                    with self.switch_lock:
-                        self.logger.info(f"Switching to {mode} measurements")
-                        if self._switch_to(mode):
-                            self.current_switch_state = mode
-                        else:
-                            self.logger.warning(
-                                f"Failed to switch to {mode}; keeping "
-                                f"current_switch_state={self.current_switch_state}"
-                            )
-                        if self.stop_client.wait(wait_time):  # wait with stop
-                            self.logger.info("Switching stopped by event")
-                            return
+                if not hold_lock_during_wait and self._wait_or_stop(wait_time):
+                    return
+
+    def _wait_or_stop(self, wait_time):
+        """Sleep for ``wait_time`` or until ``stop_client`` fires.
+
+        Returns True if stop was requested (caller should unwind its
+        loop), False otherwise.
+        """
+        if self.stop_client.wait(wait_time):
+            self.logger.info("Switching stopped by event")
+            return True
+        return False
 
     def measure_s11(self, mode):
         """

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -51,9 +51,38 @@ class PandaClient:
             cfg = self._get_cfg()
         self.cfg = json.loads(json.dumps(cfg))
 
-        # initialize proxies and VNA
         self.peltier = None
-        self._initialize()
+
+        # RF switch proxy is a thin Redis-key facade — no hardware
+        # contact, so construction cannot fail. PicoManager owns the
+        # real serial link and publishes its device list into the
+        # "picos" Redis set; we just log it for startup observability.
+        self.sw_proxy = PicoProxy(
+            "rfswitch", self.redis.r, source="panda_client"
+        )
+        self.switch_lock = threading.Lock()
+        self.current_switch_state = None
+        available = self.redis.r.smembers("picos")
+        if available:
+            names = sorted(
+                n.decode() if isinstance(n, bytes) else n for n in available
+            )
+            self.logger.info(f"PicoManager devices: {names}")
+        else:
+            self.logger.warning("No pico devices registered by PicoManager.")
+
+        if self.cfg.get("use_vna", False):
+            self.init_VNA()
+        else:
+            self.vna = None
+            self.logger.info("VNA not initialized")
+
+        self.heartbeat_thd = threading.Thread(
+            target=self._send_heartbeat,
+            kwargs={"ex": 60},
+            daemon=True,
+        )
+        self.heartbeat_thd.start()
 
     def _get_cfg(self):
         """
@@ -82,23 +111,6 @@ class PandaClient:
         caller treats falsy as "switch failed".
         """
         return self.sw_proxy.send_command("switch", state=state)
-
-    def _initialize(self):
-        self.stop_client.clear()
-        self.init_picos()
-        if self.cfg.get("use_vna", False):
-            self.init_VNA()
-        else:
-            self.vna = None
-            self.logger.info("VNA not initialized")
-
-        # start heartbeat thread
-        self.heartbeat_thd = threading.Thread(
-            target=self._send_heartbeat,
-            kwargs={"ex": 60},
-            daemon=True,
-        )
-        self.heartbeat_thd.start()
 
     def _send_heartbeat(self, ex=60):
         """
@@ -156,37 +168,6 @@ class PandaClient:
         self.logger.info(f"vna kwargs: {kwargs}")
         self.vna.setup(**kwargs)
         self.logger.info("VNA initialized")
-
-    def init_picos(self):
-        """
-        Create Redis-backed proxies for pico devices.
-
-        Sensor-only devices (IMU, potmon, lidar, tempctrl) need no
-        proxy — their data flows to Redis via PicoManager
-        automatically. Only devices that require active commands
-        (e.g. the RF switch) get a proxy.
-
-        Notes
-        -----
-        PicoManager must be running as a separate service for commands
-        to be routed. If it hasn't started yet, the proxies still
-        construct successfully and will no-op until PicoManager
-        registers the devices.
-
-        """
-        r = self.redis.r
-        self.sw_proxy = PicoProxy("rfswitch", r, source="panda_client")
-        self.switch_lock = threading.Lock()
-        self.current_switch_state = None
-        # Log what PicoManager has registered
-        available = r.smembers("picos")
-        if available:
-            names = sorted(
-                n.decode() if isinstance(n, bytes) else n for n in available
-            )
-            self.logger.info(f"PicoManager devices: {names}")
-        else:
-            self.logger.warning("No pico devices registered by PicoManager.")
 
     def switch_loop(self):
         """

--- a/src/eigsep_observing/testing/client.py
+++ b/src/eigsep_observing/testing/client.py
@@ -53,8 +53,8 @@ class DummyPandaClient(PandaClient):
 
     Starts a PicoManager with emulator-backed DummyPico* devices on
     the same (fake)redis instance before ``super().__init__`` runs, so
-    that the proxy objects created by ``init_picos`` find their devices
-    already registered.
+    that the proxy objects built inside PandaClient.__init__ find
+    their devices already registered.
     """
 
     def __init__(self, redis, default_cfg=None):
@@ -65,7 +65,8 @@ class DummyPandaClient(PandaClient):
             except FileNotFoundError:
                 default_cfg = {}
         # Start the embedded manager BEFORE super().__init__ so that
-        # PicoProxy.is_available is True when init_picos runs.
+        # PicoProxy.is_available is True when the parent constructor
+        # builds sw_proxy.
         self._manager = self._start_dummy_manager(redis)
         super().__init__(redis, default_cfg=default_cfg)
 


### PR DESCRIPTION
## Summary

Three PandaClient design-smell cleanups from the post-PR-#54 backlog.

- **Drop `sw_proxy` @property/@setter.** The setter hid the initialization of `switch_lock` and `current_switch_state` as a side effect of attribute assignment — spooky action whose only caller was `init_picos`. All three fields now initialize side-by-side in `__init__`.
- **Collapse `switch_loop` RFANT/else duplication.** The two branches shared a verbatim 9-line switch+log body and differed only in whether `stop_client.wait` ran inside or outside `switch_lock`. Now one body runs under the lock; a `hold_lock_during_wait` flag picks the wait placement. A small `_wait_or_stop` helper kills the remaining 3-line wait+log+return dup.
- **Inline `init_picos` and `_initialize` into `__init__`.** Neither touched hardware (PicoProxy is a Redis-key facade, `smembers("picos")` is a Redis read), neither had a reinit story, and both were called exactly once. `init_VNA` stays as a method because it does have a documented hot-reinit contract.

Net: 65 insertions, 92 deletions. Behaviour unchanged.

## Test plan

- [x] `pytest` — 192 passed, no regressions
- [x] `ruff check .` and `ruff format --check .` clean
- [x] Existing `test_switch_loop_does_not_mutate_cfg_schedule`, `test_vna_loop_returns_when_vna_is_none`, `test_switch_proxy_created`, `test_pico_manager_devices_visible`, `test_stop_joins_heartbeat_and_emits_goodbye` all still pass
- [ ] Dedicated end-to-end `switch_loop` test is still deferred — tracked separately in the PandaClient coverage backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)