### PR TITLE
test(panda-client): cover measure_s11 + _send_heartbeat, formalize VNA S11 contract

### DIFF
--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -7,6 +7,7 @@ from cmt_vna import VNA
 from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
+from .io import _validate_vna_s11_data, _validate_vna_s11_header
 from .utils import get_config_path
 
 logger = logging.getLogger(__name__)
@@ -320,6 +321,28 @@ class PandaClient:
         header["mode"] = mode
         header["metadata_snapshot_unix"] = time.time()
         metadata = self.redis.metadata_snapshot.get()
+
+        # Producer self-check against the VNA S11 contract (see
+        # io.VNA_S11_HEADER_SCHEMA). Loud but non-blocking: never
+        # raises, always publishes, so corr/VNA data flow is
+        # uninterrupted when the producer disagrees with its own
+        # contract. Emit on two channels because panda-side
+        # ``self.logger.warning`` writes only to the local rotating
+        # file — the operator on the ground sees nothing unless we
+        # also push through the Redis status stream, which
+        # ``EigObserver.status_logger`` re-emits ground-side. See
+        # project_status_stream_log_bridge memory.
+        violations = _validate_vna_s11_header(header) + _validate_vna_s11_data(
+            s11, mode
+        )
+        if violations:
+            msg = (
+                f"VNA S11 producer contract violation (mode={mode!r}): "
+                + "; ".join(violations)
+            )
+            self.logger.warning(msg)
+            self.redis.status.send(msg, level=logging.WARNING)
+
         self.redis.vna.add(s11, header=header, metadata=metadata)
         self.logger.info("Vna data added to redis")
 

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -730,6 +730,168 @@ def _validate_metadata(entry, schema):
     return violations
 
 
+# VNA S11 producer contract. ``PandaClient.measure_s11`` publishes to
+# the VNA stream the VNA's own ``header`` dict (fstart, fstop, npoints,
+# ifbw, power_dBm, freqs) plus two fields added at publish time:
+# ``mode`` (``"ant"`` or ``"rec"``) and ``metadata_snapshot_unix``
+# (Unix seconds, the snapshot-capture wallclock). Downstream tools and
+# file headers rely on this exact shape. ``freqs`` is a numpy array,
+# checked separately from the scalar-typed fields.
+#
+# Unit conventions (NOT enforced by the type-only schema; producer
+# must follow these):
+#   - fstart, fstop in Hz (see cmt_vna.setup default units)
+#   - ifbw in Hz
+#   - power_dBm in dBm
+#   - metadata_snapshot_unix is Unix seconds (time.time() semantics)
+VNA_S11_HEADER_SCHEMA = {
+    "fstart": float,
+    "fstop": float,
+    "npoints": int,
+    "ifbw": float,
+    "power_dBm": float,
+    "mode": str,
+    "metadata_snapshot_unix": float,
+}
+
+# OSL calibration standards measured by ``measure_OSL`` and prefixed
+# with ``"cal:"`` by ``measure_s11`` before publication. The prefix is
+# the disk-format convention also used by ``write_s11_file`` /
+# ``read_s11_file``. Sourced once here so a producer rename shows up as
+# a single-point contract break.
+VNA_S11_CAL_KEYS = frozenset({"cal:VNAO", "cal:VNAS", "cal:VNAL"})
+
+# Per-mode required DUT keys on the VNA payload (in addition to the cal
+# keys above). The ``"ant"`` mode measures antenna, load, and noise;
+# ``"rec"`` measures the receiver. These come from ``VNA.measure_ant`` /
+# ``VNA.measure_rec`` respectively and must not regress without an
+# explicit update here — downstream consumers key on these names.
+VNA_S11_MODE_DATA_KEYS = {
+    "ant": frozenset({"ant", "load", "noise"}),
+    "rec": frozenset({"rec"}),
+}
+
+
+def _validate_vna_s11_header(header):
+    """
+    Validate a VNA S11 header against ``VNA_S11_HEADER_SCHEMA`` plus
+    the ``freqs`` numpy-array field.
+
+    Parameters
+    ----------
+    header : dict
+        Header dict produced by ``PandaClient.measure_s11`` (VNA
+        header plus ``mode`` and ``metadata_snapshot_unix``).
+
+    Returns
+    -------
+    violations : list of str
+        Human-readable contract violations. Empty list means valid.
+    """
+    violations = []
+    for key, expected in VNA_S11_HEADER_SCHEMA.items():
+        if key not in header:
+            violations.append(f"missing key '{key}'")
+            continue
+        val = header[key]
+        if expected is float:
+            ok = isinstance(
+                val, (int, float, np.integer, np.floating)
+            ) and not isinstance(val, bool)
+        elif expected is int:
+            ok = isinstance(val, (int, np.integer)) and not isinstance(
+                val, bool
+            )
+        else:
+            ok = isinstance(val, expected)
+        if not ok:
+            violations.append(
+                f"key '{key}': expected {expected.__name__}, got "
+                f"{type(val).__name__}"
+            )
+    if "mode" in header and header["mode"] not in VNA_S11_MODE_DATA_KEYS:
+        violations.append(
+            f"key 'mode': expected one of "
+            f"{sorted(VNA_S11_MODE_DATA_KEYS)}, got {header['mode']!r}"
+        )
+    if "freqs" not in header:
+        violations.append("missing key 'freqs'")
+    else:
+        freqs = header["freqs"]
+        # Accept ndarray (producer side) or list (post-JSON-roundtrip
+        # through VnaWriter). Either way, ensure it's non-empty and
+        # length-matches npoints when both are present.
+        if isinstance(freqs, np.ndarray):
+            n = freqs.size
+        elif isinstance(freqs, list):
+            n = len(freqs)
+        else:
+            violations.append(
+                f"key 'freqs': expected ndarray or list, got "
+                f"{type(freqs).__name__}"
+            )
+            n = None
+        if n == 0:
+            violations.append("key 'freqs': empty array")
+        npoints = header.get("npoints")
+        if n is not None and isinstance(npoints, int) and n != npoints:
+            violations.append(
+                f"key 'freqs': length {n} does not match npoints {npoints}"
+            )
+    return violations
+
+
+def _validate_vna_s11_data(data, mode):
+    """
+    Validate a VNA S11 data dict against the per-mode contract.
+
+    Parameters
+    ----------
+    data : dict
+        Output of ``PandaClient.measure_s11``: per-DUT complex arrays
+        plus the ``cal:*`` OSL calibration arrays.
+    mode : str
+        ``"ant"`` or ``"rec"``.
+
+    Returns
+    -------
+    violations : list of str
+        Human-readable contract violations. Empty list means valid.
+    """
+    violations = []
+    if mode not in VNA_S11_MODE_DATA_KEYS:
+        violations.append(
+            f"unknown mode {mode!r}; expected one of "
+            f"{sorted(VNA_S11_MODE_DATA_KEYS)}"
+        )
+        return violations
+    expected_dut = VNA_S11_MODE_DATA_KEYS[mode]
+    required = expected_dut | VNA_S11_CAL_KEYS
+    missing = required - set(data)
+    extra = set(data) - required
+    if missing:
+        violations.append(f"missing keys: {sorted(missing)}")
+    if extra:
+        violations.append(f"extra keys: {sorted(extra)}")
+    for key in required & set(data):
+        arr = data[key]
+        if not isinstance(arr, np.ndarray):
+            violations.append(
+                f"key '{key}': expected np.ndarray, got {type(arr).__name__}"
+            )
+            continue
+        if arr.dtype.kind != "c":
+            violations.append(
+                f"key '{key}': expected complex dtype, got {arr.dtype}"
+            )
+        if arr.ndim != 1 or arr.size == 0:
+            violations.append(
+                f"key '{key}': expected non-empty 1-D array, got shape "
+                f"{arr.shape}"
+            )
+    return violations
+
+
 def avg_metadata(value):
     """
     Average metadata readings down to one entry per sample.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -325,3 +325,88 @@ def test_stop_joins_heartbeat_and_emits_goodbye(client):
     assert not client.heartbeat_thd.is_alive()
     assert client.redis.heartbeat_reader.check() is False
     client.stop()  # idempotent — must not raise
+
+
+def test_send_heartbeat_cycles_and_announces_shutdown(redis, dummy_cfg):
+    """_send_heartbeat must tick more than once while running (i.e. it
+    loops, not just publishes once at startup) and must emit its
+    alive=False farewell on shutdown. A one-shot implementation that
+    set alive=True in __init__ and never looped would still pass the
+    sibling ``test_stop_joins_heartbeat_and_emits_goodbye`` (the TTL
+    hasn't expired yet), so we explicitly count ticks here by counting
+    invocations of the writer's ``set`` method over a ~1.2s window."""
+    calls = []
+    client = DummyPandaClient(redis, default_cfg=dummy_cfg)
+    try:
+        original_set = client.redis.heartbeat.set
+
+        def recording_set(*args, **kwargs):
+            calls.append(kwargs)
+            return original_set(*args, **kwargs)
+
+        with patch.object(
+            client.redis.heartbeat, "set", side_effect=recording_set
+        ):
+            # Wait for at least two 1s loop cycles so a non-looping
+            # implementation would record zero ticks during the patch.
+            time.sleep(1.2)
+            alive_ticks = len(calls)
+            client.stop()
+
+        assert alive_ticks >= 1, (
+            f"expected at least one heartbeat tick in the 1.2s window; "
+            f"got {alive_ticks} (calls={calls})"
+        )
+        # stop() drives the loop's final iteration AND the explicit
+        # alive=False farewell; both appear after the wait window.
+        assert any(c.get("alive") is False for c in calls), (
+            f"no alive=False shutdown tick recorded (calls={calls})"
+        )
+        # The alive=True ticks must carry the configured 60s TTL so a
+        # crashed client is distinguishable from a cleanly-stopped one.
+        alive_true_calls = [c for c in calls if c.get("alive", True)]
+        assert alive_true_calls, (
+            f"expected at least one alive=True tick (calls={calls})"
+        )
+        assert all(c.get("ex") == 60 for c in alive_true_calls), (
+            f"alive=True ticks must set ex=60 for watchdog semantics; "
+            f"got {alive_true_calls}"
+        )
+    finally:
+        if client.heartbeat_thd.is_alive():
+            client.stop()
+
+
+def test_measure_s11_rejects_invalid_mode(client):
+    """measure_s11 is restricted to ``ant``/``rec``. An unknown mode is
+    a producer-side bug (wrong caller), not a runtime input; raise
+    before touching the VNA so the failure is loud and local."""
+    with pytest.raises(ValueError, match="Unknown VNA mode"):
+        client.measure_s11("bogus")
+
+
+def test_measure_s11_requires_initialized_vna(client):
+    """measure_s11 must fail loudly when self.vna is None. The dummy
+    config ships with use_vna=False so this is the default client
+    fixture's state — use it as the canary."""
+    assert client.vna is None
+    with pytest.raises(RuntimeError, match="VNA not initialized"):
+        client.measure_s11("ant")
+
+
+def test_measure_s11_uses_mode_specific_power_dbm(redis, dummy_cfg):
+    """The per-mode ``power_dBm`` from ``vna_settings`` must be applied
+    to the VNA before each measurement. Regression guard for a unified
+    or hardcoded power that would silently bias either mode."""
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(redis, default_cfg=cfg)
+    try:
+        client.measure_s11("rec")
+        expected_rec = cfg["vna_settings"]["power_dBm"]["rec"]
+        assert client.vna.power_dBm == expected_rec
+        client.measure_s11("ant")
+        expected_ant = cfg["vna_settings"]["power_dBm"]["ant"]
+        assert client.vna.power_dBm == expected_ant
+    finally:
+        client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import time
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ import pytest
 import yaml
 
 from cmt_vna.testing import DummyVNA
+from eigsep_redis.keys import STATUS_STREAM
 from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
@@ -392,6 +394,74 @@ def test_measure_s11_requires_initialized_vna(client):
     assert client.vna is None
     with pytest.raises(RuntimeError, match="VNA not initialized"):
         client.measure_s11("ant")
+
+
+def test_measure_s11_contract_violation_emits_on_both_channels(
+    redis, dummy_cfg, caplog
+):
+    """A producer-side contract violation in ``measure_s11`` must log
+    loudly locally *and* push a status-stream message so the ground
+    observer sees it without SSHing. Panda-side ``self.logger`` writes
+    only to a local RotatingFileHandler — see
+    project_status_stream_log_bridge memory. Force a real violation by
+    patching the header validator to return a canned list; the check
+    under test is "both channels receive the message," not the
+    validator's own logic (already covered by the producer-contract
+    test)."""
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(redis, default_cfg=cfg)
+    try:
+        violations = ["missing key 'npoints'", "key 'mode': expected str"]
+        with patch(
+            "eigsep_observing.client._validate_vna_s11_header",
+            return_value=violations,
+        ):
+            caplog.set_level(logging.WARNING, logger="eigsep_observing.client")
+            client.measure_s11("ant")
+
+        # Panda-local log channel.
+        warning_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "VNA S11 producer contract violation" in r.getMessage()
+        ]
+        assert len(warning_msgs) == 1, caplog.records
+        assert "missing key 'npoints'" in warning_msgs[0]
+        assert "key 'mode': expected str" in warning_msgs[0]
+        assert "mode='ant'" in warning_msgs[0]
+
+        # Ground-visible status stream. Reset position so the single
+        # test process can read the entry the producer just pushed
+        # (same rationale as the vna-reader rewind in the producer
+        # contract test).
+        client.redis._set_last_read_id(STATUS_STREAM, "0-0")
+        level, status = client.redis.status_reader.read(timeout=1)
+        assert level == logging.WARNING
+        assert status == warning_msgs[0]
+    finally:
+        client.stop()
+
+
+def test_measure_s11_clean_payload_does_not_send_status(redis, dummy_cfg):
+    """Complement to the contract-violation test: on the happy path
+    (real DummyVNA output passing the real validators), neither channel
+    should emit a violation — we must not spam the bounded 5-entry
+    status stream during normal operation."""
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(redis, default_cfg=cfg)
+    try:
+        client.measure_s11("ant")
+        client.redis._set_last_read_id(STATUS_STREAM, "0-0")
+        level, status = client.redis.status_reader.read(timeout=0.2)
+    finally:
+        client.stop()
+    assert (level, status) == (None, None), (
+        f"clean measure_s11 must not emit a status message, got "
+        f"level={level!r} status={status!r}"
+    )
 
 
 def test_measure_s11_uses_mode_specific_power_dbm(redis, dummy_cfg):

--- a/tests/test_producer_contracts.py
+++ b/tests/test_producer_contracts.py
@@ -20,10 +20,12 @@ belongs with the rest of the producer-conformance suite.
 
 import glob
 import tempfile
+import time
 from pathlib import Path
 
 import numpy as np
 import pytest
+import yaml
 from picohost import PicoPotentiometer
 from picohost.testing import (
     ImuEmulator,
@@ -34,8 +36,13 @@ from picohost.testing import (
 )
 
 from conftest import HEADER, IMU_READING
+import eigsep_observing
 from eigsep_observing import io
-from eigsep_observing.testing import DummyEigsepFpga
+from eigsep_observing.testing import (
+    DummyEigsepFpga,
+    DummyEigsepObsRedis,
+    DummyPandaClient,
+)
 
 
 def _potmon_post_handler_reading():
@@ -127,6 +134,68 @@ def test_every_schema_has_conforming_emulator(sensor_name):
     reading = SENSOR_EMULATORS[sensor_name]()
     violations = io._validate_metadata(reading, io.SENSOR_SCHEMAS[sensor_name])
     assert violations == [], f"{sensor_name} producer drift: {violations}"
+
+
+@pytest.mark.parametrize("mode", sorted(io.VNA_S11_MODE_DATA_KEYS))
+def test_measure_s11_publishes_conforming_payload(mode, tmp_path):
+    """``PandaClient.measure_s11`` is the producer of the VNA stream.
+    Drive the real method end-to-end through DummyPandaClient +
+    DummyVNA, read the entry back off the stream, and validate the
+    payload against ``VNA_S11_HEADER_SCHEMA`` + the per-mode data
+    contract. This is the canonical guard rail against silent drift in
+    the s11 header-merge shape (``cal:*`` prefix, ``mode``,
+    ``metadata_snapshot_unix``) — a rename on either side fails CI
+    immediately. Parametrizes over ``VNA_S11_MODE_DATA_KEYS`` (not a
+    literal tuple) so adding a mode without a contract test is
+    impossible by construction."""
+    cfg_path = eigsep_observing.utils.get_config_path("dummy_config.yaml")
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f)
+    cfg["use_vna"] = True
+    cfg["vna_save_dir"] = str(tmp_path)
+    redis = DummyEigsepObsRedis()
+    client = DummyPandaClient(redis, default_cfg=cfg)
+    try:
+        client.measure_s11(mode)
+        # The reader skips producer-backlog by design (see
+        # test_vna_reader_skips_producer_backlog); rewind to stream
+        # origin so this single-threaded test picks up the entry the
+        # producer just pushed.
+        client.redis._set_last_read_id("stream:vna", "0-0")
+        data, header, metadata = client.redis.vna_reader.read(timeout=1)
+    finally:
+        client.stop()
+
+    data_violations = io._validate_vna_s11_data(data, mode)
+    assert data_violations == [], (
+        f"measure_s11({mode!r}) data drift: {data_violations}"
+    )
+
+    header_violations = io._validate_vna_s11_header(header)
+    assert header_violations == [], (
+        f"measure_s11({mode!r}) header drift: {header_violations}"
+    )
+
+    # The ``mode`` field must round-trip through VnaWriter's JSON
+    # encoding unchanged — the test-vs-producer mode arg is the same
+    # string the consumer reads back.
+    assert header["mode"] == mode
+
+    # ``metadata_snapshot_unix`` must be a plausible wallclock (in
+    # seconds, not ms or ns) recorded at publish time. Guarding the
+    # unit here catches a producer that accidentally switches to
+    # monotonic/ms/ns — which is silently-valid under the float type
+    # check but breaks downstream freshness interpretation.
+    now = time.time()
+    assert abs(header["metadata_snapshot_unix"] - now) < 60.0, (
+        f"metadata_snapshot_unix {header['metadata_snapshot_unix']!r} is "
+        f"not a recent Unix timestamp (now={now})"
+    )
+
+    # Metadata snapshot was captured (rfswitch publishes on startup via
+    # DummyPicoRFSwitch). Ensures ``measure_s11`` routes the snapshot
+    # reader through to the VNA stream as opposed to dropping it.
+    assert isinstance(metadata, dict)
 
 
 def test_dummy_fpga_header_round_trips_through_file():


### PR DESCRIPTION
## Summary
- Closes the last two deferred items from the PandaClient review backlog: `measure_s11` + `_send_heartbeat` coverage (zero tests before this PR) and the formal producer contract for the VNA stream.
- Adds `VNA_S11_HEADER_SCHEMA`, `VNA_S11_CAL_KEYS`, `VNA_S11_MODE_DATA_KEYS` to `io.py` alongside the existing `CORR_HEADER_SCHEMA` / `SENSOR_SCHEMAS`, with `_validate_vna_s11_header` / `_validate_vna_s11_data` helpers following the same validator pattern.
- **Wires the contract at runtime**: `measure_s11` now self-validates its payload on every publish and emits any violations on two channels — `self.logger.warning` (panda-local `eigsep.log` via the rotating handler) plus `self.redis.status.send(..., level=WARNING)` (Redis status stream, re-emitted ground-side by `EigObserver.status_logger`). Panda's python logger is local-file-only, so the status stream is the only path that reaches the operator without SSH. Non-blocking: validators never raise; VNA publish always proceeds; status stream is bounded at `maxlen=5` so producer spam can't starve the bridge.
- Producer-contract test in `tests/test_producer_contracts.py` parametrizes over `VNA_S11_MODE_DATA_KEYS` (not a literal tuple), so adding a mode without a contract assertion is impossible by construction — same mechanical enforcement used by `test_every_schema_has_conforming_emulator`.

Tests in `tests/test_client.py`:
- invalid-mode `ValueError`, uninitialized-VNA `RuntimeError`, per-mode `power_dBm` wiring (ant vs rec)
- `_send_heartbeat` tick-count + `ex=60` TTL + shutdown `alive=False` (without the tick-count assertion, a one-shot `set` in `__init__` would pass the existing `test_stop_joins_heartbeat_and_emits_goodbye`)
- Contract-violation dual-channel emission (caplog for local log; status-stream read-back for the ground-visible channel) and a clean-path test confirming the happy path does not spam the bounded status stream.

Lock concerns (vna_loop switch-back return value, interactive-session bypass) are separate and intentionally out of scope per backlog split.

## Test plan
- [x] `pytest tests/test_client.py tests/test_producer_contracts.py` — 33 passed
- [x] Full suite — 208 passed
- [x] `ruff check .` + `ruff format --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)