### PR TITLE
feat(redis): warn on stale metadata snapshot reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,18 @@ reflect different physical semantics (integration window vs point-in-time) and
 run in different processes (`EigObserver` on the ground PC vs `PandaClient` on
 the panda).
 
-**Known weakness:** the snapshot reader has no freshness check. A dead sensor
-silently returns its last reading. The `metadata_snapshot_unix` header field
-lets downstream detect this at file inspection time, but a runtime warning
-would require panda-side timestamping in `MetadataWriter.add` (no firmware
-change needed). Tracked informally; not yet implemented.
+**Runtime freshness check.** `MetadataWriter.add` stamps a panda-side
+`{key}_ts` (UTC isoformat) into the hash on every write, and
+`MetadataSnapshotReader.get` compares each requested key's `_ts` to the
+current time. Any key older than `MetadataSnapshotReader.max_age_s`
+(default 30 s, ~150× the 200 ms producer cadence) emits a `WARNING`
+from `eigsep_redis.metadata`. The stale value is **still returned** —
+callers that want "last known" behavior are unaffected, but a dead
+sensor no longer passes silently. Keys whose `_ts` is missing or
+unparseable are skipped (no warning), so direct `hset` bypasses and
+pre-timestamp entries don't trigger false positives. Set
+`max_age_s = float("inf")` to disable. The `metadata_snapshot_unix`
+header remains the offline detection path.
 
 ## corr `sync_time` lives on the corr header, not metadata
 

--- a/LIVE_STATUS_FEATURES.md
+++ b/LIVE_STATUS_FEATURES.md
@@ -26,6 +26,7 @@ Planned features for the live status app that monitors the system via Redis.
 
 - Flag if any Pico device (IMU, thermometers, lidar) stops reporting
 - Track time since last update per sensor — stale data indicates a disconnect
+- Surface `eigsep_redis.metadata` WARNING logs ("key … is stale") — `MetadataSnapshotReader.get` already compares each key's `{key}_ts` against `max_age_s` (default 30 s) and warns on stale reads; the app should either subscribe to that logger or replicate the `_ts` vs. now check directly against the metadata hash
 
 ## RF Switch State
 

--- a/src/eigsep_redis/metadata.py
+++ b/src/eigsep_redis/metadata.py
@@ -91,11 +91,21 @@ class MetadataSnapshotReader:
     the current sensor state. **Do not use for the corr loop** — see
     :class:`MetadataStreamReader` for cadence-matched averaging.
 
-    Caveat: no freshness check. If a sensor has stopped updating, a
-    stale value is silently returned. Callers that care should record
-    a snapshot timestamp alongside the read (see PandaClient's
-    ``metadata_snapshot_unix`` header field).
+    Freshness: every :meth:`get` compares each requested key against
+    its panda-side ``{key}_ts`` (written by :class:`MetadataWriter`)
+    and logs ``WARNING`` for any key older than :attr:`max_age_s`.
+    The stale value is still returned — staleness is informational,
+    so consumers that want the "last known" reading are unaffected,
+    but a dead sensor no longer passes silently. Set
+    :attr:`max_age_s` to ``float("inf")`` to disable warnings.
+    Keys whose ``_ts`` is missing or unparseable are skipped (no
+    warning), so pre-timestamp entries don't trigger false positives.
     """
+
+    # Producer cadence is ~200 ms (picohost STATUS_CADENCE_MS = 200),
+    # so 30 s is ~150× the expected interval — transient blips don't
+    # warn, but a truly dead sensor does on the next snapshot read.
+    max_age_s = 30.0
 
     def __init__(self, transport):
         self.transport = transport
@@ -124,11 +134,47 @@ class MetadataSnapshotReader:
             raise TypeError("All keys in the list must be strings.")
         raw = self.transport.r.hgetall(METADATA_HASH)
         m = {k.decode("utf-8"): json.loads(v) for k, v in raw.items()}
+        self._warn_if_stale(m, keys)
         if keys is None:
             return m
         if isinstance(keys, str):
             return m[keys]
         return {k: m[k] for k in keys}
+
+    def _warn_if_stale(self, m, keys):
+        """Log WARNING for any requested data key older than
+        :attr:`max_age_s`. ``_ts`` bookkeeping keys are never checked
+        themselves; a missing or unparseable ``_ts`` is treated as
+        "freshness unknown" and skipped."""
+        if self.max_age_s == float("inf"):
+            return
+        if keys is None:
+            candidate_keys = [k for k in m if not k.endswith("_ts")]
+        elif isinstance(keys, str):
+            candidate_keys = [keys]
+        else:
+            candidate_keys = [k for k in keys if not k.endswith("_ts")]
+        if not candidate_keys:
+            return
+        now = datetime.now(timezone.utc)
+        for key in candidate_keys:
+            ts_str = m.get(f"{key}_ts")
+            if not isinstance(ts_str, str):
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str)
+            except ValueError:
+                continue
+            age = (now - ts).total_seconds()
+            if age > self.max_age_s:
+                logger.warning(
+                    "metadata snapshot key %r is stale: last update "
+                    "%.1fs ago (threshold %.1fs). Sensor may have "
+                    "stopped publishing; returning cached value.",
+                    key,
+                    age,
+                    self.max_age_s,
+                )
 
 
 class MetadataStreamReader:

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+import json
 import logging
 import numpy as np
 import pytest
@@ -24,6 +25,7 @@ from eigsep_redis import (
     StatusReader,
     StatusWriter,
 )
+from eigsep_redis.keys import METADATA_HASH
 from eigsep_redis.testing import DummyEigsepRedis
 
 
@@ -100,6 +102,98 @@ def test_metadata(server, client):
     # test reset
     server.reset()
     assert server.data_streams == {}
+
+
+def _backdate_ts(server, key, seconds_ago):
+    """Rewrite METADATA_HASH's ``{key}_ts`` to simulate sensor
+    silence. Paired with MetadataWriter.add, which stamps current
+    UTC isoformat; this replaces it with a past value so the
+    snapshot reader's freshness check fires deterministically."""
+    past = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    server.r.hset(
+        METADATA_HASH,
+        f"{key}_ts",
+        json.dumps(past.isoformat()).encode("utf-8"),
+    )
+
+
+def test_metadata_snapshot_fresh_no_warning(server, client, caplog):
+    client.metadata.add("acc_cnt", 1)
+    with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+        server.metadata_snapshot.get()
+    assert not any("is stale" in r.message for r in caplog.records)
+
+
+def test_metadata_snapshot_stale_warns_but_returns_value(
+    server, client, caplog
+):
+    client.metadata.add("acc_cnt", 7)
+    _backdate_ts(server, "acc_cnt", seconds_ago=120)
+    with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+        val = server.metadata_snapshot.get("acc_cnt")
+    # value still returned — staleness is informational
+    assert val == 7
+    stale = [r for r in caplog.records if "is stale" in r.message]
+    assert len(stale) == 1
+    assert "acc_cnt" in stale[0].message
+
+
+def test_metadata_snapshot_stale_warns_on_full_get(server, client, caplog):
+    client.metadata.add("acc_cnt", 1)
+    client.metadata.add("temp", 25.5)
+    _backdate_ts(server, "acc_cnt", seconds_ago=120)
+    with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+        m = server.metadata_snapshot.get()
+    assert m["acc_cnt"] == 1 and m["temp"] == 25.5
+    messages = [r.message for r in caplog.records if "is stale" in r.message]
+    assert any("acc_cnt" in msg for msg in messages)
+    assert not any("temp" in msg for msg in messages)
+
+
+def test_metadata_snapshot_missing_ts_silent(server, caplog):
+    """Pre-timestamp entries (or direct hset bypasses) must not
+    trigger false positives — freshness is simply unknown."""
+    server.r.hset(METADATA_HASH, "legacy", json.dumps(42).encode("utf-8"))
+    with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+        val = server.metadata_snapshot.get("legacy")
+    assert val == 42
+    assert not any("is stale" in r.message for r in caplog.records)
+
+
+def test_metadata_snapshot_malformed_ts_silent(server, client, caplog):
+    client.metadata.add("acc_cnt", 1)
+    server.r.hset(
+        METADATA_HASH,
+        "acc_cnt_ts",
+        json.dumps("not-a-timestamp").encode("utf-8"),
+    )
+    with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+        server.metadata_snapshot.get()
+    assert not any("is stale" in r.message for r in caplog.records)
+
+
+def test_metadata_snapshot_staleness_can_be_disabled(server, client, caplog):
+    client.metadata.add("acc_cnt", 1)
+    _backdate_ts(server, "acc_cnt", seconds_ago=3600)
+    try:
+        server.metadata_snapshot.max_age_s = float("inf")
+        with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+            server.metadata_snapshot.get()
+    finally:
+        server.metadata_snapshot.max_age_s = MetadataSnapshotReader.max_age_s
+    assert not any("is stale" in r.message for r in caplog.records)
+
+
+def test_metadata_snapshot_staleness_restricted_to_requested_keys(
+    server, client, caplog
+):
+    client.metadata.add("acc_cnt", 1)
+    client.metadata.add("temp", 25.5)
+    _backdate_ts(server, "temp", seconds_ago=120)
+    with caplog.at_level(logging.WARNING, logger="eigsep_redis.metadata"):
+        server.metadata_snapshot.get("acc_cnt")
+    # temp is stale but wasn't requested — must stay silent
+    assert not any("is stale" in r.message for r in caplog.records)
 
 
 def test_raw(server):
@@ -198,7 +292,9 @@ def test_metadata_writer_has_no_cross_bus_methods():
 def test_metadata_readers_have_no_cross_bus_methods():
     """Structural guard: metadata readers only read metadata, nothing else."""
     for cls, expected in (
-        (MetadataSnapshotReader, {"get"}),
+        # ``max_age_s`` is a tunable, not a bus method — see
+        # MetadataSnapshotReader docstring.
+        (MetadataSnapshotReader, {"get", "max_age_s"}),
         (MetadataStreamReader, {"drain", "streams"}),
     ):
         public = {name for name in vars(cls) if not name.startswith("_")}

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -161,6 +161,11 @@ def test_metadata_snapshot_missing_ts_silent(server, caplog):
 
 
 def test_metadata_snapshot_malformed_ts_silent(server, client, caplog):
+    """MetadataWriter.add always writes a valid UTC isoformat _ts, so
+    the fromisoformat ValueError branch is unreachable via the writer.
+    Overwrite _ts directly via hset to simulate a non-compliant
+    producer or manual redis intervention — the only way to exercise
+    this boundary condition."""
     client.metadata.add("acc_cnt", 1)
     server.r.hset(
         METADATA_HASH,


### PR DESCRIPTION
## Summary

- `MetadataSnapshotReader.get` now compares each requested key's panda-side `{key}_ts` against the current time and logs `WARNING` on `eigsep_redis.metadata` if older than `max_age_s` (default 30 s, ~150× the 200 ms producer cadence).
- Stale values are still returned — staleness is informational, so consumers that rely on "last known" behavior are unaffected, but a dead sensor no longer passes silently.
- Missing or unparseable `_ts` is skipped silently, so pre-timestamp entries and direct `hset` bypasses don't trigger false positives. Set `max_age_s = float("inf")` to disable.

Closes the "Known weakness" noted in `CLAUDE.md`'s metadata-flow section; the infrastructure (`MetadataWriter` `_ts` stamping) was already in place — this wires it up on the reader side.

## Test plan

- [x] `ruff check .` / `ruff format --check .` clean
- [x] Full `pytest` suite: 230 passed
- [x] New tests cover: fresh → silent; stale → WARNING + value still returned; full-hash `get()` warns only for stale keys; restricted `get(key)` doesn't warn for non-requested stale keys; missing `_ts` → silent; malformed `_ts` → silent; `max_age_s = inf` disables
- [x] Structural guard (`test_metadata_readers_have_no_cross_bus_methods`) updated to include `max_age_s` as a tunable (not a bus method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)