### PR TITLE
chore(redis): right-size metadata/corr/vna stream maxlens

### DIFF
--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -118,9 +118,16 @@ class CorrWriter:
     The wire format matches ``EigsepFpga.read_data``: per-pair bytes
     plus ``acc_cnt`` and ``dtype`` sidecars so the reader can
     ``np.frombuffer`` without a separate type registry.
+
+    ``maxlen`` is a dead-reader failsafe: in normal operation the
+    observer loop reads each integration as it arrives, so the stream
+    sits at depth ~1. Sized for ~10 min of tolerance at the 4 Hz
+    target integration rate (``corr_acc_len = 0x04000000``); at ~144
+    KB/entry for the current 12-pair × 1024-channel layout this caps
+    the worst-case Redis footprint around 360 MB.
     """
 
-    maxlen = 5000
+    maxlen = 2500
 
     def __init__(self, transport):
         self.transport = transport

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -18,9 +18,15 @@ class VnaWriter:
     (dtype/shape/order), and optional JSON-encoded ``header`` and
     ``metadata`` blobs. Numpy arrays inside ``header`` / ``metadata``
     are flattened to lists before encoding.
+
+    ``maxlen`` is a dead-reader failsafe: each ``measure_s11`` call
+    produces one bundled entry (ant+noise+load+OSL or rec+OSL), and
+    the ground reader drains it synchronously. 200 covers ~100 full
+    ant+rec sweeps of headroom even during VNA-only campaigns —
+    well beyond any realistic ground-reader outage window.
     """
 
-    maxlen = 1000
+    maxlen = 200
 
     def __init__(self, transport):
         self.transport = transport

--- a/src/eigsep_redis/metadata.py
+++ b/src/eigsep_redis/metadata.py
@@ -16,9 +16,16 @@ class MetadataWriter:
     stream in the metadata-only and generic stream-index sets. The two
     destinations back the two readers (snapshot vs streaming) — splitting
     them would let the readers drift out of sync.
+
+    ``maxlen`` is a dead-reader failsafe, not a working buffer:
+    ``MetadataStreamReader.drain`` pulls everything since its last call
+    on every corr integration, so the stream sits near-empty in normal
+    operation. Sized for ~5 min of tolerance at the 5 Hz producer
+    cadence (picohost ``STATUS_CADENCE_MS = 200``) — past that window
+    sensor data is stale and the observation is already compromised.
     """
 
-    maxlen = 5000
+    maxlen = 1500
 
     def __init__(self, transport):
         self.transport = transport


### PR DESCRIPTION
## Summary

- `maxlen` on the metadata/corr/vna streams was carried forward from the pre-refactor code at 5000/5000/1000 without annotated reasoning.
- All three readers drain to head in normal operation, so `maxlen` is a **dead-reader failsafe**, not a working buffer. Sized each for ~5–10 min of reader-outage tolerance at the worst-case production cadence.
- Each class attribute now carries a docstring explaining the cadence × retention reasoning so future bumps have a baseline to compare against.

| Stream          | Before | After | Rationale                                 |
|-----------------|-------:|------:|-------------------------------------------|
| metadata        |   5000 |  1500 | 5 Hz × 5 min (6 per-sensor streams)       |
| corr            |   5000 |  2500 | 4 Hz target × 10 min (~360 MB worst case) |
| vna             |   1000 |   200 | ~100 full ant+rec sweeps of headroom      |

Companion to #XX (status stream bump, already merged as 51aafcb on main).

## Test plan

- [x] `pytest` — 223 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `rg 'maxlen\s*=\s*(5000|1000)'` — no lingering hardcoded references in code or tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)