### PR TITLE
refactor(tempctrl): shrink tempctrl_loop to health-check after seed

### DIFF
--- a/scripts/panda_observe.py
+++ b/scripts/panda_observe.py
@@ -2,9 +2,10 @@
 
 Starts the steady-state observing loops on the suspended LattePanda:
 ``switch_loop`` (RF calibration schedule), ``vna_loop`` (periodic S11),
-and ``motor_loop`` (periodic az/el pointing scans). Each loop is gated
-by a ``use_*`` flag in the observing config so the panda can run with
-any subset.
+``motor_loop`` (periodic az/el pointing scans), and ``tempctrl_loop``
+(periodic LNA/LOAD peltier setpoint re-apply + health check). Each loop
+is gated by a ``use_*`` flag in the observing config so the panda can
+run with any subset.
 
 Dedicated observing modes that need cross-loop coordination — beam
 mapping (rfswitch pinned to RFANT), VNA-at-positions, or motion/switch
@@ -90,6 +91,13 @@ if client.cfg.get("use_motor", False):
     thds["motor"] = motor_thd
     logger.info("Starting motor thread")
     motor_thd.start()
+
+# tempctrl (periodic peltier setpoint re-apply + health check)
+if client.cfg.get("use_tempctrl", False):
+    tempctrl_thd = Thread(target=client.tempctrl_loop)
+    thds["tempctrl"] = tempctrl_thd
+    logger.info("Starting tempctrl thread")
+    tempctrl_thd.start()
 
 try:
     client.stop_client.wait()  # wait until stop signal is set

--- a/src/eigsep_observing/__init__.py
+++ b/src/eigsep_observing/__init__.py
@@ -6,4 +6,5 @@ from .observer import EigObserver
 from .fpga import EigsepFpga
 from .motor_scanner import MotorScanner
 from .motor_zeroer import MotorZeroer
+from .tempctrl_client import TempCtrlClient
 from . import testing

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -17,6 +17,7 @@ from picohost.proxy import PicoProxy
 
 from .io import _validate_vna_s11_data, _validate_vna_s11_header
 from .motor_scanner import MotorScanner
+from .tempctrl_client import TempCtrlClient
 from .utils import get_config_path
 from .vna import VnaWriter
 
@@ -69,8 +70,6 @@ class PandaClient:
             cfg = self._get_cfg()
         self.cfg = cfg
 
-        self.peltier = None
-
         # RF switch proxy is a thin Redis-key facade — no hardware
         # contact, so construction cannot fail. PicoManager owns the
         # real serial link and publishes its device list into the
@@ -114,6 +113,12 @@ class PandaClient:
         else:
             self.motor_scanner = None
             self.logger.info("Motor scanner not initialized")
+
+        if self.cfg.get("use_tempctrl", False):
+            self.init_tempctrl()
+        else:
+            self.tempctrl = None
+            self.logger.info("Tempctrl not initialized")
 
         self.heartbeat_thd = threading.Thread(
             target=self._send_heartbeat,
@@ -390,6 +395,35 @@ class PandaClient:
             )
             return
         self.logger.info(f"Motor scanner initialized (kwargs={kwargs})")
+
+    def init_tempctrl(self):
+        """
+        Build a :class:`TempCtrlClient` from the config.
+
+        ``tempctrl_settings`` (yaml, nested per-channel) forwards to the
+        :class:`TempCtrlClient` constructor and is re-applied every
+        iteration of :meth:`tempctrl_loop`. Absent/empty → no settings
+        are pushed by :meth:`TempCtrlClient.apply_settings` (firmware
+        keeps whatever it had).
+
+        Notes
+        -----
+        Called by the constructor when ``use_tempctrl`` is true. Safe
+        to call again if the config changes; no hardware contact, so
+        construction cannot fail for config reasons — only an
+        obviously-wrong (non-dict) settings block disables the client.
+        """
+        self.tempctrl = None
+        raw_settings = self.cfg.get("tempctrl_settings")
+        settings = raw_settings or {}
+        if not isinstance(settings, dict):
+            self.logger.warning(
+                "Invalid tempctrl_settings config; expected dict, "
+                f"got {type(raw_settings).__name__}. Tempctrl disabled."
+            )
+            return
+        self.tempctrl = TempCtrlClient(self.transport, settings=settings)
+        self.logger.info(f"Tempctrl initialized (settings={settings})")
 
     def switch_loop(self):
         """
@@ -730,3 +764,111 @@ class PandaClient:
                         wait_s = failure_retry_s
             if self.stop_client.wait(wait_s):
                 return
+
+    def tempctrl_loop(self):
+        """Periodic setpoint re-apply + health check for the LNA/LOAD peltiers.
+
+        Every ``tempctrl_interval`` seconds push the yaml-configured
+        settings (watchdog, clamps, setpoints, enable flags) to the
+        tempctrl pico and inspect the latest metadata snapshot for
+        operator-actionable faults:
+
+        * firmware watchdog tripped (channels disabled by firmware),
+        * a channel's ``status == "error"`` (thermistor read failed),
+        * drive saturated at the clamp while the channel is still far
+          from its target (peltier can't keep up — fan failure,
+          thermal-interface degradation, setpoint outside achievable
+          range).
+
+        Defensive re-apply is idempotent: on unchanged config the pico
+        just replaces current values with identical ones, so a missed
+        state-reset (pico reboot) self-heals on the next iteration
+        without any explicit recovery state machine. Unlike
+        :meth:`motor_loop`, there is no "stuck at an arbitrary
+        position" failure mode to guard against — the firmware
+        watchdog is the safety net.
+
+        Command-delivery errors (``RuntimeError``/``TimeoutError`` from
+        the proxy) log at WARNING on both channels and the loop sleeps
+        ``tempctrl_interval`` before retrying; a persistent pico
+        outage just means warnings at the loop cadence, not
+        quadratic-blowup retries.
+        """
+        if self.tempctrl is None:
+            self._warn_with_status(
+                "Tempctrl not initialized. Cannot run tempctrl_loop."
+            )
+            return
+        interval = self.cfg.get("tempctrl_interval")
+        if not isinstance(interval, (int, float)) or interval <= 0:
+            self._warn_with_status(
+                f"Invalid tempctrl_interval ({interval!r}); tempctrl_loop "
+                "will not run."
+            )
+            return
+
+        while not self.stop_client.is_set():
+            try:
+                self.tempctrl.apply_settings()
+            except (RuntimeError, TimeoutError) as exc:
+                self._warn_with_status(
+                    f"Tempctrl apply_settings failed "
+                    f"({type(exc).__name__}: {exc}); will retry in "
+                    f"{interval}s."
+                )
+            else:
+                status = self.tempctrl.get_status()
+                if status is not None:
+                    self._tempctrl_health_check(status)
+            if self.stop_client.wait(interval):
+                return
+
+    def _tempctrl_health_check(self, status):
+        """Emit operator-visible warnings for tempctrl fault states.
+
+        Called once per :meth:`tempctrl_loop` iteration on the latest
+        metadata snapshot. Three warn conditions:
+
+        1. ``watchdog_tripped`` — firmware disabled both channels
+           because panda-side commands stopped arriving. The next
+           ``apply_settings`` will re-arm once the link recovers, but
+           the operator needs to see why the peltiers went dark.
+        2. Per-channel ``status == "error"`` — thermistor read failed
+           on that side. Control is disabled by firmware for the
+           affected channel until the sensor recovers.
+        3. Per-channel drive saturated at the clamp while
+           ``|T_now - T_target| > 1°C`` — the peltier is trying its
+           hardest and still losing ground, i.e. a fan or
+           thermal-interface fault, or a setpoint outside the rig's
+           thermal capability. Uses a ±0.02 slack on the clamp check
+           because ``drive_level`` is a floating-point duty cycle and
+           we don't want to false-fire on the last bit of rounding.
+        """
+        if status.get("watchdog_tripped"):
+            self._warn_with_status(
+                "Tempctrl firmware watchdog tripped; channels disabled."
+            )
+        for ch in ("LNA", "LOAD"):
+            if status.get(f"{ch}_status") == "error":
+                self._warn_with_status(
+                    f"Tempctrl {ch} thermistor in error state; "
+                    "firmware has disabled that channel."
+                )
+                continue
+            drive = status.get(f"{ch}_drive_level")
+            clamp = status.get(f"{ch}_clamp")
+            t_now = status.get(f"{ch}_T_now")
+            t_target = status.get(f"{ch}_T_target")
+            if (
+                drive is not None
+                and clamp is not None
+                and t_now is not None
+                and t_target is not None
+                and abs(drive) >= abs(clamp) - 0.02
+                and abs(t_now - t_target) > 1.0
+            ):
+                self._warn_with_status(
+                    f"Tempctrl {ch} drive saturated at clamp "
+                    f"({drive:.2f}/{clamp:.2f}) with T_now={t_now:.2f}°C "
+                    f"vs target={t_target:.2f}°C; peltier cannot keep up."
+                )

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -766,12 +766,13 @@ class PandaClient:
                 return
 
     def tempctrl_loop(self):
-        """Periodic setpoint re-apply + health check for the LNA/LOAD peltiers.
+        """Seed firmware config once, then poll health forever.
 
-        Every ``tempctrl_interval`` seconds push the yaml-configured
-        settings (watchdog, clamps, setpoints, enable flags) to the
-        tempctrl pico and inspect the latest metadata snapshot for
-        operator-actionable faults:
+        The first iteration calls ``apply_settings`` to push the
+        yaml-configured watchdog / clamps / setpoints / enable flags to
+        the tempctrl pico. Once that succeeds the loop switches to
+        health-check-only mode: every ``tempctrl_interval`` seconds it
+        inspects the metadata snapshot for operator-actionable faults:
 
         * firmware watchdog tripped (channels disabled by firmware),
         * a channel's ``status == "error"`` (thermistor read failed),
@@ -780,19 +781,20 @@ class PandaClient:
           thermal-interface degradation, setpoint outside achievable
           range).
 
-        Defensive re-apply is idempotent: on unchanged config the pico
-        just replaces current values with identical ones, so a missed
-        state-reset (pico reboot) self-heals on the next iteration
-        without any explicit recovery state machine. Unlike
-        :meth:`motor_loop`, there is no "stuck at an arbitrary
-        position" failure mode to guard against — the firmware
-        watchdog is the safety net.
+        Reboot recovery is owned by picohost:
+        :class:`picohost.base.PicoPeltier` caches the last config each
+        setter pushed and replays it from ``on_reconnect``. On EIGSEP
+        hardware every firmware reset path (hard watchdog, brownout,
+        picotool re-flash via BOOTSEL) drops USB CDC, so the replay
+        fires on the serial-link reconnect without the panda needing a
+        periodic re-apply as insurance.
 
-        Command-delivery errors (``RuntimeError``/``TimeoutError`` from
-        the proxy) log at WARNING on both channels and the loop sleeps
-        ``tempctrl_interval`` before retrying; a persistent pico
-        outage just means warnings at the loop cadence, not
-        quadratic-blowup retries.
+        If the initial ``apply_settings`` fails (proxy/manager transient
+        — ``RuntimeError`` / ``TimeoutError``) it is retried on the
+        same cadence until it succeeds, then the loop locks into
+        health-check-only mode. A persistent command-delivery outage
+        just means warnings at the loop cadence, not quadratic-blowup
+        retries.
         """
         if self.tempctrl is None:
             self._warn_with_status(
@@ -807,16 +809,19 @@ class PandaClient:
             )
             return
 
+        applied = False
         while not self.stop_client.is_set():
-            try:
-                self.tempctrl.apply_settings()
-            except (RuntimeError, TimeoutError) as exc:
-                self._warn_with_status(
-                    f"Tempctrl apply_settings failed "
-                    f"({type(exc).__name__}: {exc}); will retry in "
-                    f"{interval}s."
-                )
-            else:
+            if not applied:
+                try:
+                    self.tempctrl.apply_settings()
+                    applied = True
+                except (RuntimeError, TimeoutError) as exc:
+                    self._warn_with_status(
+                        f"Tempctrl apply_settings failed "
+                        f"({type(exc).__name__}: {exc}); will retry in "
+                        f"{interval}s."
+                    )
+            if applied:
                 status = self.tempctrl.get_status()
                 if status is not None:
                     self._tempctrl_health_check(status)

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -32,3 +32,18 @@ use_motor: false
 motor_interval: 1  # seconds between scans
 motor_failure_retry_s: 0.5  # fast retry for tests
 motor_scan: {}
+# tempctrl
+use_tempctrl: false
+tempctrl_interval: 1  # seconds; short for tests
+tempctrl_settings:
+  watchdog_timeout_ms: 30000
+  LNA:
+    enable: true
+    target_C: 25.0
+    hysteresis_C: 0.5
+    clamp: 0.6
+  LOAD:
+    enable: true
+    target_C: 25.0
+    hysteresis_C: 0.5
+    clamp: 0.6

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -40,3 +40,22 @@ motor_scan: {}  # kwargs forwarded to MotorScanner.scan; {} → scan defaults
 # motor_scanner_kwargs:  # optional MotorScanner ctor overrides
 #   poll_interval_s: 0.1
 #   stall_timeout_s: 30.0
+# tempctrl (LNA + LOAD peltier control)
+# Default off: turning this on drives power into the peltiers. Opt in
+# explicitly when the rig is thermally instrumented and watchdog-
+# monitored. tempctrl_settings is re-applied every tempctrl_interval
+# seconds (idempotent) so a pico reboot is self-healing.
+use_tempctrl: false
+tempctrl_interval: 60  # seconds between setpoint re-apply + health check
+tempctrl_settings:
+  watchdog_timeout_ms: 30000  # 0 disables; must exceed keepalive cadence
+  LNA:
+    enable: true
+    target_C: 25.0
+    hysteresis_C: 0.5
+    clamp: 0.6  # max drive duty [0, 1]
+  LOAD:
+    enable: true
+    target_C: 25.0
+    hysteresis_C: 0.5
+    clamp: 0.6

--- a/src/eigsep_observing/tempctrl_client.py
+++ b/src/eigsep_observing/tempctrl_client.py
@@ -1,0 +1,182 @@
+"""
+Client-side tempctrl (Peltier) orchestrator.
+
+Wraps a :class:`picohost.proxy.PicoProxy` (``tempctrl``) and a
+:class:`eigsep_redis.MetadataSnapshotReader` so :class:`PandaClient`
+can push setpoints/clamps/enable flags to the LNA and LOAD Peltier
+channels and read back the most recent status without reaching inside
+the :class:`picohost.manager.PicoManager` process. Mirrors the role of
+:class:`eigsep_observing.motor_scanner.MotorScanner` for the motor pico.
+
+Unlike motor scans, tempctrl commands are atomic — there is no
+multi-step orchestration and no stall/timeout concept on the panda
+side. The firmware runs its own closed-loop hysteresis control; the
+Python side just publishes fresh setpoints periodically and watches
+the metadata snapshot for health.
+"""
+
+import logging
+
+from eigsep_redis import MetadataSnapshotReader
+from picohost.proxy import PicoProxy
+
+logger = logging.getLogger(__name__)
+
+
+class TempCtrlClient:
+    """Push LNA/LOAD Peltier settings through ``PicoManager`` via Redis.
+
+    Parameters
+    ----------
+    transport : eigsep_redis.Transport
+        Shared transport; used to build the proxy and metadata reader.
+    settings : dict or None
+        Validated yaml settings dict, shaped as::
+
+            {
+                "watchdog_timeout_ms": int,
+                "LNA": {
+                    "enable": bool,
+                    "target_C": float,
+                    "hysteresis_C": float,
+                    "clamp": float,
+                },
+                "LOAD": {... same keys as LNA ...},
+            }
+
+        ``None`` or ``{}`` means "do not push anything on
+        ``apply_settings`` beyond what's explicitly passed as an
+        override." The yaml schema is kept readable (``target_C``,
+        ``hysteresis_C``) and translated to firmware field names
+        (``LNA_temp_target``, ``LNA_hysteresis``, ...) inside
+        :meth:`apply_settings`.
+    source : str
+        Identifier stamped on proxy command stream entries.
+    """
+
+    _CHANNELS = ("LNA", "LOAD")
+
+    def __init__(self, transport, *, settings=None, source="panda_client"):
+        self.transport = transport
+        self._proxy = PicoProxy("tempctrl", transport, source=source)
+        self._reader = MetadataSnapshotReader(transport)
+        self.settings = dict(settings) if settings else {}
+        self.logger = logger
+
+    @property
+    def is_available(self):
+        return self._proxy.is_available
+
+    def get_status(self):
+        """Latest tempctrl metadata snapshot, or ``None`` if absent."""
+        try:
+            return self._reader.get("tempctrl")
+        except KeyError:
+            return None
+
+    def set_watchdog_timeout(self, timeout_ms):
+        self._proxy.send_command(
+            "set_watchdog_timeout", timeout_ms=int(timeout_ms)
+        )
+
+    def set_clamp(self, *, LNA=None, LOAD=None):
+        kwargs = {}
+        if LNA is not None:
+            kwargs["LNA"] = float(LNA)
+        if LOAD is not None:
+            kwargs["LOAD"] = float(LOAD)
+        if kwargs:
+            self._proxy.send_command("set_clamp", **kwargs)
+
+    def set_temperature(
+        self, *, T_LNA=None, LNA_hyst=None, T_LOAD=None, LOAD_hyst=None
+    ):
+        """Push setpoints. Hysteresis piggybacks on the set_temperature
+        command to match the :class:`picohost.base.PicoPeltier` signature.
+        """
+        kwargs = {}
+        if T_LNA is not None:
+            kwargs["T_LNA"] = float(T_LNA)
+            if LNA_hyst is not None:
+                kwargs["LNA_hyst"] = float(LNA_hyst)
+        if T_LOAD is not None:
+            kwargs["T_LOAD"] = float(T_LOAD)
+            if LOAD_hyst is not None:
+                kwargs["LOAD_hyst"] = float(LOAD_hyst)
+        if kwargs:
+            self._proxy.send_command("set_temperature", **kwargs)
+
+    def set_enable(self, *, LNA=None, LOAD=None):
+        """Arm/disarm per-channel peltier drive.
+
+        Only sends the command if at least one channel is specified, so
+        partial-application callers don't flip the untouched channel.
+        ``PicoPeltier.set_enable`` defaults missing kwargs to ``True``
+        firmware-side, so we pass both explicitly to avoid surprise
+        arming.
+        """
+        if LNA is None and LOAD is None:
+            return
+        current = self.settings
+        lna_enable = (
+            bool(LNA)
+            if LNA is not None
+            else bool(current.get("LNA", {}).get("enable", False))
+        )
+        load_enable = (
+            bool(LOAD)
+            if LOAD is not None
+            else bool(current.get("LOAD", {}).get("enable", False))
+        )
+        self._proxy.send_command(
+            "set_enable", LNA=lna_enable, LOAD=load_enable
+        )
+
+    def apply_settings(self):
+        """Push the full config to the pico in safe order.
+
+        Order:
+
+        1. ``set_watchdog_timeout`` first so any subsequent
+           delay-between-commands cannot trip a zero-timeout default.
+        2. ``set_clamp`` — establish the duty-cycle ceiling before
+           anything is armed.
+        3. ``set_temperature`` — publish the target (and hysteresis)
+           while still disarmed (or at prior arm state).
+        4. ``set_enable`` — arm last, so by the time the channel turns
+           on the clamp and setpoint are already in place.
+
+        Idempotent: calling repeatedly with unchanged settings is a
+        no-op on the hardware side (firmware replaces current values
+        with identical ones). Missing sections are skipped — e.g.
+        omitting ``watchdog_timeout_ms`` leaves whatever the firmware
+        currently has.
+
+        Raises
+        ------
+        RuntimeError, TimeoutError
+            From the underlying :class:`PicoProxy` on command delivery
+            failure. Caller decides whether to log, retry, or surface.
+        """
+        s = self.settings
+        if not s:
+            return
+        watchdog = s.get("watchdog_timeout_ms")
+        if watchdog is not None:
+            self.set_watchdog_timeout(watchdog)
+        lna = s.get("LNA", {})
+        load = s.get("LOAD", {})
+        self.set_clamp(
+            LNA=lna.get("clamp"),
+            LOAD=load.get("clamp"),
+        )
+        self.set_temperature(
+            T_LNA=lna.get("target_C"),
+            LNA_hyst=lna.get("hysteresis_C"),
+            T_LOAD=load.get("target_C"),
+            LOAD_hyst=load.get("hysteresis_C"),
+        )
+        self.set_enable(
+            LNA=lna.get("enable"),
+            LOAD=load.get("enable"),
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ from eigsep_redis.testing import DummyTransport
 from picohost.proxy import PicoProxy
 
 import eigsep_observing
-from eigsep_observing import MotorScanner
+from eigsep_observing import MotorScanner, TempCtrlClient
 from eigsep_observing.testing import DummyPandaClient
 from eigsep_observing.testing.utils import compare_dicts
 
@@ -1811,5 +1811,242 @@ def test_motor_loop_set_delay_failure_is_warning_not_fatal(
         level, status = _status_reader(client).read(timeout=1)
         assert level == logging.WARNING
         assert "Motor set_delay failed" in status
+    finally:
+        client.stop()
+
+
+# ``tempctrl_loop`` mirrors ``motor_loop``: periodic action gated by a
+# ``use_*`` flag. Unit tests for the command dispatch + emulator state
+# live in tests/test_tempctrl_client.py; these tests cover the
+# gating and loop-level behavior.
+
+
+def test_use_tempctrl_false_leaves_client_none(client):
+    """Default dummy_config has ``use_tempctrl: false``; PandaClient
+    must leave ``self.tempctrl`` as ``None`` and skip the init call."""
+    assert client.cfg.get("use_tempctrl", False) is False
+    assert client.tempctrl is None
+
+
+def test_use_tempctrl_true_builds_client(transport, dummy_cfg):
+    """With ``use_tempctrl: true``, ``self.tempctrl`` is a real
+    ``TempCtrlClient`` bound to the same transport."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        assert isinstance(client.tempctrl, TempCtrlClient)
+        assert client.tempctrl.transport is client.transport
+        # Settings from dummy_config land on the client object.
+        assert client.tempctrl.settings.get("watchdog_timeout_ms") == 30000
+        assert client.tempctrl.settings["LNA"]["target_C"] == 25.0
+    finally:
+        client.stop()
+
+
+def test_tempctrl_settings_non_dict_disables_client(
+    transport, dummy_cfg, caplog
+):
+    """A non-dict ``tempctrl_settings`` is a config-side bug. Bail out
+    loudly and leave the client disabled; do not construct a
+    ``TempCtrlClient`` against garbage."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_settings"] = "not a dict"
+    caplog.set_level("WARNING")
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        assert client.tempctrl is None
+        assert any(
+            "Invalid tempctrl_settings" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_returns_when_client_is_none(caplog, client):
+    """``tempctrl_loop`` must return promptly when disabled — no tight
+    spin, warning rides both channels."""
+    assert client.tempctrl is None
+    _arm_status_reader(client)
+    caplog.set_level("WARNING")
+    t0 = time.monotonic()
+    client.tempctrl_loop()
+    elapsed = time.monotonic() - t0
+    assert elapsed < 1.0
+    assert any(
+        "Tempctrl not initialized" in r.getMessage() for r in caplog.records
+    )
+    level, status = _status_reader(client).read(timeout=1)
+    assert level == logging.WARNING
+    assert "Tempctrl not initialized" in status
+
+
+def test_tempctrl_loop_invalid_interval_returns(transport, dummy_cfg, caplog):
+    """Non-positive / non-numeric ``tempctrl_interval`` → refuse to run."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_interval"] = 0
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        _arm_status_reader(client)
+        caplog.set_level("WARNING")
+        t0 = time.monotonic()
+        client.tempctrl_loop()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 1.0
+        assert any(
+            "Invalid tempctrl_interval" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_applies_settings_then_stops(transport, dummy_cfg):
+    """One pass through the loop calls ``apply_settings`` and honors
+    ``stop_client``. We patch ``apply_settings`` so we don't race the
+    emulator; the gating contract is what this test covers."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_interval"] = 60  # long; only one iteration
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        apply_calls = []
+
+        def fake_apply():
+            apply_calls.append(True)
+            client.stop_client.set()
+
+        with patch.object(
+            client.tempctrl, "apply_settings", side_effect=fake_apply
+        ):
+            client.tempctrl_loop()
+        assert apply_calls == [True]
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_survives_apply_runtime_error(
+    transport, dummy_cfg, caplog
+):
+    """Command-delivery failures log a WARNING on both channels and do
+    not unwind the loop — the next iteration retries."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_interval"] = 60
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        _arm_status_reader(client)
+        apply_calls = []
+
+        def raising_apply():
+            apply_calls.append(True)
+            client.stop_client.set()
+            raise RuntimeError("pico unreachable")
+
+        with patch.object(
+            client.tempctrl, "apply_settings", side_effect=raising_apply
+        ):
+            caplog.set_level("WARNING")
+            client.tempctrl_loop()  # must return, not raise
+        assert apply_calls == [True]
+        assert any(
+            "Tempctrl apply_settings failed" in r.getMessage()
+            and "RuntimeError" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.WARNING
+        assert "Tempctrl apply_settings failed" in status
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_warns_on_watchdog_tripped(transport, dummy_cfg, caplog):
+    """When the metadata snapshot reports ``watchdog_tripped``, the
+    health check emits an operator-visible WARNING so the peltiers
+    going dark is visible ground-side."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        caplog.set_level("WARNING")
+        client._tempctrl_health_check(
+            {
+                "watchdog_tripped": True,
+                "LNA_status": "update",
+                "LOAD_status": "update",
+            }
+        )
+        assert any(
+            "Tempctrl firmware watchdog tripped" in r.getMessage()
+            for r in caplog.records
+        )
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_warns_on_channel_error(transport, dummy_cfg, caplog):
+    """Per-channel ``status == "error"`` (thermistor read failed) must
+    ride the status stream so the operator sees the dead sensor."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        caplog.set_level("WARNING")
+        client._tempctrl_health_check(
+            {
+                "watchdog_tripped": False,
+                "LNA_status": "error",
+                "LOAD_status": "update",
+            }
+        )
+        assert any(
+            "LNA thermistor in error state" in r.getMessage()
+            for r in caplog.records
+        )
+        assert not any(
+            "LOAD thermistor in error state" in r.getMessage()
+            for r in caplog.records
+        )
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_warns_on_saturated_drive(transport, dummy_cfg, caplog):
+    """Drive saturated at the clamp while still >1°C from target =
+    peltier can't keep up. Log loudly for the operator."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        caplog.set_level("WARNING")
+        client._tempctrl_health_check(
+            {
+                "watchdog_tripped": False,
+                "LNA_status": "update",
+                "LOAD_status": "update",
+                "LNA_drive_level": 0.6,
+                "LNA_clamp": 0.6,
+                "LNA_T_now": 35.0,
+                "LNA_T_target": 25.0,
+                "LOAD_drive_level": 0.05,
+                "LOAD_clamp": 0.6,
+                "LOAD_T_now": 25.1,
+                "LOAD_T_target": 25.0,
+            }
+        )
+        assert any(
+            "LNA drive saturated at clamp" in r.getMessage()
+            for r in caplog.records
+        )
+        assert not any(
+            "LOAD drive saturated" in r.getMessage() for r in caplog.records
+        )
     finally:
         client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1906,10 +1906,11 @@ def test_tempctrl_loop_invalid_interval_returns(transport, dummy_cfg, caplog):
         client.stop()
 
 
-def test_tempctrl_loop_applies_settings_then_stops(transport, dummy_cfg):
+def test_tempctrl_loop_applies_settings_once_then_stops(transport, dummy_cfg):
     """One pass through the loop calls ``apply_settings`` and honors
-    ``stop_client``. We patch ``apply_settings`` so we don't race the
-    emulator; the gating contract is what this test covers."""
+    ``stop_client``. Gating contract + single-seed contract: only the
+    first iteration seeds firmware config; picohost owns reboot replay,
+    so there is no periodic re-apply."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
     cfg["tempctrl_interval"] = 60  # long; only one iteration
@@ -1930,39 +1931,113 @@ def test_tempctrl_loop_applies_settings_then_stops(transport, dummy_cfg):
         client.stop()
 
 
-def test_tempctrl_loop_survives_apply_runtime_error(
-    transport, dummy_cfg, caplog
-):
-    """Command-delivery failures log a WARNING on both channels and do
-    not unwind the loop — the next iteration retries."""
+def test_tempctrl_loop_does_not_reapply_after_success(transport, dummy_cfg):
+    """After apply_settings succeeds once, subsequent iterations run
+    the health check only — no re-apply. picohost's PicoPeltier caches
+    the last-applied config and replays it on reconnect, which makes
+    panda-side periodic re-apply redundant. Regression guard so we
+    don't drift back to the old "apply every iteration" shape."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
-    cfg["tempctrl_interval"] = 60
+    cfg["tempctrl_interval"] = 0.01  # fast so we run many iterations
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        apply_calls = []
+        health_calls = []
+
+        def fake_apply():
+            apply_calls.append(True)
+
+        def fake_health(status):
+            health_calls.append(status)
+            if len(health_calls) >= 5:
+                client.stop_client.set()
+
+        with (
+            patch.object(
+                client.tempctrl, "apply_settings", side_effect=fake_apply
+            ),
+            patch.object(
+                client.tempctrl,
+                "get_status",
+                return_value={
+                    "watchdog_tripped": False,
+                    "LNA_status": "update",
+                    "LOAD_status": "update",
+                },
+            ),
+            patch.object(
+                client, "_tempctrl_health_check", side_effect=fake_health
+            ),
+        ):
+            client.tempctrl_loop()
+        assert apply_calls == [True]  # seeded once, not re-applied
+        assert len(health_calls) >= 5  # health check runs every iteration
+    finally:
+        client.stop()
+
+
+def test_tempctrl_loop_retries_apply_until_success(
+    transport, dummy_cfg, caplog
+):
+    """If the initial apply_settings raises RuntimeError / TimeoutError
+    (proxy/manager transient), retry on the same cadence until it
+    sticks, then lock into health-check-only mode. Guards both the
+    failure-survival contract (loop doesn't unwind on RuntimeError)
+    and the retry-on-init-failure contract."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_interval"] = 0.01
     client = DummyPandaClient(transport, default_cfg=cfg)
     try:
         _arm_status_reader(client)
         apply_calls = []
 
-        def raising_apply():
+        def flaky_apply():
             apply_calls.append(True)
-            client.stop_client.set()
-            raise RuntimeError("pico unreachable")
+            if len(apply_calls) < 3:
+                raise RuntimeError(f"transient #{len(apply_calls)}")
+            # third call succeeds; stop after one health-check iteration
+            # so the rest of the loop is pure health check.
 
-        with patch.object(
-            client.tempctrl, "apply_settings", side_effect=raising_apply
+        health_calls = []
+
+        def fake_health(status):
+            health_calls.append(status)
+            if len(health_calls) >= 2:
+                client.stop_client.set()
+
+        with (
+            patch.object(
+                client.tempctrl, "apply_settings", side_effect=flaky_apply
+            ),
+            patch.object(
+                client.tempctrl,
+                "get_status",
+                return_value={
+                    "watchdog_tripped": False,
+                    "LNA_status": "update",
+                    "LOAD_status": "update",
+                },
+            ),
+            patch.object(
+                client, "_tempctrl_health_check", side_effect=fake_health
+            ),
         ):
             caplog.set_level("WARNING")
-            client.tempctrl_loop()  # must return, not raise
-        assert apply_calls == [True]
-        assert any(
-            "Tempctrl apply_settings failed" in r.getMessage()
-            and "RuntimeError" in r.getMessage()
-            and r.levelname == "WARNING"
-            for r in caplog.records
+            client.tempctrl_loop()
+        # Two failed attempts + one success; no re-apply after success.
+        assert apply_calls == [True, True, True]
+        assert (
+            sum(
+                1
+                for r in caplog.records
+                if "Tempctrl apply_settings failed" in r.getMessage()
+                and "RuntimeError" in r.getMessage()
+                and r.levelname == "WARNING"
+            )
+            == 2
         )
-        level, status = _status_reader(client).read(timeout=1)
-        assert level == logging.WARNING
-        assert "Tempctrl apply_settings failed" in status
     finally:
         client.stop()
 

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -1,0 +1,179 @@
+"""Tests for ``TempCtrlClient`` driven against the dummy PicoManager.
+
+The ``client`` fixture starts an in-process ``PicoManager`` with a
+``DummyPicoPeltier`` backed by ``TempCtrlEmulator``. Tests inspect the
+emulator's channel states (``lna``, ``load``) to confirm that commands
+sent via :class:`TempCtrlClient` land with the right fields.
+"""
+
+import time
+
+import pytest
+
+from eigsep_observing import TempCtrlClient
+
+
+SETTINGS = {
+    "watchdog_timeout_ms": 25000,
+    "LNA": {
+        "enable": True,
+        "target_C": 27.5,
+        "hysteresis_C": 0.3,
+        "clamp": 0.5,
+    },
+    "LOAD": {
+        "enable": True,
+        "target_C": 22.0,
+        "hysteresis_C": 0.4,
+        "clamp": 0.7,
+    },
+}
+
+
+def _emulator(client):
+    return client._manager.picos["tempctrl"]._emulator
+
+
+def _wait_until(predicate, timeout=2.0, interval=0.02):
+    """Poll ``predicate`` until it returns truthy or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_apply_settings_pushes_all_fields(client):
+    """apply_settings walks watchdog → clamp → setpoint → enable, and
+    every field ends up on the emulator. Commands are dispatched
+    asynchronously through PicoManager's cmd_loop so poll for the
+    final expected state."""
+    tc = TempCtrlClient(client.transport, settings=SETTINGS)
+    tc.apply_settings()
+    em = _emulator(client)
+
+    assert _wait_until(
+        lambda: (
+            em.watchdog_timeout_ms == 25000
+            and em.lna.clamp == pytest.approx(0.5)
+            and em.load.clamp == pytest.approx(0.7)
+            and em.lna.T_target == pytest.approx(27.5)
+            and em.load.T_target == pytest.approx(22.0)
+            and em.lna.hysteresis == pytest.approx(0.3)
+            and em.load.hysteresis == pytest.approx(0.4)
+            and em.lna.enabled is True
+            and em.load.enabled is True
+        )
+    ), (
+        f"emulator state did not converge: watchdog={em.watchdog_timeout_ms}, "
+        f"LNA(clamp={em.lna.clamp}, T_target={em.lna.T_target}, "
+        f"hyst={em.lna.hysteresis}, enabled={em.lna.enabled}), "
+        f"LOAD(clamp={em.load.clamp}, T_target={em.load.T_target}, "
+        f"hyst={em.load.hysteresis}, enabled={em.load.enabled})"
+    )
+
+
+def test_apply_settings_empty_is_no_op(client):
+    """Empty settings dict sends no commands — the pre-existing
+    firmware state (defaults) is untouched."""
+    em = _emulator(client)
+    pre = (
+        em.watchdog_timeout_ms,
+        em.lna.T_target,
+        em.load.T_target,
+        em.lna.enabled,
+        em.load.enabled,
+    )
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.apply_settings()
+    # Nothing to wait for, but sleep a touch to make sure no command
+    # snuck through.
+    time.sleep(0.1)
+    post = (
+        em.watchdog_timeout_ms,
+        em.lna.T_target,
+        em.load.T_target,
+        em.lna.enabled,
+        em.load.enabled,
+    )
+    assert pre == post
+
+
+def test_set_temperature_only_pushes_specified_channel(client):
+    """Passing only T_LNA must leave the LOAD target untouched so a
+    partial-apply caller doesn't accidentally rewrite the other side."""
+    em = _emulator(client)
+    load_before = em.load.T_target
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.set_temperature(T_LNA=31.0, LNA_hyst=0.25)
+    assert _wait_until(
+        lambda: (
+            em.lna.T_target == pytest.approx(31.0)
+            and em.lna.hysteresis == pytest.approx(0.25)
+        )
+    )
+    assert em.load.T_target == pytest.approx(load_before)
+
+
+def test_set_clamp_partial(client):
+    em = _emulator(client)
+    load_before = em.load.clamp
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.set_clamp(LNA=0.35)
+    assert _wait_until(lambda: em.lna.clamp == pytest.approx(0.35))
+    assert em.load.clamp == pytest.approx(load_before)
+
+
+def test_set_enable_requires_at_least_one_channel(client):
+    """With neither LNA nor LOAD specified, set_enable is a no-op —
+    the firmware's default-True kwargs would otherwise silently arm
+    both channels."""
+    em = _emulator(client)
+    pre = (em.lna.enabled, em.load.enabled)
+    tc = TempCtrlClient(client.transport, settings=SETTINGS)
+    tc.set_enable()
+    time.sleep(0.1)
+    assert (em.lna.enabled, em.load.enabled) == pre
+
+
+def test_set_enable_uses_settings_for_unspecified_channel(client):
+    """When only one channel is passed, the other falls back to the
+    stored settings' ``enable`` — avoids silently arming LOAD when the
+    caller only intended to touch LNA."""
+    em = _emulator(client)
+    settings = {
+        "LNA": {"enable": False},
+        "LOAD": {"enable": False},
+    }
+    tc = TempCtrlClient(client.transport, settings=settings)
+    tc.set_enable(LNA=True)
+    assert _wait_until(
+        lambda: em.lna.enabled is True and em.load.enabled is False
+    )
+
+
+def test_set_watchdog_timeout(client):
+    em = _emulator(client)
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.set_watchdog_timeout(12345)
+    assert _wait_until(lambda: em.watchdog_timeout_ms == 12345)
+
+
+def test_get_status_returns_snapshot_or_none(client):
+    """get_status returns a dict with the full schema, or None before
+    the pico has published. Fire a command first to ensure at least
+    one publish has happened."""
+    tc = TempCtrlClient(client.transport, settings=SETTINGS)
+    tc.apply_settings()
+    assert _wait_until(lambda: tc.get_status() is not None)
+    status = tc.get_status()
+    assert status["sensor_name"] == "tempctrl"
+    assert "LNA_T_target" in status
+    assert "LOAD_T_target" in status
+
+
+def test_is_available_reflects_registration(client):
+    tc = TempCtrlClient(client.transport)
+    # Dummy manager registers ``tempctrl`` in ``DUMMY_PICO_CLASSES``.
+    assert tc.is_available


### PR DESCRIPTION
## Summary

- `tempctrl_loop` drops its periodic `apply_settings` re-push. It now seeds firmware config once (with retry on initial `RuntimeError` / `TimeoutError` until it sticks), then runs the health check forever.
- Reboot recovery is owned by picohost: `PicoPeltier` caches the last config each setter pushed and replays it from `on_reconnect`. On EIGSEP hardware every firmware reset path (hard watchdog, brownout, picotool re-flash via BOOTSEL) drops USB CDC, so the replay fires on the serial-link reconnect in seconds — the panda's periodic re-apply was duplicating work picohost can do closer to the fault.
- New test guards the contract: after a successful seed, subsequent iterations must not re-apply. Prevents drift back to the old "apply every iteration" shape.

## Why

The previous periodic re-apply existed to self-heal pico reboots (brownout, firmware watchdog). It worked, but at O(`tempctrl_interval`) recovery latency (60s default) and it duplicated a concern picohost can handle generically: any `PicoPeltier` user — including non-EIGSEP consumers — now gets reboot recovery for free via the cached-config + `on_reconnect` replay. The panda no longer needs to know that tempctrl firmware is reboot-fragile.

The watchdog petting was never tempctrl_loop's job anyway: picohost's `PicoPeltier._keepalive_thread_func` has always sent an empty command every `keepalive_interval` seconds (10s default) specifically to keep the firmware's 30s communication watchdog happy. The re-apply loop was purely reboot-to-defaults insurance, and that insurance is now structural rather than policy-based.

## Dependency

Requires picohost PR [#61](https://github.com/EIGSEP/pico-firmware/pull/61) (`feat/peltier-replay-on-reconnect`). Merge ordering: picohost first, then bump the picohost pin on a follow-up and merge this.

## Behavior delta

| case | before | after |
|---|---|---|
| steady-state (no reboot) | `apply_settings` every 60s | health-check every 60s, no re-apply |
| pico reboot (brownout) | recovered on next loop tick (≤60s) | recovered on `on_reconnect` (seconds) |
| picotool re-flash | setpoints silently lost until next loop tick | resumes at previous setpoints on CDC re-enumerate |
| initial apply fails (proxy flaky) | retried every loop tick forever | retried every loop tick until success, then stops retrying |
| sustained proxy outage | WARNING every 60s forever | WARNING every 60s until first success |

## Test plan

- [x] `pytest tests/test_client.py -k tempctrl` — 11 tests, pass (9 existing updated + 2 new: no-reapply-after-success guard, retry-until-success).
- [x] `pytest tests/test_client.py` — 69 tests, pass.
- [x] `pytest tests/test_tempctrl_client.py` — 9 tests, pass (tempctrl_client untouched).
- [x] `ruff check` / `ruff format --check` on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)