### PR TITLE
refactor(tests): ship producer-contract suite inside the wheel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ against the **post-`_pot_redis_handler`** shape, not the raw
 `PotMonEmulator.get_status()` output. The emulator only emits voltages;
 the slope/intercept and derived angle fields are added by
 `PicoPotentiometer._pot_redis_handler` at Redis-publish time. The
-producer-contract test (`tests/test_producer_contracts.py`) composes the
+producer-contract test (`src/eigsep_observing/contract_tests/test_producer_contracts.py`) composes the
 two by bypassing `PicoPotentiometer.__init__` and calling
 `_pot_redis_handler` directly with a calibrated cal dict — see
 `_potmon_post_handler_reading` there. The picohost scalar-only contract
@@ -328,7 +328,9 @@ silently normalizes bugs. Two rules:
    are bugs in the test suite.
 
 These rules apply doubly to "golden" fixtures shared across many tests
-(e.g. `HEADER`, `CORR_METADATA`, `VNA_METADATA` in `tests/test_io.py`).
+(e.g. `HEADER`, `CORR_METADATA`, `VNA_METADATA` in
+`src/eigsep_observing/_test_fixtures.py`, re-exported via
+`tests/conftest.py` for `test_io.py`).
 Shared fixtures amplify drift: one wrong value rots every test that
 touches it. Related values should be derived from a single source of
 truth — e.g. `FILE_TIME = NTIMES * INTEGRATION_TIME` rather than two

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ where = ["src"]
 "eigsep_observing" = ["config/*.yaml", "data/*.fpg"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src/eigsep_observing/contract_tests"]
 pythonpath = ["src"]
 addopts = [
   "--cov=eigsep_observing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ addopts = [
   "--timeout=60",
 ]
 
+[tool.coverage.run]
+omit = [
+  "src/eigsep_observing/contract_tests/*",
+  "src/eigsep_observing/_test_fixtures.py",
+]
+
 [tool.ruff]
 line-length = 79
 

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -1,0 +1,266 @@
+"""Golden fixtures for the eigsep_observing test suite and for the
+producer-contract tests shipped under ``eigsep_observing.contract_tests``.
+
+These constants and helpers are deliberately constructed to mirror the
+shape and types of real production data. See the "Testing philosophy"
+section in CLAUDE.md: fixtures should look like what producers actually
+emit so tests catch contract drift, and any deviations should be called
+out explicitly.
+
+They live under ``src/`` (rather than in ``tests/conftest.py``) so the
+producer-contract suite can ship inside the installed wheel — the
+eigsep-field CLI runs it via ``pytest --pyargs
+eigsep_observing.contract_tests`` on nodes that only have the wheel
+(the Pi), not the test tree. The leading underscore marks this module
+as private: it is not part of the supported public API of
+eigsep_observing and its shape can change without a deprecation cycle.
+The in-repo ``tests/conftest.py`` re-exports from here so existing
+``from conftest import HEADER`` imports in ``test_io.py`` keep working
+unchanged.
+
+These are kept as plain module-level constants rather than
+``@pytest.fixture`` functions because they are referenced from inside
+nested data structures (e.g. ``CORR_METADATA``) and from helper module
+imports — both of which the parameter-injection style does not support
+without significant test rewrites.
+"""
+
+import numpy as np
+
+# One corr file accumulates NTIMES integrations, each of duration
+# INTEGRATION_TIME seconds. FILE_TIME = NTIMES * INTEGRATION_TIME is the
+# wall-clock duration of the file and is included in HEADER so the
+# relationship is explicit at the fixture level (rather than being two
+# independently-set numbers that can drift apart).
+NTIMES = 60
+INTEGRATION_TIME = 1.0  # seconds
+FILE_TIME = NTIMES * INTEGRATION_TIME  # seconds
+
+# HEADER mimics EigsepFpga().header: the static-configuration portion of a
+# corr file. Units match corr_config.yaml: sample_rate is in MHz (NOT Hz).
+HEADER = {
+    "dtype": ">i4",
+    "acc_bins": 2,
+    "avg_even_odd": True,
+    "nchan": 1024,
+    "fgp_file": "fpg_files/eigsep_fengine.fpg",
+    "fpg_version": [0, 0],
+    "corr_acc_len": 2**28,
+    "corr_scalar": 2**9,
+    "pol01_delay": 0,
+    "pol23_delay": 0,
+    "pol45_delay": 0,
+    "fft_shift": 0x00FF,
+    "sample_rate": 500.0,  # MHz, matching corr_config.yaml convention
+    "gain": 4,
+    "pam_atten": {"0": 8, "1": 8, "2": 8},
+    "sync_time": 1748732903.4203713,
+    "integration_time": INTEGRATION_TIME,
+    "file_time": FILE_TIME,
+}
+
+# Schema-conformant raw IMU reading (as emitted by a pico and pushed into
+# stream:imu_el by picohost). Mirrors the BNO085 UART RVC payload
+# introduced in picohost 1.0.0: yaw/pitch/roll orientation in degrees and
+# accel_x/y/z in m/s². Used to build CORR_METADATA entries and by tests
+# that feed raw stream data into File.add_data.
+IMU_READING = {
+    "sensor_name": "imu_el",
+    "status": "update",
+    "app_id": 3,
+    "yaw": 0.0,
+    "pitch": 0.0,
+    "roll": 0.0,
+    "accel_x": 0.0,
+    "accel_y": 0.0,
+    "accel_z": 9.81,
+}
+
+
+def _imu_avg_entry(yaw):
+    """One per-sample IMU entry as avg_metadata would emit it.
+
+    All numeric fields are float and take the float→mean reduction in
+    ``_avg_sensor_values``. ``yaw`` is the per-sample varying axis used
+    by tests that need to assert on a non-constant float field.
+    """
+    return {
+        "sensor_name": "imu_el",
+        "status": "update",
+        "app_id": 3,
+        "yaw": yaw,
+        "pitch": 0.0,
+        "roll": 0.0,
+        "accel_x": 0.0,
+        "accel_y": 0.0,
+        "accel_z": 9.81,
+    }
+
+
+def _lidar_avg_entry(distance_m):
+    """One per-sample lidar entry as avg_metadata would emit it."""
+    return {
+        "sensor_name": "lidar",
+        "status": "update",
+        "app_id": 4,
+        "distance_m": distance_m,
+    }
+
+
+def _tempctrl_channel_entry(t_now, timestamp):
+    """One per-sample tempctrl channel (LNA or LOAD) after add_data's split.
+
+    The top-level fields returned by ``_avg_temp_metadata`` are dropped
+    by the LNA/LOAD split in ``File.add_data``; only the per-channel
+    sub-dict survives. The bool/float fault flags are constant in this
+    fixture (steady-state operation); tests that need to exercise
+    fault-flag transitions construct their own samples. ``T_target`` is
+    a user-configured setpoint that is constant over the lifetime of a
+    real run, so it is hard-coded to ``25.0`` here rather than tracking
+    the per-sample ``t_now`` — matching the pattern used by every
+    inline tempctrl fixture in ``test_io.py``.
+    """
+    return {
+        "status": "update",
+        "T_now": t_now,
+        "timestamp": timestamp,
+        "T_target": 25.0,
+        "drive_level": 0.0,
+        "enabled": True,
+        "active": True,
+        "int_disabled": False,
+        "hysteresis": 0.5,
+        "clamp": 100.0,
+    }
+
+
+def _potmon_avg_entry(pot_el_voltage):
+    """One per-sample potmon entry as avg_metadata would emit it.
+
+    Mirrors the post-``_pot_redis_handler`` shape that lands in Redis:
+    raw voltages plus the flattened cal slope/intercept and the derived
+    angle. All-scalar per the picohost scalar-only contract; the cal
+    fields are de-facto invariants for the lifetime of a stream.
+
+    A *calibrated* reading is used here so every cal/angle field is a
+    real float, exercising the float→mean reduction in
+    ``_avg_sensor_values``. The uncalibrated-stream case (cal/angle
+    fields all ``None``) is a first-class producer state — see the
+    ``potmon`` schema comment in ``io.py`` — but it is intentionally
+    not exercised by this golden fixture because it would force the
+    round-trip assertion to special-case ``None`` survivors and obscure
+    the steady-state contract this fixture is meant to pin. Tests that
+    need to cover the uncalibrated path should build their own samples.
+    Same rationale as ``_potmon_post_handler_reading`` in
+    ``test_producer_contracts.py``.
+    """
+    return {
+        "sensor_name": "potmon",
+        "status": "update",
+        "app_id": 2,
+        "pot_el_voltage": pot_el_voltage,
+        "pot_az_voltage": 1.5,
+        "pot_el_cal_slope": 100.0,
+        "pot_el_cal_intercept": -50.0,
+        "pot_az_cal_slope": 200.0,
+        "pot_az_cal_intercept": -100.0,
+        "pot_el_angle": 100.0 * pot_el_voltage - 50.0,
+        "pot_az_angle": 200.0 * 1.5 - 100.0,
+    }
+
+
+ERROR_INTEGRATION_INDEX = 30
+
+
+def _imu_errored_integration_entry(yaw):
+    return {**_imu_avg_entry(yaw), "status": "error"}
+
+
+CORR_METADATA = {
+    "imu_el": [
+        _imu_avg_entry(0.001 * i)
+        if i != ERROR_INTEGRATION_INDEX
+        else _imu_errored_integration_entry(0.001 * i)
+        for i in range(NTIMES)
+    ],
+    "imu_az": [
+        {**_imu_avg_entry(0.002 * i), "sensor_name": "imu_az", "app_id": 6}
+        for i in range(NTIMES)
+    ],
+    "lidar": [_lidar_avg_entry(1.5 + 0.001 * i) for i in range(NTIMES)],
+    "potmon": [_potmon_avg_entry(1.5 + 0.001 * i) for i in range(NTIMES)],
+    "tempctrl_lna": [
+        _tempctrl_channel_entry(30.0 + 0.01 * i, 1.0 + i)
+        for i in range(NTIMES)
+    ],
+    "tempctrl_load": [
+        _tempctrl_channel_entry(25.0 + 0.01 * i, 1.0 + i)
+        for i in range(NTIMES)
+    ],
+    "rfswitch": (
+        ["RFANT"] * 20  # steady state
+        + ["UNKNOWN"] * 5  # transition window
+        + ["RFNOFF"] * 20  # new steady state
+        + [None] * 5  # sensor dropout (gap-fill pad in _insert_sample)
+        + ["RFNOFF"] * 10  # recovery
+    ),
+}
+
+# VNA_METADATA mirrors the flat ``{key: value}`` dict returned by
+# ``MetadataSnapshotReader.get()`` — the snapshot path used by the VNA
+# code in ``PandaClient.measure_s11``. Values are whatever the producer
+# last pushed via ``MetadataWriter.add``:
+#   - picohost pushes the raw sensor dict for each sensor key
+#   - ``MetadataWriter.add`` auto-appends a ``{key}_ts`` Unix-seconds float
+#   - misc. scalars (e.g. ``corr_sync_time``) go in as floats
+# There is NO averaging on this path; unlike CORR_METADATA, values are
+# scalars or nested dicts, never per-sample lists.
+_SNAPSHOT_TS = 1775997296.789012
+VNA_METADATA = {
+    "imu_el": IMU_READING,
+    "imu_el_ts": _SNAPSHOT_TS,
+    "imu_az": {**IMU_READING, "sensor_name": "imu_az", "app_id": 6},
+    "imu_az_ts": _SNAPSHOT_TS,
+    "lidar": {
+        "sensor_name": "lidar",
+        "status": "update",
+        "app_id": 4,
+        "distance_m": 1.52,
+    },
+    "lidar_ts": _SNAPSHOT_TS,
+    "potmon": {
+        "sensor_name": "potmon",
+        "status": "update",
+        "app_id": 2,
+        "pot_el_voltage": 1.5,
+        "pot_az_voltage": 1.5,
+        "pot_el_cal_slope": 100.0,
+        "pot_el_cal_intercept": -50.0,
+        "pot_az_cal_slope": 200.0,
+        "pot_az_cal_intercept": -100.0,
+        "pot_el_angle": 100.0,
+        "pot_az_angle": 200.0,
+    },
+    "potmon_ts": _SNAPSHOT_TS,
+    "rfswitch": {
+        "sensor_name": "rfswitch",
+        "status": "update",
+        "app_id": 5,
+        "sw_state": 3,
+        "sw_state_name": "VNAS",
+    },
+    "rfswitch_ts": _SNAPSHOT_TS,
+    "corr_sync_time": 1748732903.4203713,
+    "corr_sync_time_ts": _SNAPSHOT_TS,
+}
+
+S11_HEADER = {
+    "fstart": 1e6,
+    "fstop": 250e6,
+    "npoints": 1000,
+    "ifbw": 100,
+    "power_dBm": 0,
+    "freqs": np.linspace(1e6, 250e6, 1000),
+    "mode": "ant",
+    "metadata_snapshot_unix": 1748734379.905014,
+}

--- a/src/eigsep_observing/contract_tests/__init__.py
+++ b/src/eigsep_observing/contract_tests/__init__.py
@@ -1,0 +1,12 @@
+"""Producer / fixture contract conformance tests.
+
+This subpackage ships inside the installed wheel so that
+``eigsep-field verify`` can run it on nodes that do not have the
+eigsep_observing test tree checked out (e.g. the Pi). Invoke via::
+
+    pytest --pyargs eigsep_observing.contract_tests
+
+In the eigsep_observing development checkout the same tests are
+discovered by plain ``pytest`` thanks to the entry in
+``tool.pytest.ini_options.testpaths``.
+"""

--- a/src/eigsep_observing/contract_tests/test_key_uniqueness.py
+++ b/src/eigsep_observing/contract_tests/test_key_uniqueness.py
@@ -1,5 +1,4 @@
-"""
-Cross-package Redis-key uniqueness guard.
+"""Cross-package Redis-key uniqueness guard.
 
 Every Redis key/stream/set this repo writes to lives in
 ``eigsep_redis.keys`` or ``eigsep_observing.keys``. Two constants
@@ -10,6 +9,13 @@ never happens.
 If this test fails, pick a new name — do not "fix" it by deleting one
 of the duplicates. The right fix depends on which key is actually in
 use at runtime.
+
+This module ships under ``src/`` (alongside the producer-contract
+suite) rather than ``tests/`` so that ``eigsep-field verify`` can run
+it on wheel-only installs via
+``pytest --pyargs eigsep_observing.contract_tests``. The uniqueness
+check also catches mixed-version pins that CI's pre-release gate
+cannot see (e.g. an on-Pi hand upgrade of ``eigsep_redis``).
 """
 
 from eigsep_observing import keys as obs_keys

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -16,6 +16,10 @@ The end-to-end ``DummyEigsepFpga → File → corr_write → read_hdf5``
 round-trip lives here as well: it's the canonical contract test that
 ties the producer side to the file format on disk, and conceptually
 belongs with the rest of the producer-conformance suite.
+
+This module ships under ``src/`` rather than ``tests/`` so that the
+eigsep-field CLI (``eigsep-field verify``) can run it on installs that
+only have the wheel and no test tree — see ``contract_tests/__init__.py``.
 """
 
 import glob
@@ -39,9 +43,9 @@ from picohost.testing import (
 from eigsep_redis.keys import STATUS_STREAM  # noqa: F401
 from eigsep_redis.testing import DummyTransport
 
-from conftest import HEADER, IMU_READING
 import eigsep_observing
 from eigsep_observing import io
+from eigsep_observing._test_fixtures import HEADER, IMU_READING
 from eigsep_observing.testing import (
     DummyEigsepFpga,
     DummyPandaClient,

--- a/src/eigsep_observing/keys.py
+++ b/src/eigsep_observing/keys.py
@@ -4,7 +4,7 @@ Central registry of Redis keys owned by ``eigsep_observing``.
 Complements ``eigsep_redis.keys`` — this module holds observer-side
 keys (corr, vna) that don't belong in the shared lower-level package.
 Cross-package uniqueness is enforced by
-``tests/test_key_uniqueness.py``.
+``src/eigsep_observing/contract_tests/test_key_uniqueness.py``.
 """
 
 CORR_STREAM = "stream:corr"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,270 +1,39 @@
 """Shared test fixtures for the eigsep_observing test suite.
 
-These constants and helpers are deliberately constructed to mirror the
-shape and types of real production data. See the "Testing philosophy"
-section in CLAUDE.md: fixtures should look like what producers actually
-emit so tests catch contract drift, and any deviations should be called
-out explicitly.
+The golden data constants (``HEADER``, ``IMU_READING``, ``CORR_METADATA``,
+``VNA_METADATA``, ``S11_HEADER``, ``NTIMES``, ``ERROR_INTEGRATION_INDEX``)
+now live in ``eigsep_observing._test_fixtures`` — under ``src/`` rather
+than here — so the producer-contract tests under
+``eigsep_observing.contract_tests`` can import them from the installed
+wheel. They are re-exported from this module so existing
+``from conftest import HEADER`` imports in ``test_io.py`` keep working
+unchanged; pytest's default ``importmode=prepend`` puts the tests
+directory on ``sys.path`` during collection, which is what makes that
+import pattern work.
 
-They live in conftest.py so both ``test_io.py`` and
-``test_producer_contracts.py`` can import them by name (pytest's default
-``importmode=prepend`` puts the tests directory on sys.path during
-collection, so ``from conftest import HEADER`` works in any test file
-under ``tests/``).
-
-These are kept as plain module-level constants rather than
-``@pytest.fixture`` functions because they are referenced from inside
-nested data structures (e.g. ``CORR_METADATA``) and from helper module
-imports — both of which the parameter-injection style does not support
-without significant test rewrites.
+This file retains only the ``@pytest.fixture`` definitions — these stay
+here because they depend on pytest's fixture-injection machinery and
+are not useful outside a test run.
 """
 
-import numpy as np
 import pytest
 import yaml
 
 from eigsep_redis.testing import DummyTransport
 
 import eigsep_observing
+from eigsep_observing._test_fixtures import (  # noqa: F401 (re-exported)
+    CORR_METADATA,
+    ERROR_INTEGRATION_INDEX,
+    FILE_TIME,
+    HEADER,
+    IMU_READING,
+    INTEGRATION_TIME,
+    NTIMES,
+    S11_HEADER,
+    VNA_METADATA,
+)
 from eigsep_observing.testing import DummyPandaClient
-
-# One corr file accumulates NTIMES integrations, each of duration
-# INTEGRATION_TIME seconds. FILE_TIME = NTIMES * INTEGRATION_TIME is the
-# wall-clock duration of the file and is included in HEADER so the
-# relationship is explicit at the fixture level (rather than being two
-# independently-set numbers that can drift apart).
-NTIMES = 60
-INTEGRATION_TIME = 1.0  # seconds
-FILE_TIME = NTIMES * INTEGRATION_TIME  # seconds
-
-# HEADER mimics EigsepFpga().header: the static-configuration portion of a
-# corr file. Units match corr_config.yaml: sample_rate is in MHz (NOT Hz).
-HEADER = {
-    "dtype": ">i4",
-    "acc_bins": 2,
-    "avg_even_odd": True,
-    "nchan": 1024,
-    "fgp_file": "fpg_files/eigsep_fengine.fpg",
-    "fpg_version": [0, 0],
-    "corr_acc_len": 2**28,
-    "corr_scalar": 2**9,
-    "pol01_delay": 0,
-    "pol23_delay": 0,
-    "pol45_delay": 0,
-    "fft_shift": 0x00FF,
-    "sample_rate": 500.0,  # MHz, matching corr_config.yaml convention
-    "gain": 4,
-    "pam_atten": {"0": 8, "1": 8, "2": 8},
-    "sync_time": 1748732903.4203713,
-    "integration_time": INTEGRATION_TIME,
-    "file_time": FILE_TIME,
-}
-
-# Schema-conformant raw IMU reading (as emitted by a pico and pushed into
-# stream:imu_el by picohost). Mirrors the BNO085 UART RVC payload
-# introduced in picohost 1.0.0: yaw/pitch/roll orientation in degrees and
-# accel_x/y/z in m/s². Used to build CORR_METADATA entries and by tests
-# that feed raw stream data into File.add_data.
-IMU_READING = {
-    "sensor_name": "imu_el",
-    "status": "update",
-    "app_id": 3,
-    "yaw": 0.0,
-    "pitch": 0.0,
-    "roll": 0.0,
-    "accel_x": 0.0,
-    "accel_y": 0.0,
-    "accel_z": 9.81,
-}
-
-
-def _imu_avg_entry(yaw):
-    """One per-sample IMU entry as avg_metadata would emit it.
-
-    All numeric fields are float and take the float→mean reduction in
-    ``_avg_sensor_values``. ``yaw`` is the per-sample varying axis used
-    by tests that need to assert on a non-constant float field.
-    """
-    return {
-        "sensor_name": "imu_el",
-        "status": "update",
-        "app_id": 3,
-        "yaw": yaw,
-        "pitch": 0.0,
-        "roll": 0.0,
-        "accel_x": 0.0,
-        "accel_y": 0.0,
-        "accel_z": 9.81,
-    }
-
-
-def _lidar_avg_entry(distance_m):
-    """One per-sample lidar entry as avg_metadata would emit it."""
-    return {
-        "sensor_name": "lidar",
-        "status": "update",
-        "app_id": 4,
-        "distance_m": distance_m,
-    }
-
-
-def _tempctrl_channel_entry(t_now, timestamp):
-    """One per-sample tempctrl channel (LNA or LOAD) after add_data's split.
-
-    The top-level fields returned by ``_avg_temp_metadata`` are dropped
-    by the LNA/LOAD split in ``File.add_data``; only the per-channel
-    sub-dict survives. The bool/float fault flags are constant in this
-    fixture (steady-state operation); tests that need to exercise
-    fault-flag transitions construct their own samples. ``T_target`` is
-    a user-configured setpoint that is constant over the lifetime of a
-    real run, so it is hard-coded to ``25.0`` here rather than tracking
-    the per-sample ``t_now`` — matching the pattern used by every
-    inline tempctrl fixture in ``test_io.py``.
-    """
-    return {
-        "status": "update",
-        "T_now": t_now,
-        "timestamp": timestamp,
-        "T_target": 25.0,
-        "drive_level": 0.0,
-        "enabled": True,
-        "active": True,
-        "int_disabled": False,
-        "hysteresis": 0.5,
-        "clamp": 100.0,
-    }
-
-
-def _potmon_avg_entry(pot_el_voltage):
-    """One per-sample potmon entry as avg_metadata would emit it.
-
-    Mirrors the post-``_pot_redis_handler`` shape that lands in Redis:
-    raw voltages plus the flattened cal slope/intercept and the derived
-    angle. All-scalar per the picohost scalar-only contract; the cal
-    fields are de-facto invariants for the lifetime of a stream.
-
-    A *calibrated* reading is used here so every cal/angle field is a
-    real float, exercising the float→mean reduction in
-    ``_avg_sensor_values``. The uncalibrated-stream case (cal/angle
-    fields all ``None``) is a first-class producer state — see the
-    ``potmon`` schema comment in ``io.py`` — but it is intentionally
-    not exercised by this golden fixture because it would force the
-    round-trip assertion to special-case ``None`` survivors and obscure
-    the steady-state contract this fixture is meant to pin. Tests that
-    need to cover the uncalibrated path should build their own samples.
-    Same rationale as ``_potmon_post_handler_reading`` in
-    ``test_producer_contracts.py``.
-    """
-    return {
-        "sensor_name": "potmon",
-        "status": "update",
-        "app_id": 2,
-        "pot_el_voltage": pot_el_voltage,
-        "pot_az_voltage": 1.5,
-        "pot_el_cal_slope": 100.0,
-        "pot_el_cal_intercept": -50.0,
-        "pot_az_cal_slope": 200.0,
-        "pot_az_cal_intercept": -100.0,
-        "pot_el_angle": 100.0 * pot_el_voltage - 50.0,
-        "pot_az_angle": 200.0 * 1.5 - 100.0,
-    }
-
-
-ERROR_INTEGRATION_INDEX = 30
-
-
-def _imu_errored_integration_entry(yaw):
-    return {**_imu_avg_entry(yaw), "status": "error"}
-
-
-CORR_METADATA = {
-    "imu_el": [
-        _imu_avg_entry(0.001 * i)
-        if i != ERROR_INTEGRATION_INDEX
-        else _imu_errored_integration_entry(0.001 * i)
-        for i in range(NTIMES)
-    ],
-    "imu_az": [
-        {**_imu_avg_entry(0.002 * i), "sensor_name": "imu_az", "app_id": 6}
-        for i in range(NTIMES)
-    ],
-    "lidar": [_lidar_avg_entry(1.5 + 0.001 * i) for i in range(NTIMES)],
-    "potmon": [_potmon_avg_entry(1.5 + 0.001 * i) for i in range(NTIMES)],
-    "tempctrl_lna": [
-        _tempctrl_channel_entry(30.0 + 0.01 * i, 1.0 + i)
-        for i in range(NTIMES)
-    ],
-    "tempctrl_load": [
-        _tempctrl_channel_entry(25.0 + 0.01 * i, 1.0 + i)
-        for i in range(NTIMES)
-    ],
-    "rfswitch": (
-        ["RFANT"] * 20  # steady state
-        + ["UNKNOWN"] * 5  # transition window
-        + ["RFNOFF"] * 20  # new steady state
-        + [None] * 5  # sensor dropout (gap-fill pad in _insert_sample)
-        + ["RFNOFF"] * 10  # recovery
-    ),
-}
-
-# VNA_METADATA mirrors the flat ``{key: value}`` dict returned by
-# ``MetadataSnapshotReader.get()`` — the snapshot path used by the VNA
-# code in ``PandaClient.measure_s11``. Values are whatever the producer
-# last pushed via ``MetadataWriter.add``:
-#   - picohost pushes the raw sensor dict for each sensor key
-#   - ``MetadataWriter.add`` auto-appends a ``{key}_ts`` Unix-seconds float
-#   - misc. scalars (e.g. ``corr_sync_time``) go in as floats
-# There is NO averaging on this path; unlike CORR_METADATA, values are
-# scalars or nested dicts, never per-sample lists.
-_SNAPSHOT_TS = 1775997296.789012
-VNA_METADATA = {
-    "imu_el": IMU_READING,
-    "imu_el_ts": _SNAPSHOT_TS,
-    "imu_az": {**IMU_READING, "sensor_name": "imu_az", "app_id": 6},
-    "imu_az_ts": _SNAPSHOT_TS,
-    "lidar": {
-        "sensor_name": "lidar",
-        "status": "update",
-        "app_id": 4,
-        "distance_m": 1.52,
-    },
-    "lidar_ts": _SNAPSHOT_TS,
-    "potmon": {
-        "sensor_name": "potmon",
-        "status": "update",
-        "app_id": 2,
-        "pot_el_voltage": 1.5,
-        "pot_az_voltage": 1.5,
-        "pot_el_cal_slope": 100.0,
-        "pot_el_cal_intercept": -50.0,
-        "pot_az_cal_slope": 200.0,
-        "pot_az_cal_intercept": -100.0,
-        "pot_el_angle": 100.0,
-        "pot_az_angle": 200.0,
-    },
-    "potmon_ts": _SNAPSHOT_TS,
-    "rfswitch": {
-        "sensor_name": "rfswitch",
-        "status": "update",
-        "app_id": 5,
-        "sw_state": 3,
-        "sw_state_name": "VNAS",
-    },
-    "rfswitch_ts": _SNAPSHOT_TS,
-    "corr_sync_time": 1748732903.4203713,
-    "corr_sync_time_ts": _SNAPSHOT_TS,
-}
-
-S11_HEADER = {
-    "fstart": 1e6,
-    "fstop": 250e6,
-    "npoints": 1000,
-    "ifbw": 100,
-    "power_dBm": 0,
-    "freqs": np.linspace(1e6, 250e6, 1000),
-    "mode": "ant",
-    "metadata_snapshot_unix": 1748734379.905014,
-}
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2698,9 +2698,9 @@ def test_metadata_filler_is_none_when_stream_appears_late():
 
 
 # Producer/fixture contract conformance tests live in
-# tests/test_producer_contracts.py — they test external producers
-# (picohost emulators, DummyEigsepFpga) against the schemas in io.py
-# rather than testing io.py itself.
+# src/eigsep_observing/contract_tests/test_producer_contracts.py — they
+# test external producers (picohost emulators, DummyEigsepFpga) against
+# the schemas in io.py rather than testing io.py itself.
 
 
 # Production correlation pair lists. CURRENT is what corr_config.yaml


### PR DESCRIPTION
## Summary

Ship eigsep_observing's contract-enforcement tests inside the installed wheel, so they are reachable via `pytest --pyargs eigsep_observing.contract_tests` on installs that only have the wheel (the Pi). The eigsep-field CLI's `verify` command uses exactly that invocation.

- **Producer contracts**: move `tests/test_producer_contracts.py` → `src/eigsep_observing/contract_tests/test_producer_contracts.py`.
- **Golden fixtures**: extract `HEADER`, `IMU_READING`, `CORR_METADATA`, `VNA_METADATA`, `S11_HEADER`, `NTIMES`, `ERROR_INTEGRATION_INDEX` and their `_*_avg_entry` helpers into a new private module `src/eigsep_observing/_test_fixtures.py`. Leading underscore = non-public API; shape may change without a deprecation cycle.
- `tests/conftest.py` re-exports those names, so existing `from conftest import HEADER, ...` imports in `test_io.py` keep working unchanged.
- **Key uniqueness**: also move `tests/test_key_uniqueness.py` → `src/eigsep_observing/contract_tests/test_key_uniqueness.py`. Same rationale as the producer contracts (ship it where `eigsep-field verify` can reach it, kill the eigsep-field CI's `/tmp/obs` clone dance). Zero fixture deps so the move was trivial.
- Add `src/eigsep_observing/contract_tests` to `tool.pytest.ini_options.testpaths` so plain `pytest` from the repo root still auto-discovers the suite.

## Why

`eigsep-field verify` runs the contract suite via `pytest --pyargs eigsep_observing.contract_tests`. Previously the tests lived under `tests/` (outside the installed package), so `--pyargs` couldn't find them; the eigsep-field CLI shimmed around this by trying a filesystem path that only works when the `eigsep_observing` repo is cloned next to `eigsep-field`. That shim doesn't hold on a Pi that only has wheels. Relocating the suite under `src/` makes it ship inside the wheel, which is the reachable form for `eigsep-field`'s blessed-install verification path.

## Test plan

- [x] `pytest` from repo root: 290 passed (full suite)
- [x] `pytest --pyargs eigsep_observing.contract_tests`: 15 passed (12 producer + 3 key uniqueness) — exact wheel-style invocation used by `eigsep-field verify`
- [x] `ruff check` clean on changed files
- [x] `eigsep-field verify` end-to-end against an editable install of this branch: 15 passed
- [ ] CI green
- [ ] Follow-up in `eigsep-field` ([PR #1](https://github.com/EIGSEP/eigsep-field/pull/1)) retargets the CLI + CI to the new path and drops the filesystem fallback.

## Commit history

- `7fa89f5` — `refactor(tests): ship producer-contract suite inside the wheel`
- `634bd3e` — `refactor(tests): fold test_key_uniqueness into contract_tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)