### PR TITLE
feat(redis): warn on corr stream gaps via acc_cnt monotonicity

### DIFF
--- a/src/eigsep_observing/corr.py
+++ b/src/eigsep_observing/corr.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 _UNSYNCED_LOG_THROTTLE_S = 60.0
 _last_unsynced_log = [0.0]
 
+_GAP_WARN_THROTTLE_S = 60.0
+
 
 def _log_unsynced_drop(cnt):
     """Throttled ERROR log for a pre-sync corr integration drop.
@@ -179,10 +181,22 @@ class CorrReader:
     other per-sync invariants live on the corr header; callers that
     need them should read the header separately
     (:class:`CorrConfigStore.get_header`).
+
+    Tracks ``acc_cnt`` across consecutive ``read`` calls and emits a
+    throttled WARNING if it jumps by more than one — the only online
+    signal that integrations were lost, whether because the stream was
+    trimmed (reader fell behind ``CorrWriter.maxlen``) or the producer
+    dropped entries. A backwards jump (``acc_cnt`` decreasing) is a
+    SNAP re-sync and silently resets the tracker; the observer already
+    rolls to a new file on ``sync_time`` change. ``seek`` also resets
+    the tracker so offline tools replaying from a prior ID don't
+    trigger false alarms.
     """
 
     def __init__(self, transport):
         self.transport = transport
+        self._prev_acc_cnt = None
+        self._last_gap_warn_monotonic = 0.0
 
     def seek(self, position):
         """
@@ -191,6 +205,7 @@ class CorrReader:
         rather than from '$' / the last read.
         """
         self.transport._set_last_read_id(CORR_STREAM, position)
+        self._prev_acc_cnt = None
 
     def read(self, pairs=None, timeout=10, unpack=True):
         """
@@ -239,6 +254,24 @@ class CorrReader:
         eid, fields = out[0][1][0]
         self.transport._set_last_read_id(CORR_STREAM, eid)
         acc_cnt = int(fields.pop(b"acc_cnt").decode())
+        if self._prev_acc_cnt is not None:
+            gap = acc_cnt - self._prev_acc_cnt
+            if gap > 1:
+                now = time.monotonic()
+                if now - self._last_gap_warn_monotonic >= _GAP_WARN_THROTTLE_S:
+                    self._last_gap_warn_monotonic = now
+                    logger.warning(
+                        "Corr stream gap: acc_cnt jumped %d -> %d "
+                        "(%d missed integrations). Stream was likely "
+                        "trimmed because the reader fell behind "
+                        "maxlen=%d, or the producer dropped "
+                        "integrations.",
+                        self._prev_acc_cnt,
+                        acc_cnt,
+                        gap - 1,
+                        CorrWriter.maxlen,
+                    )
+        self._prev_acc_cnt = acc_cnt
         dtype = fields.pop(b"dtype").decode()
         data = {}
         for k, v in fields.items():

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -419,6 +419,96 @@ def test_corr_writer_unsynced_log_throttled(obs_client, caplog):
     assert len(records) == 1
 
 
+def _seed_corr(obs_client, cnt):
+    """Write one corr entry with the given acc_cnt."""
+    data = generate_data(ntimes=1, reshape=False)
+    raw = {p: d[0].tobytes() for p, d in data.items()}
+    obs_client.corr.add(raw, cnt=cnt, sync_time=1713200000.0, dtype=">i4")
+    return list(data.keys())
+
+
+def test_corr_reader_warns_on_acc_cnt_gap(obs_server, obs_client, caplog):
+    """A jump of >1 in ``acc_cnt`` between reads fires a WARNING so
+    that a silently trimmed / dropped corr integration isn't missed
+    online. Models the ``acc_cnt=1`` → ``acc_cnt=3`` gap the observer
+    would see if one entry were trimmed under reader backpressure.
+    """
+    pairs = _seed_corr(obs_client, cnt=1)
+    _seed_corr(obs_client, cnt=3)
+    obs_server.corr_reader.seek("0-0")
+    with caplog.at_level(logging.WARNING, logger="eigsep_observing.corr"):
+        obs_server.corr_reader.read(pairs=pairs)
+        obs_server.corr_reader.read(pairs=pairs)
+    gap_records = [r for r in caplog.records if "Corr stream gap" in r.message]
+    assert len(gap_records) == 1
+    assert "1 -> 3" in gap_records[0].message
+    assert "1 missed" in gap_records[0].message
+
+
+def test_corr_reader_no_warn_on_monotonic(obs_server, obs_client, caplog):
+    """Consecutive ``acc_cnt`` values (1, 2, 3) are the normal case and
+    must not produce any gap warning."""
+    pairs = _seed_corr(obs_client, cnt=1)
+    _seed_corr(obs_client, cnt=2)
+    _seed_corr(obs_client, cnt=3)
+    obs_server.corr_reader.seek("0-0")
+    with caplog.at_level(logging.WARNING, logger="eigsep_observing.corr"):
+        for _ in range(3):
+            obs_server.corr_reader.read(pairs=pairs)
+    assert not [r for r in caplog.records if "Corr stream gap" in r.message]
+
+
+def test_corr_reader_resets_on_resync(obs_server, obs_client, caplog):
+    """A SNAP re-sync drives ``acc_cnt`` back to a small value. That
+    backwards jump is a real event (handled at file level by the
+    observer) and must not fire the gap warning. The tracker rebaselines
+    on the post-resync value so a subsequent *forward* gap is still
+    caught.
+    """
+    obs_server.corr_reader._last_gap_warn_monotonic = 0.0
+    pairs = _seed_corr(obs_client, cnt=100)
+    _seed_corr(obs_client, cnt=1)  # resync; acc_cnt resets
+    _seed_corr(obs_client, cnt=3)  # gap from the new baseline
+    obs_server.corr_reader.seek("0-0")
+    with caplog.at_level(logging.WARNING, logger="eigsep_observing.corr"):
+        obs_server.corr_reader.read(pairs=pairs)  # 100, baseline
+        obs_server.corr_reader.read(pairs=pairs)  # 1, backwards: silent
+        obs_server.corr_reader.read(pairs=pairs)  # 3, forward gap
+    gap_records = [r for r in caplog.records if "Corr stream gap" in r.message]
+    assert len(gap_records) == 1
+    assert "1 -> 3" in gap_records[0].message
+
+
+def test_corr_reader_seek_resets_gap_tracker(obs_server, obs_client):
+    """``seek`` clears ``_prev_acc_cnt`` so offline replays (e.g. the
+    linearity sweep) don't mistake a rewind for a gap.
+    """
+    pairs = _seed_corr(obs_client, cnt=1)
+    obs_server.corr_reader.seek("0-0")
+    obs_server.corr_reader.read(pairs=pairs)
+    assert obs_server.corr_reader._prev_acc_cnt == 1
+    obs_server.corr_reader.seek("0-0")
+    assert obs_server.corr_reader._prev_acc_cnt is None
+
+
+def test_corr_reader_gap_warn_throttled(obs_server, obs_client, caplog):
+    """Persistent reader backpressure at the 4 Hz corr rate must not
+    drown the log file — the throttle collapses repeated gaps to one
+    WARNING per window.
+    """
+    obs_server.corr_reader._last_gap_warn_monotonic = 0.0
+    pairs = _seed_corr(obs_client, cnt=1)
+    _seed_corr(obs_client, cnt=3)
+    _seed_corr(obs_client, cnt=5)
+    _seed_corr(obs_client, cnt=7)
+    obs_server.corr_reader.seek("0-0")
+    with caplog.at_level(logging.WARNING, logger="eigsep_observing.corr"):
+        for _ in range(4):
+            obs_server.corr_reader.read(pairs=pairs)
+    gap_records = [r for r in caplog.records if "Corr stream gap" in r.message]
+    assert len(gap_records) == 1
+
+
 def test_vna_reader_skips_producer_backlog(obs_server, obs_client):
     """Tier-2 guard for stream:vna — same rationale as the corr test."""
     old = {"ant": np.array([1 + 2j], dtype=np.complex128)}


### PR DESCRIPTION
## Summary

Follow-up to #61 (right-sized stream maxlens). Adds the only online signal for lost corr integrations: a throttled WARNING from `CorrReader.read` whenever `acc_cnt` jumps by more than one between consecutive reads.

A MAXLEN trim or a dropped producer integration is otherwise silent — `XADD` trims without error, and the reader just resumes from the next surviving entry. Gaps only surface offline via the saved file, long after the fact.

- **Forward gap** (`acc_cnt` jumps > 1) → WARNING, throttled to once per 60 s (matches the existing `_UNSYNCED_LOG_THROTTLE_S` pattern).
- **Backwards jump** (SNAP re-sync) → silent reset of the tracker. The observer already rolls to a new file on `sync_time` change (`observer.py:241-253`).
- **`seek()`** → resets the tracker so offline replay tools (e.g. the linearity sweep) don't trigger false alarms.

WARNING rather than ERROR to match `MetadataSnapshotReader`'s stale-key log — informational and actionable, not a failure the observer halts on.

## Test plan

- [x] `pytest tests/test_redis.py -k corr_reader` — 6 passed (1 existing + 5 new)
- [x] `pytest` full suite — 228 passed (was 223)
- [x] `ruff check` / `ruff format --check` — clean
- [x] New tests cover: forward gap warns, monotonic does not, resync resets tracker then still catches later gap, `seek` clears `_prev_acc_cnt`, throttle collapses bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)