### PR TITLE
feat(panda): add motor_loop + use_motor gating to PandaClient

### DIFF
--- a/scripts/panda_observe.py
+++ b/scripts/panda_observe.py
@@ -1,3 +1,18 @@
+"""Panda observing client entry point.
+
+Starts the steady-state observing loops on the suspended LattePanda:
+``switch_loop`` (RF calibration schedule), ``vna_loop`` (periodic S11),
+and ``motor_loop`` (periodic az/el pointing scans). Each loop is gated
+by a ``use_*`` flag in the observing config so the panda can run with
+any subset.
+
+Dedicated observing modes that need cross-loop coordination — beam
+mapping (rfswitch pinned to RFANT), VNA-at-positions, or motion/switch
+sync — are deferred to separate top-level scripts; running them
+through this entry point would couple the steady-state loops to
+mode-specific orchestration.
+"""
+
 from argparse import ArgumentParser
 import logging
 from threading import Thread
@@ -43,6 +58,13 @@ if client.cfg["use_vna"]:
     thds["vna"] = vna_thd
     logger.info("Starting VNA thread")
     vna_thd.start()
+
+# motor (periodic az/el scans)
+if client.cfg.get("use_motor", False):
+    motor_thd = Thread(target=client.motor_loop)
+    thds["motor"] = motor_thd
+    logger.info("Starting motor thread")
+    motor_thd.start()
 
 try:
     client.stop_client.wait()  # wait until stop signal is set

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -16,6 +16,7 @@ from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
 from .io import _validate_vna_s11_data, _validate_vna_s11_header
+from .motor_scanner import MotorScanner
 from .utils import get_config_path
 from .vna import VnaWriter
 
@@ -107,6 +108,12 @@ class PandaClient:
         else:
             self.vna = None
             self.logger.info("VNA not initialized")
+
+        if self.cfg.get("use_motor", False):
+            self.init_motor_scanner()
+        else:
+            self.motor_scanner = None
+            self.logger.info("Motor scanner not initialized")
 
         self.heartbeat_thd = threading.Thread(
             target=self._send_heartbeat,
@@ -351,6 +358,24 @@ class PandaClient:
         self.vna.setup(**kwargs)
         self.logger.info("VNA initialized")
 
+    def init_motor_scanner(self):
+        """
+        Build a :class:`MotorScanner` from the config.
+
+        ``motor_scanner_kwargs`` (optional) forwards to the
+        :class:`MotorScanner` constructor (per-axis step delays, poll
+        interval, stall timeout). Absent/empty → use scanner defaults.
+
+        Notes
+        -----
+        Called by the constructor when ``use_motor`` is true. Safe to
+        call again if the config changes; no hardware contact, so
+        construction cannot fail.
+        """
+        kwargs = self.cfg.get("motor_scanner_kwargs") or {}
+        self.motor_scanner = MotorScanner(self.transport, **kwargs)
+        self.logger.info(f"Motor scanner initialized (kwargs={kwargs})")
+
     def switch_loop(self):
         """
         Use the RF switches to switch between sky, load, and noise
@@ -543,3 +568,69 @@ class PandaClient:
                         f"Failed to switch back to {target_mode}"
                     )
             self.stop_client.wait(self.cfg["vna_interval"])
+
+    def motor_loop(self):
+        """Periodic az/el beam scans, sibling of :meth:`vna_loop`.
+
+        Runs a full ``MotorScanner.scan`` every ``motor_interval``
+        seconds with ``motor_scan`` kwargs (``az_range_deg``,
+        ``el_range_deg``, ``el_first``, ``repeat_count``, ``pause_s``,
+        ``sleep_between``). Runs concurrently with ``switch_loop`` and
+        ``vna_loop``; does **not** acquire ``switch_lock``. This is the
+        steady-state "do a pointing survey every N hours" mode, and it
+        deliberately lets switching/VNA continue uninterrupted while
+        the motors move.
+
+        Scan errors (``TimeoutError``/``RuntimeError``) are logged at
+        ERROR on both channels, the motors are halted, and the loop
+        waits for the next interval — a stalled or misconfigured motor
+        must not wedge observing.
+
+        Follow-ups (deferred; separate top-level scripts when we know
+        what we want):
+
+        * Beam mapping: scan with rfswitch pinned to RFANT for clean
+          per-position corr (needs ``switch_lock`` + switch-loop pause).
+        * VNA-at-positions: lockstep motor move / VNA measure for S11
+          vs pointing comparisons.
+        * Motion/switch sync: suppress switching while motors are
+          moving if hardware interference proves to be a concern.
+        """
+        if self.motor_scanner is None:
+            self._warn_with_status(
+                "Motor scanner not initialized. Cannot execute motor scans."
+            )
+            return
+        interval = self.cfg.get("motor_interval")
+        if not isinstance(interval, (int, float)) or interval <= 0:
+            self._warn_with_status(
+                f"Invalid motor_interval ({interval!r}); motor_loop will "
+                "not run."
+            )
+            return
+        scan_kwargs = self.cfg.get("motor_scan") or {}
+
+        # Push delay config once at loop entry. A failure here (motor
+        # pico unreachable) is warned but not fatal — the scan call
+        # below re-surfaces the same fault and drives the retry loop.
+        try:
+            self.motor_scanner.set_delay()
+        except (RuntimeError, TimeoutError) as exc:
+            self._warn_with_status(
+                f"Motor set_delay failed at loop start "
+                f"({type(exc).__name__}: {exc}); scans will retry."
+            )
+
+        while not self.stop_client.is_set():
+            try:
+                self.motor_scanner.scan(
+                    stop_event=self.stop_client, **scan_kwargs
+                )
+            except (TimeoutError, RuntimeError) as exc:
+                self._error_with_status(
+                    f"Motor scan aborted "
+                    f"({type(exc).__name__}: {exc}); halting motors."
+                )
+                self.motor_scanner.halt()
+            if self.stop_client.wait(interval):
+                return

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -603,20 +603,26 @@ class PandaClient:
         rather than at home. The failure path:
 
         1. Log the abort at ERROR on both channels.
-        2. Attempt an explicit ``home()`` to park the motors at
+        2. Attempt an inline ``home()`` to park the motors at
            ``(0, 0)`` so a subsequent power loss (batteries dying
            before the next scan) doesn't leave the rig in a random
-           position that's annoying to lower. If ``home()`` also
-           fails (pico still unreachable, mechanical stall persists),
-           log that at ERROR too — we've done what we can from
-           Python, operator intervention is required.
-        3. Wait ``motor_failure_retry_s`` (default 60s) before the
-           next attempt rather than the full ``motor_interval``.
-           Transient pico-comms glitches recover quickly; persistent
-           faults keep complaining loudly but at a bounded cadence.
+           position that's annoying to lower.
+        3. If the inline park succeeded, return to normal cadence —
+           the next full scan fires at ``motor_interval``.
+        4. If the inline park also failed, enter **recovery mode**:
+           subsequent iterations retry ``home()`` only (no full scan)
+           at ``motor_failure_retry_s`` cadence. Running a full grid
+           every failure_retry_s would churn the motors and flood the
+           bounded status stream during a persistent fault; once
+           parked we're safe, so there's no benefit to re-running the
+           scan fast. Recovery-mode park failures log at INFO locally
+           only (no status push) so the status ring keeps the
+           original actionable ERROR.
+        5. When recovery-mode ``home()`` finally succeeds, the loop
+           exits recovery and waits ``motor_interval`` before the
+           next real scan.
 
-        After a successful scan, the cadence returns to
-        ``motor_interval``.
+        After a successful scan, the cadence is ``motor_interval``.
 
         Follow-ups (deferred; separate top-level scripts when we know
         what we want):
@@ -672,29 +678,55 @@ class PandaClient:
                 f"({type(exc).__name__}: {exc}); scans will retry."
             )
 
-        last_failed = False
+        needs_park = False
         while not self.stop_client.is_set():
-            try:
-                self.motor_scanner.scan(
-                    stop_event=self.stop_client, **scan_kwargs
-                )
-                last_failed = False
-            except (TimeoutError, RuntimeError) as exc:
-                last_failed = True
-                self._error_with_status(
-                    f"Motor scan aborted ({type(exc).__name__}: {exc})."
-                )
+            if needs_park:
+                # Recovery mode: retry ``home()`` only. Do NOT run a
+                # full scan — see docstring step 4.
                 try:
                     self.motor_scanner.home()
+                    needs_park = False
+                    self._log_with_status(
+                        "Motors parked at home after prior scan failure.",
+                        logging.INFO,
+                    )
+                    wait_s = interval
+                except (TimeoutError, RuntimeError) as exc:
+                    # Log locally only so repeated failures during a
+                    # persistent fault don't flood the bounded status
+                    # stream. Operator already saw the original ERROR
+                    # pair explaining that we'd retry.
                     self.logger.info(
-                        "Motors parked at home after scan failure."
+                        f"Park retry still failing "
+                        f"({type(exc).__name__}: {exc}); "
+                        f"retrying in {failure_retry_s}s."
                     )
-                except (TimeoutError, RuntimeError) as park_exc:
+                    wait_s = failure_retry_s
+            else:
+                try:
+                    self.motor_scanner.scan(
+                        stop_event=self.stop_client, **scan_kwargs
+                    )
+                    wait_s = interval
+                except (TimeoutError, RuntimeError) as exc:
                     self._error_with_status(
-                        f"Post-failure home() also failed "
-                        f"({type(park_exc).__name__}: {park_exc}); "
-                        "motors in unknown position until next retry."
+                        f"Motor scan aborted ({type(exc).__name__}: {exc})."
                     )
-            wait_s = failure_retry_s if last_failed else interval
+                    try:
+                        self.motor_scanner.home()
+                        self.logger.info(
+                            "Motors parked at home after scan failure."
+                        )
+                        wait_s = interval
+                    except (TimeoutError, RuntimeError) as park_exc:
+                        self._error_with_status(
+                            f"Post-failure home() also failed "
+                            f"({type(park_exc).__name__}: {park_exc}); "
+                            "motors in unknown position — retrying "
+                            f"park every {failure_retry_s}s (no full "
+                            "scans until parked)."
+                        )
+                        needs_park = True
+                        wait_s = failure_retry_s
             if self.stop_client.wait(wait_s):
                 return

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -372,8 +372,25 @@ class PandaClient:
         call again if the config changes; no hardware contact, so
         construction cannot fail.
         """
-        kwargs = self.cfg.get("motor_scanner_kwargs") or {}
-        self.motor_scanner = MotorScanner(self.transport, **kwargs)
+        self.motor_scanner = None
+        raw_kwargs = self.cfg.get("motor_scanner_kwargs")
+        kwargs = raw_kwargs or {}
+        if not isinstance(kwargs, dict):
+            self.logger.warning(
+                "Invalid motor_scanner_kwargs config; expected dict, "
+                f"got {type(raw_kwargs).__name__}. Motor scanner disabled."
+            )
+            return
+        try:
+            self.motor_scanner = MotorScanner(
+                self.transport, **kwargs
+            )
+        except TypeError as err:
+            self.logger.warning(
+                "Invalid motor_scanner_kwargs for MotorScanner: "
+                f"{err}. Motor scanner disabled."
+            )
+            return
         self.logger.info(f"Motor scanner initialized (kwargs={kwargs})")
 
     def switch_loop(self):
@@ -608,7 +625,15 @@ class PandaClient:
                 "not run."
             )
             return
-        scan_kwargs = self.cfg.get("motor_scan") or {}
+        scan_kwargs = self.cfg.get("motor_scan")
+        if scan_kwargs is None:
+            scan_kwargs = {}
+        elif not isinstance(scan_kwargs, dict):
+            self._warn_with_status(
+                f"Invalid motor_scan ({scan_kwargs!r}); motor_loop will "
+                "not run."
+            )
+            return
 
         # Push delay config once at loop entry. A failure here (motor
         # pico unreachable) is warned but not fatal — the scan call

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -382,9 +382,7 @@ class PandaClient:
             )
             return
         try:
-            self.motor_scanner = MotorScanner(
-                self.transport, **kwargs
-            )
+            self.motor_scanner = MotorScanner(self.transport, **kwargs)
         except TypeError as err:
             self.logger.warning(
                 "Invalid motor_scanner_kwargs for MotorScanner: "
@@ -598,10 +596,27 @@ class PandaClient:
         deliberately lets switching/VNA continue uninterrupted while
         the motors move.
 
-        Scan errors (``TimeoutError``/``RuntimeError``) are logged at
-        ERROR on both channels, the motors are halted, and the loop
-        waits for the next interval — a stalled or misconfigured motor
-        must not wedge observing.
+        Failure handling. ``MotorScanner.scan`` already halts the
+        motors in its own ``finally`` block, so by the time a
+        ``TimeoutError``/``RuntimeError`` reaches us the motors are
+        stationary — but they may be stuck at an arbitrary grid point
+        rather than at home. The failure path:
+
+        1. Log the abort at ERROR on both channels.
+        2. Attempt an explicit ``home()`` to park the motors at
+           ``(0, 0)`` so a subsequent power loss (batteries dying
+           before the next scan) doesn't leave the rig in a random
+           position that's annoying to lower. If ``home()`` also
+           fails (pico still unreachable, mechanical stall persists),
+           log that at ERROR too — we've done what we can from
+           Python, operator intervention is required.
+        3. Wait ``motor_failure_retry_s`` (default 60s) before the
+           next attempt rather than the full ``motor_interval``.
+           Transient pico-comms glitches recover quickly; persistent
+           faults keep complaining loudly but at a bounded cadence.
+
+        After a successful scan, the cadence returns to
+        ``motor_interval``.
 
         Follow-ups (deferred; separate top-level scripts when we know
         what we want):
@@ -625,6 +640,17 @@ class PandaClient:
                 "not run."
             )
             return
+        failure_retry_s = self.cfg.get("motor_failure_retry_s", 60)
+        if (
+            not isinstance(failure_retry_s, (int, float))
+            or failure_retry_s <= 0
+        ):
+            self._warn_with_status(
+                f"Invalid motor_failure_retry_s ({failure_retry_s!r}); "
+                f"falling back to motor_interval ({interval}s) for "
+                "post-failure retries."
+            )
+            failure_retry_s = interval
         scan_kwargs = self.cfg.get("motor_scan")
         if scan_kwargs is None:
             scan_kwargs = {}
@@ -646,16 +672,29 @@ class PandaClient:
                 f"({type(exc).__name__}: {exc}); scans will retry."
             )
 
+        last_failed = False
         while not self.stop_client.is_set():
             try:
                 self.motor_scanner.scan(
                     stop_event=self.stop_client, **scan_kwargs
                 )
+                last_failed = False
             except (TimeoutError, RuntimeError) as exc:
+                last_failed = True
                 self._error_with_status(
-                    f"Motor scan aborted "
-                    f"({type(exc).__name__}: {exc}); halting motors."
+                    f"Motor scan aborted ({type(exc).__name__}: {exc})."
                 )
-                self.motor_scanner.halt()
-            if self.stop_client.wait(interval):
+                try:
+                    self.motor_scanner.home()
+                    self.logger.info(
+                        "Motors parked at home after scan failure."
+                    )
+                except (TimeoutError, RuntimeError) as park_exc:
+                    self._error_with_status(
+                        f"Post-failure home() also failed "
+                        f"({type(park_exc).__name__}: {park_exc}); "
+                        "motors in unknown position until next retry."
+                    )
+            wait_s = failure_retry_s if last_failed else interval
+            if self.stop_client.wait(wait_s):
                 return

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -27,3 +27,7 @@ vna_settings:
     ant: 0.0
     rec: -40.0
 vna_save_dir: "/home/christian/Documents/research/eigsep/eigsep_observing/test_s11_data"
+# motor
+use_motor: false
+motor_interval: 1  # seconds between scans
+motor_scan: {}

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -30,4 +30,5 @@ vna_save_dir: "/home/christian/Documents/research/eigsep/eigsep_observing/test_s
 # motor
 use_motor: false
 motor_interval: 1  # seconds between scans
+motor_failure_retry_s: 0.5  # fast retry for tests
 motor_scan: {}

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -33,6 +33,9 @@ vna_save_dir: "/media/eigsep/T7/data/s11_data"
 # panda_observe boot. Opt in explicitly when the rig is ready to move.
 use_motor: false
 motor_interval: 3600  # seconds between scans
+motor_failure_retry_s: 60  # shorter wait after a failed scan so
+                           # transient faults recover faster than the
+                           # full motor_interval cadence
 motor_scan: {}  # kwargs forwarded to MotorScanner.scan; {} → scan defaults
 # motor_scanner_kwargs:  # optional MotorScanner ctor overrides
 #   poll_interval_s: 0.1

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -28,3 +28,12 @@ vna_settings:
     ant: 0.0
     rec: -40.0
 vna_save_dir: "/media/eigsep/T7/data/s11_data"
+# motor (az/el scans)
+# Default off: turning this on starts physical motor motion on
+# panda_observe boot. Opt in explicitly when the rig is ready to move.
+use_motor: false
+motor_interval: 3600  # seconds between scans
+motor_scan: {}  # kwargs forwarded to MotorScanner.scan; {} → scan defaults
+# motor_scanner_kwargs:  # optional MotorScanner ctor overrides
+#   poll_interval_s: 0.1
+#   stall_timeout_s: 30.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1446,13 +1446,14 @@ def test_motor_loop_logs_error_when_post_failure_home_also_fails(
         client.stop()
 
 
-def test_motor_loop_uses_failure_retry_interval_after_failure(
+def test_motor_loop_waits_motor_interval_when_inline_park_succeeds(
     transport, dummy_cfg
 ):
-    """After a failed scan, motor_loop waits ``motor_failure_retry_s``
-    (fast retry) instead of the full ``motor_interval``. Transient
-    faults recover quickly; without the short retry the rig could be
-    stuck at an arbitrary grid point for a full hour."""
+    """When a scan fails but the inline ``home()`` succeeds, motor_loop
+    is back to a safe state — motors parked, no recovery needed — and
+    the next wait uses the normal ``motor_interval`` cadence, not the
+    fast retry. The fast retry is reserved for recovery mode (scan
+    failure + inline park also failed)."""
     cfg = dict(dummy_cfg)
     cfg["use_motor"] = True
     cfg["motor_interval"] = 3600
@@ -1463,9 +1464,6 @@ def test_motor_loop_uses_failure_retry_interval_after_failure(
         motor_waits = []
 
         def recording_wait(timeout):
-            # Heartbeat thread calls stop_client.wait(1.0); only
-            # motor_loop's post-iteration wait has a non-1.0 timeout in
-            # this test. Pass heartbeat ticks through unmodified.
             if timeout == 1.0:
                 return client.stop_client.is_set()
             motor_waits.append(timeout)
@@ -1478,7 +1476,56 @@ def test_motor_loop_uses_failure_retry_interval_after_failure(
                 "scan",
                 side_effect=TimeoutError("stall"),
             ),
-            patch.object(client.motor_scanner, "home"),
+            patch.object(client.motor_scanner, "home"),  # park succeeds
+            patch.object(
+                client.stop_client, "wait", side_effect=recording_wait
+            ),
+        ):
+            client.motor_loop()
+
+        assert motor_waits == [3600], (
+            f"inline park succeeded → expected motor_interval=3600s wait, "
+            f"got {motor_waits}"
+        )
+    finally:
+        client.stop()
+
+
+def test_motor_loop_uses_failure_retry_interval_after_failed_park(
+    transport, dummy_cfg
+):
+    """When BOTH the scan and the inline ``home()`` fail, motor_loop
+    enters recovery mode and waits ``motor_failure_retry_s`` (fast
+    retry) instead of the full ``motor_interval``. Transient faults
+    recover quickly; without the short retry the rig could sit stuck
+    at an arbitrary position for a full hour."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_failure_retry_s"] = 5
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        motor_waits = []
+
+        def recording_wait(timeout):
+            if timeout == 1.0:
+                return client.stop_client.is_set()
+            motor_waits.append(timeout)
+            client.stop_client.set()
+            return True
+
+        with (
+            patch.object(
+                client.motor_scanner,
+                "scan",
+                side_effect=TimeoutError("stall"),
+            ),
+            patch.object(
+                client.motor_scanner,
+                "home",
+                side_effect=TimeoutError("park also failed"),
+            ),
             patch.object(
                 client.stop_client, "wait", side_effect=recording_wait
             ),
@@ -1486,8 +1533,141 @@ def test_motor_loop_uses_failure_retry_interval_after_failure(
             client.motor_loop()
 
         assert motor_waits == [5], (
-            f"expected one post-failure wait of motor_failure_retry_s=5s, "
-            f"got {motor_waits}"
+            f"scan+park both failed → expected motor_failure_retry_s=5s "
+            f"wait, got {motor_waits}"
+        )
+    finally:
+        client.stop()
+
+
+def test_motor_loop_recovery_retries_home_only_not_full_scan(
+    transport, dummy_cfg
+):
+    """During recovery mode (scan + inline park both failed), motor_loop
+    must retry ``home()`` only at the fast cadence and NOT re-run the
+    full scan. Re-running the grid every failure_retry_s during a
+    persistent fault would churn the motors and flood the bounded
+    status stream; once parked, we're safe, so there's no benefit."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_failure_retry_s"] = 5
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        scan_calls = []
+        home_calls = []
+
+        def raising_scan(**kwargs):
+            scan_calls.append(kwargs)
+            raise TimeoutError("stall")
+
+        def raising_home():
+            home_calls.append(True)
+            raise TimeoutError("home stalled")
+
+        # Let the loop iterate twice so we observe one recovery pass
+        # before we shut it down. The second motor_loop wait returns
+        # True, setting stop.
+        motor_waits = []
+
+        def recording_wait(timeout):
+            if timeout == 1.0:
+                return client.stop_client.is_set()
+            motor_waits.append(timeout)
+            if len(motor_waits) >= 2:
+                client.stop_client.set()
+                return True
+            return False  # proceed to next iteration
+
+        with (
+            patch.object(
+                client.motor_scanner, "scan", side_effect=raising_scan
+            ),
+            patch.object(
+                client.motor_scanner, "home", side_effect=raising_home
+            ),
+            patch.object(
+                client.stop_client, "wait", side_effect=recording_wait
+            ),
+        ):
+            client.motor_loop()
+
+        # First iteration: scan + inline home (both fail).
+        # Second iteration: recovery — home only, scan NOT called again.
+        assert len(scan_calls) == 1, (
+            f"recovery mode must not re-run scan; got {len(scan_calls)} "
+            f"scan calls"
+        )
+        assert len(home_calls) == 2, (
+            f"recovery mode must retry home() after the inline park "
+            f"failure; got {len(home_calls)} home calls"
+        )
+        # Both waits used the fast-retry cadence.
+        assert motor_waits == [5, 5], motor_waits
+    finally:
+        client.stop()
+
+
+def test_motor_loop_exits_recovery_when_home_finally_succeeds(
+    transport, dummy_cfg
+):
+    """Once recovery-mode ``home()`` finally succeeds (transient fault
+    cleared), motor_loop exits recovery and the next iteration runs a
+    full scan again at ``motor_interval`` cadence. Guards against a
+    bug where ``needs_park`` never clears."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_failure_retry_s"] = 5
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        scan_calls = []
+        home_calls = []
+
+        def failing_then_success_scan(**kwargs):
+            scan_calls.append(kwargs)
+            if len(scan_calls) == 1:
+                raise TimeoutError("first scan stalls")
+            # second scan (post-recovery) succeeds; trigger shutdown
+            client.stop_client.set()
+
+        def home_side_effect():
+            home_calls.append(True)
+            if len(home_calls) == 1:
+                # inline park after first scan failure — raise
+                raise TimeoutError("park fails first")
+            # second home (recovery retry) — succeed
+
+        def fast_wait(timeout):
+            # Pass everything through instantly — we don't care about
+            # wait durations in this test, only the call sequence.
+            return client.stop_client.is_set()
+
+        with (
+            patch.object(
+                client.motor_scanner,
+                "scan",
+                side_effect=failing_then_success_scan,
+            ),
+            patch.object(
+                client.motor_scanner, "home", side_effect=home_side_effect
+            ),
+            patch.object(client.stop_client, "wait", side_effect=fast_wait),
+        ):
+            client.motor_loop()
+
+        # Expected sequence across iterations:
+        #   1. scan fails → inline home fails → needs_park = True
+        #   2. recovery: home succeeds → needs_park = False
+        #   3. scan succeeds → sets stop
+        assert len(scan_calls) == 2, (
+            f"recovery must exit and run scan again; got {len(scan_calls)} "
+            f"scan calls"
+        )
+        assert len(home_calls) == 2, (
+            f"expected inline home + one recovery home; got {len(home_calls)}"
         )
     finally:
         client.stop()
@@ -1541,7 +1721,10 @@ def test_motor_loop_invalid_failure_retry_s_falls_back_to_interval(
     must warn loudly and fall back to ``motor_interval`` for retries,
     rather than falling into a tight no-sleep retry loop. Chosen over
     "refuse to run" because the steady-state scan cadence is still
-    useful even without the fast-recovery tweak."""
+    useful even without the fast-recovery tweak. Drives the fallback
+    through the recovery-mode wait path by failing both scan and
+    inline home, so the wait observed is specifically the
+    failure_retry_s fallback and not the normal-cadence wait."""
     cfg = dict(dummy_cfg)
     cfg["use_motor"] = True
     cfg["motor_interval"] = 42
@@ -1565,7 +1748,11 @@ def test_motor_loop_invalid_failure_retry_s_falls_back_to_interval(
                 "scan",
                 side_effect=TimeoutError("stall"),
             ),
-            patch.object(client.motor_scanner, "home"),
+            patch.object(
+                client.motor_scanner,
+                "home",
+                side_effect=TimeoutError("park also stalled"),
+            ),
             patch.object(
                 client.stop_client, "wait", side_effect=recording_wait
             ),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1279,26 +1279,29 @@ def test_motor_loop_calls_scan_with_stop_event_and_cfg_kwargs(
         client.stop()
 
 
-def test_motor_loop_survives_scan_timeout_error(transport, dummy_cfg, caplog):
+def test_motor_loop_survives_scan_timeout_error_and_parks_motors(
+    transport, dummy_cfg, caplog
+):
     """A scan ``TimeoutError`` (stall, pico unreachable) must not unwind
-    motor_loop — the error rides both channels, the scanner is halted,
-    and the loop proceeds to the next interval. Matches the "keep the
-    loop up across transient faults" contract used by switch_loop and
-    vna_loop."""
+    motor_loop. The error rides both channels, the loop attempts a
+    post-failure ``home()`` to park the motors at (0,0) so a subsequent
+    power loss doesn't leave the rig in a random position, and the loop
+    stays up for the next retry. ``scan`` itself halts the motors in
+    its own ``finally`` block, so motor_loop does not double-halt."""
     cfg = dict(dummy_cfg)
     cfg["use_motor"] = True
     cfg["motor_interval"] = 60
     cfg["motor_scan"] = {"repeat_count": 1}
     client = DummyPandaClient(transport, default_cfg=cfg)
     try:
-        halt_calls = []
+        home_calls = []
 
         def raising_scan(**kwargs):
             client.stop_client.set()
             raise TimeoutError("motor stalled for 30.0s without progress")
 
-        def recording_halt():
-            halt_calls.append(True)
+        def recording_home():
+            home_calls.append(True)
 
         _arm_status_reader(client)
         with (
@@ -1306,20 +1309,26 @@ def test_motor_loop_survives_scan_timeout_error(transport, dummy_cfg, caplog):
                 client.motor_scanner, "scan", side_effect=raising_scan
             ),
             patch.object(
-                client.motor_scanner, "halt", side_effect=recording_halt
+                client.motor_scanner, "home", side_effect=recording_home
             ),
         ):
-            caplog.set_level("ERROR")
+            caplog.set_level("INFO")
             client.motor_loop()  # must return, not raise
 
-        assert halt_calls == [True], (
-            "motor_loop must halt the scanner after a scan exception"
+        assert home_calls == [True], (
+            "motor_loop must attempt to park motors at home after scan "
+            "failure so a later power loss doesn't strand the rig at an "
+            "arbitrary grid point"
         )
         assert any(
             "Motor scan aborted" in r.getMessage()
             and "TimeoutError" in r.getMessage()
-            and "halting motors" in r.getMessage()
             and r.levelname == "ERROR"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+        assert any(
+            "Motors parked at home after scan failure" in r.getMessage()
+            and r.levelname == "INFO"
             for r in caplog.records
         ), [r.getMessage() for r in caplog.records]
 
@@ -1332,25 +1341,36 @@ def test_motor_loop_survives_scan_timeout_error(transport, dummy_cfg, caplog):
 
 def test_motor_loop_survives_scan_runtime_error(transport, dummy_cfg, caplog):
     """Sibling of the TimeoutError test. A firmware RuntimeError from
-    the scan must log at ERROR and the loop must stay up."""
+    the scan must log at ERROR, park via ``home()``, and keep the loop
+    up."""
     cfg = dict(dummy_cfg)
     cfg["use_motor"] = True
     cfg["motor_interval"] = 60
     cfg["motor_scan"] = {"repeat_count": 1}
     client = DummyPandaClient(transport, default_cfg=cfg)
     try:
+        home_calls = []
 
         def raising_scan(**kwargs):
             client.stop_client.set()
             raise RuntimeError("fw boom")
 
+        def recording_home():
+            home_calls.append(True)
+
         _arm_status_reader(client)
-        with patch.object(
-            client.motor_scanner, "scan", side_effect=raising_scan
+        with (
+            patch.object(
+                client.motor_scanner, "scan", side_effect=raising_scan
+            ),
+            patch.object(
+                client.motor_scanner, "home", side_effect=recording_home
+            ),
         ):
             caplog.set_level("ERROR")
             client.motor_loop()
 
+        assert home_calls == [True]
         assert any(
             "Motor scan aborted" in r.getMessage()
             and "RuntimeError" in r.getMessage()
@@ -1362,6 +1382,206 @@ def test_motor_loop_survives_scan_runtime_error(transport, dummy_cfg, caplog):
         level, status = _status_reader(client).read(timeout=1)
         assert level == logging.ERROR
         assert "Motor scan aborted" in status
+    finally:
+        client.stop()
+
+
+def test_motor_loop_logs_error_when_post_failure_home_also_fails(
+    transport, dummy_cfg, caplog
+):
+    """If the post-failure ``home()`` also raises (pico still
+    unreachable, mechanical stall persists), motor_loop logs a second
+    ERROR on both channels so the operator knows motors are in an
+    unknown position — we've done what we can from Python, operator
+    intervention is required. The loop still stays up for the next
+    retry."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 60
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+
+        def raising_scan(**kwargs):
+            client.stop_client.set()
+            raise TimeoutError("stall")
+
+        def raising_home():
+            raise TimeoutError("home stalled too")
+
+        _arm_status_reader(client)
+        with (
+            patch.object(
+                client.motor_scanner, "scan", side_effect=raising_scan
+            ),
+            patch.object(
+                client.motor_scanner, "home", side_effect=raising_home
+            ),
+        ):
+            caplog.set_level("ERROR")
+            client.motor_loop()
+
+        # Both errors are logged — the original scan abort *and* the
+        # park-failure diagnosis.
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any(
+            "Motor scan aborted" in m and "TimeoutError" in m for m in msgs
+        ), msgs
+        assert any(
+            "Post-failure home() also failed" in m
+            and "home stalled too" in m
+            and "motors in unknown position" in m
+            for m in msgs
+        ), msgs
+
+        # Both rode the status stream so the ground observer sees them.
+        level1, status1 = _status_reader(client).read(timeout=1)
+        level2, status2 = _status_reader(client).read(timeout=1)
+        assert level1 == logging.ERROR
+        assert level2 == logging.ERROR
+        statuses = [status1, status2]
+        assert any("Motor scan aborted" in s for s in statuses)
+        assert any("Post-failure home() also failed" in s for s in statuses)
+    finally:
+        client.stop()
+
+
+def test_motor_loop_uses_failure_retry_interval_after_failure(
+    transport, dummy_cfg
+):
+    """After a failed scan, motor_loop waits ``motor_failure_retry_s``
+    (fast retry) instead of the full ``motor_interval``. Transient
+    faults recover quickly; without the short retry the rig could be
+    stuck at an arbitrary grid point for a full hour."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_failure_retry_s"] = 5
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        motor_waits = []
+
+        def recording_wait(timeout):
+            # Heartbeat thread calls stop_client.wait(1.0); only
+            # motor_loop's post-iteration wait has a non-1.0 timeout in
+            # this test. Pass heartbeat ticks through unmodified.
+            if timeout == 1.0:
+                return client.stop_client.is_set()
+            motor_waits.append(timeout)
+            client.stop_client.set()
+            return True
+
+        with (
+            patch.object(
+                client.motor_scanner,
+                "scan",
+                side_effect=TimeoutError("stall"),
+            ),
+            patch.object(client.motor_scanner, "home"),
+            patch.object(
+                client.stop_client, "wait", side_effect=recording_wait
+            ),
+        ):
+            client.motor_loop()
+
+        assert motor_waits == [5], (
+            f"expected one post-failure wait of motor_failure_retry_s=5s, "
+            f"got {motor_waits}"
+        )
+    finally:
+        client.stop()
+
+
+def test_motor_loop_uses_motor_interval_after_successful_scan(
+    transport, dummy_cfg
+):
+    """After a *successful* scan, the cadence must return to
+    ``motor_interval`` — the short retry only applies while we're
+    recovering from a failure. Guards against a bug where
+    ``last_failed`` never resets."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_failure_retry_s"] = 5
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        motor_waits = []
+
+        def recording_wait(timeout):
+            if timeout == 1.0:
+                return client.stop_client.is_set()
+            motor_waits.append(timeout)
+            client.stop_client.set()
+            return True
+
+        def successful_scan(**kwargs):
+            pass  # no-op: scan completed normally
+
+        with (
+            patch.object(
+                client.motor_scanner, "scan", side_effect=successful_scan
+            ),
+            patch.object(
+                client.stop_client, "wait", side_effect=recording_wait
+            ),
+        ):
+            client.motor_loop()
+
+        assert motor_waits == [3600]
+    finally:
+        client.stop()
+
+
+def test_motor_loop_invalid_failure_retry_s_falls_back_to_interval(
+    transport, dummy_cfg, caplog
+):
+    """An invalid ``motor_failure_retry_s`` is a config bug; motor_loop
+    must warn loudly and fall back to ``motor_interval`` for retries,
+    rather than falling into a tight no-sleep retry loop. Chosen over
+    "refuse to run" because the steady-state scan cadence is still
+    useful even without the fast-recovery tweak."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 42
+    cfg["motor_failure_retry_s"] = 0  # invalid
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        motor_waits = []
+
+        def recording_wait(timeout):
+            if timeout == 1.0:
+                return client.stop_client.is_set()
+            motor_waits.append(timeout)
+            client.stop_client.set()
+            return True
+
+        _arm_status_reader(client)
+        with (
+            patch.object(
+                client.motor_scanner,
+                "scan",
+                side_effect=TimeoutError("stall"),
+            ),
+            patch.object(client.motor_scanner, "home"),
+            patch.object(
+                client.stop_client, "wait", side_effect=recording_wait
+            ),
+        ):
+            caplog.set_level("WARNING")
+            client.motor_loop()
+
+        assert motor_waits == [42], (
+            f"expected fallback wait of motor_interval=42s, got {motor_waits}"
+        )
+        assert any(
+            "Invalid motor_failure_retry_s" in r.getMessage()
+            and "falling back to motor_interval" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
     finally:
         client.stop()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ from eigsep_redis.testing import DummyTransport
 from picohost.proxy import PicoProxy
 
 import eigsep_observing
+from eigsep_observing import MotorScanner
 from eigsep_observing.testing import DummyPandaClient
 from eigsep_observing.testing.utils import compare_dicts
 
@@ -1158,5 +1159,250 @@ def test_vna_loop_recovers_to_rfant_on_measurement_exception(
         level, status = _status_reader(client).read(timeout=1)
         assert level == logging.ERROR
         assert "VNA cycle aborted" in status
+    finally:
+        client.stop()
+
+
+# ``motor_loop`` is the sibling of ``vna_loop``: periodic action, loud
+# error recovery, honors ``stop_client``. These tests patch
+# ``motor_scanner.scan`` to drive the loop deterministically — the real
+# scan path (grid traversal, emulator tick cadence) is covered by
+# tests/test_motor_scanner.py.
+
+
+def test_use_motor_false_leaves_scanner_none(client):
+    """Default dummy_config has ``use_motor: false``, so
+    ``PandaClient.__init__`` must leave ``motor_scanner`` as ``None``.
+    Mirrors the ``self.vna is None`` convention."""
+    assert client.cfg.get("use_motor", False) is False
+    assert client.motor_scanner is None
+
+
+def test_use_motor_true_builds_scanner(transport, dummy_cfg):
+    """With ``use_motor: true``, ``motor_scanner`` is a real
+    ``MotorScanner`` bound to the same transport — so ``motor_loop`` has
+    something to drive and the dummy PicoManager's motor pico is
+    addressable through the scanner's proxy."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        assert isinstance(client.motor_scanner, MotorScanner)
+        # Scanner shares the client's transport, i.e. the PicoManager is
+        # reachable through the same fake redis.
+        assert client.motor_scanner.transport is client.transport
+    finally:
+        client.stop()
+
+
+def test_motor_loop_returns_when_scanner_is_none(caplog, client):
+    """motor_loop must return promptly when ``motor_scanner`` is None —
+    no polling, no silent spin. The warning must ride both channels
+    (local log + status stream) so the ground observer sees the
+    misconfiguration."""
+    assert client.motor_scanner is None  # dummy_config has use_motor: false
+    _arm_status_reader(client)
+    caplog.set_level("WARNING")
+    t0 = time.monotonic()
+    client.motor_loop()
+    elapsed = time.monotonic() - t0
+    assert elapsed < 1.0, f"motor_loop did not return promptly ({elapsed}s)"
+    assert any(
+        "Motor scanner not initialized" in r.getMessage()
+        for r in caplog.records
+    )
+
+    level, status = _status_reader(client).read(timeout=1)
+    assert level == logging.WARNING
+    assert "Motor scanner not initialized" in status
+
+
+def test_motor_loop_invalid_interval_returns(transport, dummy_cfg, caplog):
+    """An invalid (non-positive / non-numeric) ``motor_interval`` is a
+    config-side bug; motor_loop must refuse to run and warn loudly
+    rather than fall into a tight no-sleep scan loop."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 0  # invalid
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        _arm_status_reader(client)
+        caplog.set_level("WARNING")
+        t0 = time.monotonic()
+        client.motor_loop()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 1.0
+        assert any(
+            "Invalid motor_interval" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.WARNING
+        assert "Invalid motor_interval" in status
+    finally:
+        client.stop()
+
+
+def test_motor_loop_calls_scan_with_stop_event_and_cfg_kwargs(
+    transport, dummy_cfg
+):
+    """motor_loop forwards ``motor_scan`` kwargs to ``scan`` and injects
+    ``stop_event=self.stop_client`` so a mid-scan ``stop()`` unwinds the
+    traversal instead of having to wait for the current move to finish."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 60  # long; only one scan before stop fires
+    cfg["motor_scan"] = {
+        "az_range_deg": [-1.0, 0.0, 1.0],
+        "el_range_deg": [-1.0, 0.0, 1.0],
+        "repeat_count": 1,
+    }
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        scan_calls = []
+
+        def fake_scan(**kwargs):
+            scan_calls.append(kwargs)
+            client.stop_client.set()
+
+        with patch.object(client.motor_scanner, "scan", side_effect=fake_scan):
+            client.motor_loop()
+
+        assert len(scan_calls) == 1, scan_calls
+        call = scan_calls[0]
+        assert call["stop_event"] is client.stop_client
+        assert call["az_range_deg"] == [-1.0, 0.0, 1.0]
+        assert call["el_range_deg"] == [-1.0, 0.0, 1.0]
+        assert call["repeat_count"] == 1
+    finally:
+        client.stop()
+
+
+def test_motor_loop_survives_scan_timeout_error(transport, dummy_cfg, caplog):
+    """A scan ``TimeoutError`` (stall, pico unreachable) must not unwind
+    motor_loop — the error rides both channels, the scanner is halted,
+    and the loop proceeds to the next interval. Matches the "keep the
+    loop up across transient faults" contract used by switch_loop and
+    vna_loop."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 60
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        halt_calls = []
+
+        def raising_scan(**kwargs):
+            client.stop_client.set()
+            raise TimeoutError("motor stalled for 30.0s without progress")
+
+        def recording_halt():
+            halt_calls.append(True)
+
+        _arm_status_reader(client)
+        with (
+            patch.object(
+                client.motor_scanner, "scan", side_effect=raising_scan
+            ),
+            patch.object(
+                client.motor_scanner, "halt", side_effect=recording_halt
+            ),
+        ):
+            caplog.set_level("ERROR")
+            client.motor_loop()  # must return, not raise
+
+        assert halt_calls == [True], (
+            "motor_loop must halt the scanner after a scan exception"
+        )
+        assert any(
+            "Motor scan aborted" in r.getMessage()
+            and "TimeoutError" in r.getMessage()
+            and "halting motors" in r.getMessage()
+            and r.levelname == "ERROR"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.ERROR
+        assert "Motor scan aborted" in status
+    finally:
+        client.stop()
+
+
+def test_motor_loop_survives_scan_runtime_error(transport, dummy_cfg, caplog):
+    """Sibling of the TimeoutError test. A firmware RuntimeError from
+    the scan must log at ERROR and the loop must stay up."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 60
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+
+        def raising_scan(**kwargs):
+            client.stop_client.set()
+            raise RuntimeError("fw boom")
+
+        _arm_status_reader(client)
+        with patch.object(
+            client.motor_scanner, "scan", side_effect=raising_scan
+        ):
+            caplog.set_level("ERROR")
+            client.motor_loop()
+
+        assert any(
+            "Motor scan aborted" in r.getMessage()
+            and "RuntimeError" in r.getMessage()
+            and "fw boom" in r.getMessage()
+            and r.levelname == "ERROR"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.ERROR
+        assert "Motor scan aborted" in status
+    finally:
+        client.stop()
+
+
+def test_motor_loop_set_delay_failure_is_warning_not_fatal(
+    transport, dummy_cfg, caplog
+):
+    """A ``set_delay`` failure at loop entry is warned but non-fatal —
+    the scan call is the real retry surface and will surface the same
+    fault cleanly through the ERROR path on the next iteration."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 60
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+
+        def fake_scan(**kwargs):
+            client.stop_client.set()
+
+        _arm_status_reader(client)
+        with (
+            patch.object(
+                client.motor_scanner,
+                "set_delay",
+                side_effect=RuntimeError("pico unreachable"),
+            ),
+            patch.object(client.motor_scanner, "scan", side_effect=fake_scan),
+        ):
+            caplog.set_level("WARNING")
+            client.motor_loop()  # must proceed past set_delay failure
+
+        assert any(
+            "Motor set_delay failed" in r.getMessage()
+            and "RuntimeError" in r.getMessage()
+            and "pico unreachable" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.WARNING
+        assert "Motor set_delay failed" in status
     finally:
         client.stop()


### PR DESCRIPTION
## Summary
- Adds `motor_loop` on `PandaClient` as a sibling of `switch_loop` / `vna_loop`, gated by `use_motor` in the observing config. Periodic `MotorScanner.scan` every `motor_interval` with `motor_scan` kwargs forwarded; `stop_event=stop_client` for clean mid-scan shutdown; scan errors log ERROR on both channels, halt the motors, and let the loop retry.
- Wires a `use_motor`-gated motor thread into `scripts/panda_observe.py` and adds a module docstring flagging deferred dedicated-mode scripts (beam mapping, VNA-at-positions, motion/switch sync).
- Defaults `use_motor: false` in both `obs_config.yaml` (opt-in, so panda boot doesn't start physical motor motion) and `dummy_config.yaml` (tests flip it on explicitly, mirroring the `use_vna` convention).

## Design notes
- `motor_loop` deliberately does **not** acquire `switch_lock`. This is the steady-state "pointing survey every N hours" mode; switching and VNA continue uninterrupted while the motors move.
- Dedicated observing modes that need cross-loop coordination (pin switch on RFANT for clean beam-mapping corr; lockstep motor+VNA; suppress switching during motion) are flagged as follow-up top-level scripts rather than additional modes inside `panda_observe`. Stuffing mode switching into one observing entrypoint would couple the steady-state loops to mode-specific orchestration.
- `MotorScanner` already lives client-side of `PicoManager` (PR #71), so running it from `motor_loop` does not restall the shared `cmd_loop`.

## Test plan
- [x] New `test_client.py` tests: scanner-None default, `use_motor=true` builds scanner, prompt return when scanner None, invalid-interval rejection, cfg-kwargs forwarded + `stop_event` injected, loop survives `TimeoutError` + halts motors, loop survives `RuntimeError`, `set_delay` failure at entry is warn-not-fatal.
- [x] Local: `pytest tests/test_client.py tests/test_motor_scanner.py` → 59 passed.
- [x] Local: `ruff check` + `ruff format --check` clean.
- [ ] CI full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)