### PR TITLE
feat(dev): local fake-observation harness sharing one Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.eig
 *.npz
 
+# run_fake_observation.sh output
+logs/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/scripts/fpga_init.py
+++ b/scripts/fpga_init.py
@@ -8,6 +8,7 @@ from threading import Thread  # noqa: E402
 
 import IPython  # noqa: E402
 import yaml  # noqa: E402
+from eigsep_redis import Transport  # noqa: E402
 from eigsep_observing import EigsepFpga  # noqa: E402
 from eigsep_observing.testing import DummyEigsepFpga  # noqa: E402
 from eigsep_observing.utils import get_config_path, load_config  # noqa: E402
@@ -95,7 +96,10 @@ else:
 
 if args.dummy_mode:
     logger.warning("Running in DUMMY mode.")
-    fpga = DummyEigsepFpga(cfg=cfg, wiring=wiring, program=program)
+    transport = Transport(host="localhost", port=6380)
+    fpga = DummyEigsepFpga(
+        cfg=cfg, wiring=wiring, transport=transport, program=program
+    )
 else:
     snap_ip = cfg["snap_ip"]
     logger.info(f"Connecting to Eigsep correlator at {snap_ip}.")

--- a/scripts/run_fake_observation.sh
+++ b/scripts/run_fake_observation.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# run_fake_observation.sh
+#
+# Dev-only harness: launches an end-to-end fake EIGSEP observation
+# pipeline locally (panda_observe --dummy, fpga_init --dummy --reinit,
+# observe --dummy) with all three processes sharing a single Redis on
+# localhost:6380. Intended for dogfooding the live-status dashboard
+# against a running fake pipeline. NOT for production.
+#
+# Starts redis-server on :6380 in daemon mode if nothing is listening.
+# The daemon persists after this script exits; stop it with:
+#     redis-cli -p 6380 shutdown
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOG_DIR="${REPO_ROOT}/logs"
+REDIS_PORT=6380
+
+mkdir -p "${LOG_DIR}"
+
+# --- Redis ---------------------------------------------------------------
+if redis-cli -p "${REDIS_PORT}" ping >/dev/null 2>&1; then
+    echo "Redis already listening on :${REDIS_PORT}"
+else
+    echo "Starting redis-server on :${REDIS_PORT} (daemonized)"
+    redis-server --port "${REDIS_PORT}" --daemonize yes
+    # Give the daemon a moment to bind the port.
+    sleep 1
+    if ! redis-cli -p "${REDIS_PORT}" ping >/dev/null 2>&1; then
+        echo "ERROR: redis-server failed to start on :${REDIS_PORT}" >&2
+        exit 1
+    fi
+fi
+
+# --- Process launches ----------------------------------------------------
+# Order matters: panda uploads obs_config that observe.py waits on,
+# then fpga_init uploads corr_config + header, then observe.py attaches.
+
+PANDA_LOG="${LOG_DIR}/panda_observe.log"
+FPGA_LOG="${LOG_DIR}/fpga_init.log"
+OBS_LOG="${LOG_DIR}/observe.log"
+
+echo "Launching panda_observe --dummy -> ${PANDA_LOG}"
+python "${SCRIPT_DIR}/panda_observe.py" --dummy \
+    >"${PANDA_LOG}" 2>&1 &
+PANDA_PID=$!
+
+sleep 2
+
+echo "Launching fpga_init --dummy --reinit -> ${FPGA_LOG}"
+python "${SCRIPT_DIR}/fpga_init.py" --dummy --reinit \
+    >"${FPGA_LOG}" 2>&1 &
+FPGA_PID=$!
+
+sleep 2
+
+echo "Launching observe --dummy -> ${OBS_LOG}"
+python "${SCRIPT_DIR}/observe.py" --dummy \
+    >"${OBS_LOG}" 2>&1 &
+OBS_PID=$!
+
+echo ""
+echo "================================================================"
+echo "  Fake observation pipeline running:"
+echo "    panda_observe.py    PID ${PANDA_PID}"
+echo "    fpga_init.py        PID ${FPGA_PID}"
+echo "    observe.py          PID ${OBS_PID}"
+echo "  Logs in ${LOG_DIR}/"
+echo "  Press Ctrl-C to stop (observer is flushed first)."
+echo "================================================================"
+
+# --- Shutdown handling ---------------------------------------------------
+# Observer first so its HDF5 file flushes cleanly, then FPGA, then panda.
+cleanup() {
+    echo ""
+    echo "Shutting down fake observation pipeline..."
+    kill -TERM "${OBS_PID}" 2>/dev/null || true
+    wait "${OBS_PID}" 2>/dev/null || true
+    kill -TERM "${FPGA_PID}" 2>/dev/null || true
+    wait "${FPGA_PID}" 2>/dev/null || true
+    kill -TERM "${PANDA_PID}" 2>/dev/null || true
+    wait "${PANDA_PID}" 2>/dev/null || true
+    echo "All processes stopped. Redis daemon still running on :${REDIS_PORT}."
+    echo "Stop it with: redis-cli -p ${REDIS_PORT} shutdown"
+}
+trap cleanup INT TERM
+
+# Block until any child exits or we get a signal.
+wait -n "${PANDA_PID}" "${FPGA_PID}" "${OBS_PID}" || true
+cleanup

--- a/scripts/run_fake_observation.sh
+++ b/scripts/run_fake_observation.sh
@@ -25,7 +25,10 @@ if redis-cli -p "${REDIS_PORT}" ping >/dev/null 2>&1; then
     echo "Redis already listening on :${REDIS_PORT}"
 else
     echo "Starting redis-server on :${REDIS_PORT} (daemonized)"
-    redis-server --port "${REDIS_PORT}" --daemonize yes
+    # Disable persistence: this is a dev harness, no snapshots or AOF
+    # files should land in the repo root.
+    redis-server --port "${REDIS_PORT}" --daemonize yes \
+        --save "" --appendonly no
     # Give the daemon a moment to bind the port.
     sleep 1
     if ! redis-cli -p "${REDIS_PORT}" ping >/dev/null 2>&1; then
@@ -41,6 +44,32 @@ fi
 PANDA_LOG="${LOG_DIR}/panda_observe.log"
 FPGA_LOG="${LOG_DIR}/fpga_init.log"
 OBS_LOG="${LOG_DIR}/observe.log"
+
+# --- Shutdown handling ---------------------------------------------------
+# Install trap BEFORE launching children so a Ctrl-C, kill, SSH
+# disconnect (HUP), or set -e abort during the startup window cannot
+# leave Python children orphaned. PIDs start empty; `${VAR:-}` guards
+# in cleanup handle the pre-launch window. Trap disarms itself on
+# entry so re-entry from EXIT after INT/TERM/HUP is a no-op.
+# Order: observer first so its HDF5 file flushes, then FPGA, then panda.
+PANDA_PID=""
+FPGA_PID=""
+OBS_PID=""
+
+cleanup() {
+    trap - INT TERM HUP EXIT
+    echo ""
+    echo "Shutting down fake observation pipeline..."
+    kill -TERM "${OBS_PID:-}" 2>/dev/null || true
+    wait "${OBS_PID:-}" 2>/dev/null || true
+    kill -TERM "${FPGA_PID:-}" 2>/dev/null || true
+    wait "${FPGA_PID:-}" 2>/dev/null || true
+    kill -TERM "${PANDA_PID:-}" 2>/dev/null || true
+    wait "${PANDA_PID:-}" 2>/dev/null || true
+    echo "All processes stopped. Redis daemon still running on :${REDIS_PORT}."
+    echo "Stop it with: redis-cli -p ${REDIS_PORT} shutdown"
+}
+trap cleanup INT TERM HUP EXIT
 
 echo "Launching panda_observe --dummy -> ${PANDA_LOG}"
 python "${SCRIPT_DIR}/panda_observe.py" --dummy \
@@ -71,22 +100,6 @@ echo "  Logs in ${LOG_DIR}/"
 echo "  Press Ctrl-C to stop (observer is flushed first)."
 echo "================================================================"
 
-# --- Shutdown handling ---------------------------------------------------
-# Observer first so its HDF5 file flushes cleanly, then FPGA, then panda.
-cleanup() {
-    echo ""
-    echo "Shutting down fake observation pipeline..."
-    kill -TERM "${OBS_PID}" 2>/dev/null || true
-    wait "${OBS_PID}" 2>/dev/null || true
-    kill -TERM "${FPGA_PID}" 2>/dev/null || true
-    wait "${FPGA_PID}" 2>/dev/null || true
-    kill -TERM "${PANDA_PID}" 2>/dev/null || true
-    wait "${PANDA_PID}" 2>/dev/null || true
-    echo "All processes stopped. Redis daemon still running on :${REDIS_PORT}."
-    echo "Stop it with: redis-cli -p ${REDIS_PORT} shutdown"
-}
-trap cleanup INT TERM
-
-# Block until any child exits or we get a signal.
+# Block until any child exits or we get a signal. The EXIT trap
+# will run cleanup on fall-through.
 wait -n "${PANDA_PID}" "${FPGA_PID}" "${OBS_PID}" || true
-cleanup

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -33,7 +33,7 @@ motor_interval: 1  # seconds between scans
 motor_failure_retry_s: 0.5  # fast retry for tests
 motor_scan: {}
 # tempctrl
-use_tempctrl: false
+use_tempctrl: true
 tempctrl_interval: 1  # seconds; short for tests
 tempctrl_settings:
   watchdog_timeout_ms: 30000

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1821,11 +1821,17 @@ def test_motor_loop_set_delay_failure_is_warning_not_fatal(
 # gating and loop-level behavior.
 
 
-def test_use_tempctrl_false_leaves_client_none(client):
-    """Default dummy_config has ``use_tempctrl: false``; PandaClient
-    must leave ``self.tempctrl`` as ``None`` and skip the init call."""
-    assert client.cfg.get("use_tempctrl", False) is False
-    assert client.tempctrl is None
+def test_use_tempctrl_false_leaves_client_none(transport, dummy_cfg):
+    """With ``use_tempctrl: false``, PandaClient must leave
+    ``self.tempctrl`` as ``None`` and skip the init call."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = False
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        assert client.cfg.get("use_tempctrl", False) is False
+        assert client.tempctrl is None
+    finally:
+        client.stop()
 
 
 def test_use_tempctrl_true_builds_client(transport, dummy_cfg):
@@ -1893,22 +1899,31 @@ def test_tempctrl_settings_bad_numeric_disables_client(
         client.stop()
 
 
-def test_tempctrl_loop_returns_when_client_is_none(caplog, client):
+def test_tempctrl_loop_returns_when_client_is_none(
+    caplog, transport, dummy_cfg
+):
     """``tempctrl_loop`` must return promptly when disabled — no tight
     spin, warning rides both channels."""
-    assert client.tempctrl is None
-    _arm_status_reader(client)
-    caplog.set_level("WARNING")
-    t0 = time.monotonic()
-    client.tempctrl_loop()
-    elapsed = time.monotonic() - t0
-    assert elapsed < 1.0
-    assert any(
-        "Tempctrl not initialized" in r.getMessage() for r in caplog.records
-    )
-    level, status = _status_reader(client).read(timeout=1)
-    assert level == logging.WARNING
-    assert "Tempctrl not initialized" in status
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = False
+    client = DummyPandaClient(transport, default_cfg=cfg)
+    try:
+        assert client.tempctrl is None
+        _arm_status_reader(client)
+        caplog.set_level("WARNING")
+        t0 = time.monotonic()
+        client.tempctrl_loop()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 1.0
+        assert any(
+            "Tempctrl not initialized" in r.getMessage()
+            for r in caplog.records
+        )
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.WARNING
+        assert "Tempctrl not initialized" in status
+    finally:
+        client.stop()
 
 
 def test_tempctrl_loop_invalid_interval_returns(transport, dummy_cfg, caplog):


### PR DESCRIPTION
## Summary

Plumbs all three `--dummy` scripts (`panda_observe`, `fpga_init`, `observe`) through a single real Redis on `localhost:6380` so a live-status dashboard can be dogfooded against a running fake pipeline end-to-end.

- Fixes the one inconsistency blocking the multi-process fake setup: `fpga_init.py --dummy` used to fall through to an in-process `DummyTransport`, so its corr stream never reached the observer waiting on 6380 (observer's `record_corr_data` would hit its 300s watchdog and crash). It now uses `Transport("localhost", 6380)` like `panda_observe.py --dummy` already does.
- `dummy_config.yaml`: `use_tempctrl: true` so the dashboard's tempctrl tiles light up locally. The `TempCtrlEmulator` is already wired via `DUMMY_PICO_CLASSES`.
- New `scripts/run_fake_observation.sh`: dev-only launcher that starts `redis-server --port 6380` if needed, sequences `panda → fpga → observer` with logs in `./logs/`, and on Ctrl-C shuts down observer first (so HDF5 flushes), then FPGA, then panda.
- Two tests in `tests/test_client.py` that relied on the default `use_tempctrl=false` now build their own client with the flag off.

## Test plan

- [x] `pytest tests/test_client.py` → 70 passed
- [x] `pytest tests/test_fpga.py tests/test_observer.py` → 65 passed
- [x] `ruff check .` + `ruff format --check .` clean
- [ ] End-to-end smoke: `./scripts/run_fake_observation.sh`, confirm `logs/*.log` show no tracebacks, `redis-cli -p 6380 xlen <corr_stream>` grows, HDF5 files land in `corr_save_dir`, live-status tiles classify (not "unknown")

🤖 Generated with [Claude Code](https://claude.com/claude-code)