### PR TITLE
fix(live-status): unstall the plotter, pin axes, label by wiring

### DIFF
--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -415,37 +415,60 @@ class LiveStatusAggregator:
                 s.file_heartbeat = file_h
 
     def _read_corr(self) -> tuple[Optional[tuple], bool]:
-        """One CorrReader.read call with a finite timeout.
+        """Drain the corr stream to the latest entry; reshape the tail.
 
-        Returns ``(result, ok)``. ``ok`` is True when the call
-        round-tripped to Redis (even if no new data landed in the
-        window — that's a ``TimeoutError`` from ``CorrReader``, not a
-        connectivity failure). ``ok=False`` means a transport error
-        fired. ``result`` is ``(acc_cnt, pairs_data)`` when data was
-        available, else ``None``.
+        ``CorrReader.read`` consumes one stream entry per call. The
+        producer publishes at the integration cadence (~4 Hz at the
+        default ``corr_acc_len``); this drain ticks at
+        ``1/snap_tick_s`` (~2 Hz). Reading one entry per tick falls
+        behind by ~2 entries/sec, which surfaces as a growing display
+        lag — the legacy ``live_plotter`` polls faster than the
+        producer (FuncAnimation at 20 Hz) and therefore never lags.
+        Drain to the tail so the plot always reflects the most recent
+        integration; intermediate entries are discarded because the
+        dashboard renders current state, not history.
+
+        Returns ``(result, ok)``. ``ok`` is True when every call
+        round-tripped to Redis (a ``TimeoutError`` from ``CorrReader``
+        is the natural drain-exit and counts as success). ``ok=False``
+        means a transport error fired during the drain. ``result`` is
+        ``(acc_cnt, pairs_data)`` for the *latest* drained entry, or
+        ``None`` if the tick saw no new entries.
         """
-        try:
-            acc_cnt, pairs_data = self.corr_reader.read(
-                timeout=self._read_timeout_s, unpack=True
-            )
-        except TimeoutError:
+        last_acc_cnt: Optional[int] = None
+        last_pairs: Optional[dict] = None
+        # First read waits up to read_timeout_s for *any* new entry;
+        # subsequent reads use a tiny timeout so the drain only consumes
+        # entries already in Redis at this moment and never blocks
+        # waiting for the producer's next push (which would let a
+        # fast producer starve _snap_tick from ever returning).
+        timeout = self._read_timeout_s
+        while True:
+            try:
+                acc_cnt, pairs_data = self.corr_reader.read(
+                    timeout=timeout, unpack=True
+                )
+            except TimeoutError:
+                break
+            except RedisError as exc:
+                logger.error("corr_reader.read transport failure: %s", exc)
+                return None, False
+            except Exception as exc:
+                logger.error("corr_reader.read failed: %s", exc)
+                return None, False
+            if acc_cnt is None:
+                break
+            last_acc_cnt = acc_cnt
+            last_pairs = pairs_data
+            timeout = 0.001
+        if last_acc_cnt is None:
             return None, True
-        except RedisError as exc:
-            logger.error("corr_reader.read transport failure: %s", exc)
-            return None, False
-        except Exception as exc:
-            logger.error("corr_reader.read failed: %s", exc)
-            return None, False
-        if acc_cnt is None:
-            return None, True
-        # Reshape even/odd average (same pattern as plot.py /
-        # File._insert_sample).
         try:
-            reshaped = reshape_data(pairs_data, avg_even_odd=True)
+            reshaped = reshape_data(last_pairs, avg_even_odd=True)
         except Exception as exc:
             logger.error("reshape_data failed: %s", exc)
             return None, True
-        return (acc_cnt, reshaped), True
+        return (last_acc_cnt, reshaped), True
 
     def _read_adc_snapshot(self) -> tuple[Optional[tuple], bool]:
         """One AdcSnapshotReader.read call with a finite timeout.

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -28,13 +28,54 @@ def _envelope(data: Any, warnings: Optional[list] = None) -> dict:
     return {"ok": True, "data": data, "warnings": warnings or []}
 
 
+def _input_to_ant(wiring: Optional[dict]) -> dict[str, str]:
+    """Invert ``wiring["ants"]`` to ``{snap_input_str: antenna_name}``.
+
+    Permissive: missing ``snap.input`` fields are skipped, an absent or
+    empty wiring returns an empty map. Lab/test setups that publish no
+    wiring (or wire to test loads) end up with ``{}``, and the
+    front-end falls back to raw input numbers.
+    """
+    if not wiring:
+        return {}
+    out: dict[str, str] = {}
+    for ant, spec in (wiring.get("ants") or {}).items():
+        snap = (spec or {}).get("snap") or {}
+        inp = snap.get("input")
+        if inp is None:
+            continue
+        out[str(inp)] = ant
+    return out
+
+
+def _pair_label(pair: str, input_to_ant: dict[str, str]) -> Optional[str]:
+    """Antenna-friendly label for a corr pair, or ``None`` if unmappable.
+
+    Crosses follow the ``"{a} / {b}"`` convention from
+    ``plot.pairs_to_labels``. A pair with any input not in the map
+    yields ``None`` so the front-end can fall back to the raw key
+    rather than rendering a half-mapped label.
+    """
+    if len(pair) == 1:
+        return input_to_ant.get(pair)
+    if len(pair) == 2:
+        a = input_to_ant.get(pair[0])
+        b = input_to_ant.get(pair[1])
+        if a is None or b is None:
+            return None
+        return f"{a} / {b}"
+    return None
+
+
 def _corr_payload(state: StateSnapshot) -> dict:
     pairs_out: dict[str, dict] = {}
     freqs = state.corr_freqs
+    input_to_ant = _input_to_ant((state.corr_header or {}).get("wiring"))
     if state.corr_pairs and freqs is not None:
         for pair, arr in state.corr_pairs.items():
             if arr is None or arr.size == 0:
                 continue
+            label = _pair_label(pair, input_to_ant)
             # Aggregator stores the output of reshape_data(avg_even_odd=True):
             #   autos   → shape (ntimes=1, nchan) int32
             #   crosses → shape (ntimes=1, nchan, 2) int32
@@ -49,12 +90,14 @@ def _corr_payload(state: StateSnapshot) -> dict:
                 pairs_out[pair] = {
                     "mag": mag.tolist(),
                     "phase": phase.tolist(),
+                    "label": label,
                 }
             else:
                 row = arr[0] if arr.ndim == 2 else arr
                 pairs_out[pair] = {
                     "mag": np.asarray(row, dtype=np.float64).tolist(),
                     "phase": None,
+                    "label": label,
                 }
     return {
         "acc_cnt": state.corr_acc_cnt,
@@ -112,6 +155,13 @@ def _metadata_payload(
 
 def _adc_payload(state: StateSnapshot) -> dict:
     adc_stats = state.adc_stats_latest or {}
+    # Prefer the corr header's wiring (canonical, written on every
+    # state-changing FPGA call); fall back to the ADC sidecar so
+    # standalone ADC snapshots still carry labels even when corr
+    # publishing is paused.
+    sidecar_wiring = (state.adc_snapshot_sidecar or {}).get("wiring")
+    header_wiring = (state.corr_header or {}).get("wiring")
+    input_to_ant = _input_to_ant(header_wiring or sidecar_wiring)
     per_input = []
     for n in range(6):
         for c in range(2):
@@ -126,6 +176,7 @@ def _adc_payload(state: StateSnapshot) -> dict:
                     "mean": mean,
                     "power": power,
                     "clip_frac": state.adc_clip_fraction.get(str(n)),
+                    "label": input_to_ant.get(str(n)),
                 }
             )
     return {

--- a/src/eigsep_observing/live_status/static/css/dashboard.css
+++ b/src/eigsep_observing/live_status/static/css/dashboard.css
@@ -43,6 +43,22 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
   font-size: 12px;
 }
 
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle input { margin: 0; cursor: pointer; }
+
 .tile.ok      { background: var(--ok);      color: #fff; }
 .tile.warn    { background: var(--warn);    color: #000; }
 .tile.danger  { background: var(--danger);  color: #fff; }

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -1,6 +1,34 @@
 "use strict";
 
 const POLL_MS = 1000;
+const WIRING_TOGGLE_KEY = "eigsep.useWiringLabels";
+
+// Wiring-labels toggle. Persisted in localStorage so the user's
+// choice survives reloads; gracefully no-ops when no labels are
+// present in the API payload (e.g. lab benches with no wiring).
+function getUseWiringLabels() {
+  try {
+    return localStorage.getItem(WIRING_TOGGLE_KEY) !== "0";
+  } catch (e) {
+    return true;
+  }
+}
+
+function setUseWiringLabels(on) {
+  try {
+    localStorage.setItem(WIRING_TOGGLE_KEY, on ? "1" : "0");
+  } catch (e) {
+    // localStorage unavailable (e.g. private mode); checkbox state still works.
+  }
+}
+
+// Pick wiring label when the toggle is on AND the API gave us one;
+// otherwise fall back to the raw key the caller passed in (input
+// number, pair string, etc.).
+function pickLabel(rawKey, apiLabel) {
+  if (getUseWiringLabels() && apiLabel) return apiLabel;
+  return rawKey;
+}
 
 function tileClass(classify) {
   return `tile ${classify || "unknown"}`;
@@ -31,13 +59,20 @@ async function fetchJson(path) {
 
 // ---- corr spectra ---------------------------------------------------
 
+// Plotly log axes take ranges in log10. [-2, 9] mirrors the legacy
+// live_plotter ylim of (1e-2, 1e9); fixed range avoids autoscale jitter.
 const magLayout = {
   margin: { l: 50, r: 20, t: 10, b: 40 },
   paper_bgcolor: "#1a1a1a",
   plot_bgcolor: "#111",
   font: { color: "#eee" },
-  xaxis: { title: "Frequency (MHz)", gridcolor: "#333" },
-  yaxis: { title: "Magnitude", type: "log", gridcolor: "#333" },
+  xaxis: { title: "Frequency [MHz]", gridcolor: "#333" },
+  yaxis: {
+    title: "Amplitude [arb. units]",
+    type: "log",
+    range: [-2, 9],
+    gridcolor: "#333",
+  },
   showlegend: true,
   legend: { orientation: "h", y: -0.2 },
 };
@@ -47,11 +82,17 @@ const phaseLayout = {
   paper_bgcolor: "#1a1a1a",
   plot_bgcolor: "#111",
   font: { color: "#eee" },
-  xaxis: { title: "Frequency (MHz)", gridcolor: "#333" },
-  yaxis: { title: "Phase (rad)", range: [-Math.PI, Math.PI], gridcolor: "#333" },
+  xaxis: { title: "Frequency [MHz]", gridcolor: "#333" },
+  yaxis: {
+    title: "Phase [deg]",
+    range: [-180, 180],
+    gridcolor: "#333",
+  },
   showlegend: true,
   legend: { orientation: "h", y: -0.2 },
 };
+
+const RAD_TO_DEG = 180 / Math.PI;
 
 let magPlotInitialized = false;
 let phasePlotInitialized = false;
@@ -64,23 +105,24 @@ function updateCorr(corr) {
   for (const pair of Object.keys(corr.pairs)) {
     const p = corr.pairs[pair];
     if (!p) continue;
+    const name = pickLabel(pair, p.label);
     if (p.mag) {
       magTraces.push({
         x: freqs,
         y: p.mag,
         type: "scatter",
         mode: "lines",
-        name: pair,
+        name,
         line: { width: 1.5 },
       });
     }
     if (p.phase) {
       phaseTraces.push({
         x: freqs,
-        y: p.phase,
+        y: p.phase.map((v) => v * RAD_TO_DEG),
         type: "scatter",
         mode: "lines",
-        name: pair,
+        name,
         line: { width: 1.5 },
       });
     }
@@ -194,8 +236,9 @@ function renderAdcTiles(adc) {
       entry.clip_frac !== null && entry.clip_frac !== undefined
         ? fmt(entry.clip_frac * 100, 2) + "%"
         : "—";
+    const inputName = pickLabel(`in${entry.input}`, entry.label);
     row.append(
-      makeSpan("label", `in${entry.input}/c${entry.core}`),
+      makeSpan("label", `${inputName}/c${entry.core}`),
       makeSpan("value", `rms ${rmsStr}`),
       makeSpan("value", `clip ${clipStr}`)
     );
@@ -257,6 +300,11 @@ function renderStatusLog(entries) {
 
 // ---- poll loop ------------------------------------------------------
 
+// Last successful payloads cached so the wiring-labels toggle can
+// re-render immediately without waiting up to POLL_MS for the next tick.
+let lastCorr = null;
+let lastAdc = null;
+
 async function tick() {
   try {
     const [health, corr, metadata, adc, rfswitch, file, status] = await Promise.all([
@@ -268,6 +316,8 @@ async function tick() {
       fetchJson("/api/file"),
       fetchJson("/api/status"),
     ]);
+    lastCorr = corr.data;
+    lastAdc = adc.data;
     updateHealth(health.data, file.data);
     updateCorr(corr.data);
     renderMetadataTiles(metadata.data);
@@ -280,5 +330,17 @@ async function tick() {
   }
 }
 
+function initWiringToggle() {
+  const cb = document.getElementById("toggle-wiring");
+  if (!cb) return;
+  cb.checked = getUseWiringLabels();
+  cb.addEventListener("change", () => {
+    setUseWiringLabels(cb.checked);
+    if (lastCorr) updateCorr(lastCorr);
+    if (lastAdc) renderAdcTiles(lastAdc);
+  });
+}
+
+initWiringToggle();
 tick();
 setInterval(tick, POLL_MS);

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -14,6 +14,10 @@
     <span class="tile" id="tile-panda">Panda: ?</span>
     <span class="tile" id="tile-observing">Observing: ?</span>
     <span class="tile" id="tile-file">Last file: ?</span>
+    <label class="toggle" title="Use antenna names from wiring.yaml (falls back to raw inputs when wiring is missing).">
+      <input type="checkbox" id="toggle-wiring">
+      <span>Wiring labels</span>
+    </label>
   </div>
 </header>
 

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -259,6 +259,29 @@ def test_snap_tick_computes_cadence_from_acc_cnt_delta(agg, seeded):
     assert 0.1 < state.corr_cadence_s < 1.0
 
 
+def test_snap_tick_drains_corr_backlog_to_latest(agg, seeded):
+    """Regression: a tick must consume the full backlog and surface the
+    *newest* entry, not the next one in stream order.
+
+    Before the drain-to-tail fix, ``CorrReader.read`` consumed one
+    entry per tick at ``count=1``; with a 4 Hz producer and a 2 Hz
+    drain (default ``snap_tick_s=0.5``), the position pointer fell
+    behind by ~2 entries/sec, surfacing as ~10 s of plot lag after
+    20 s of dashboard runtime. Seeding three entries here would have
+    landed acc_cnt=10 in the state on the first tick, not acc_cnt=12.
+    """
+    snap, _ = seeded
+    writer = CorrWriter(snap)
+    for cnt in (10, 11, 12):
+        writer.add(_make_corr_row(), cnt=cnt, sync_time=1000.0, dtype=DTYPE)
+    _rewind_streams(snap, ["stream:corr"])
+
+    agg._snap_tick()
+
+    state = agg.snapshot()
+    assert state.corr_acc_cnt == 12
+
+
 def test_snap_tick_drains_adc_stats_stream(agg, seeded):
     snap, _ = seeded
     writer = MetadataWriter(snap)

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -240,9 +240,81 @@ def test_corr_route_has_pairs_and_freqs(client):
     # Cross pair has both.
     assert data["pairs"]["02"]["mag"] is not None
     assert data["pairs"]["02"]["phase"] is not None
+    # No wiring in CORR_HEADER fixture → label field present but null.
+    assert data["pairs"]["0"]["label"] is None
+    assert data["pairs"]["02"]["label"] is None
     # Frequency axis in MHz.
     assert data["freq_mhz"] is not None
     assert len(data["freq_mhz"]) == NCHAN
+
+
+def test_corr_and_adc_routes_use_wiring_labels_when_published():
+    """When the corr header carries a wiring manifest, the API should
+    expose ``label`` on each pair (autos as the antenna name, crosses
+    as ``"{a} / {b}"``) and on each ADC per-input entry. Lab/test setups
+    that publish no wiring fall back to ``label=None`` — covered by the
+    base ``test_corr_route_has_pairs_and_freqs`` above.
+    """
+    snap = DummyTransport()
+    panda = DummyTransport()
+    CorrConfigStore(snap).upload(CORR_CONFIG)
+    CorrConfigStore(snap).upload_header(
+        {
+            **CORR_HEADER,
+            "wiring": {
+                "ants": {
+                    "ant0": {"snap": {"input": 0}},
+                    "ant2": {"snap": {"input": 2}},
+                }
+            },
+        }
+    )
+    CorrWriter(snap).add(
+        {"0": _auto_bytes(), "02": _cross_bytes()},
+        cnt=100,
+        sync_time=CORR_HEADER["sync_time"],
+        dtype=DTYPE,
+    )
+    MetadataWriter(snap).add(
+        "adc_stats",
+        {
+            "sensor_name": "adc_stats",
+            "status": "update",
+            **{
+                f"input{n}_core{c}_{stat}": 15.0
+                for n in range(6)
+                for c in range(2)
+                for stat in ("mean", "power", "rms")
+            },
+        },
+    )
+    _rewind(snap, ["stream:corr", "stream:adc_stats"])
+
+    agg = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+        read_timeout_s=0.05,
+    )
+    try:
+        agg._snap_tick()
+        client = create_app(agg).test_client()
+
+        corr = client.get("/api/corr").get_json()["data"]
+        assert corr["pairs"]["0"]["label"] == "ant0"
+        assert corr["pairs"]["02"]["label"] == "ant0 / ant2"
+
+        adc = client.get("/api/adc").get_json()["data"]
+        per_input = {
+            entry["input"]: entry["label"] for entry in adc["per_input"]
+        }
+        assert per_input[0] == "ant0"
+        assert per_input[2] == "ant2"
+        # Inputs without a wiring entry stay None (lab/test scenario).
+        assert per_input[1] is None
+        assert per_input[3] is None
+    finally:
+        agg.stop(timeout=1.0)
 
 
 def test_metadata_route_includes_classify(client):


### PR DESCRIPTION
## Summary

Three plotter regressions vs. the legacy `live_plotter`, surfaced together from one field-deploy session.

- **Drain lag (~10 s).** `CorrReader.read` is `xread count=1`; the aggregator's drain ran at ~2 Hz against a ~4 Hz producer, so the stream position fell behind by ~2 entries/sec and showed up as a growing display lag. `_read_corr` now drains to the tail — first read uses the full `read_timeout_s`, subsequent reads use a 1 ms timeout so a fast producer can't starve `_snap_tick` from returning.
- **Pinned axes & better labels.** Magnitude y-range pinned to `[-2, 9]` (log10, mirrors legacy `set_ylim(1e-2, 1e9)`); phase pinned to `[-180, 180]` and converted from radians to degrees. Axis titles are now `Frequency [MHz]`, `Amplitude [arb. units]`, `Phase [deg]`.
- **Wiring labels.** API exposes a per-pair / per-ADC-input `label` derived from `corr_header["wiring"]["ants"]` (autos as the antenna name, crosses as `"{a} / {b}"`). A header-row "Wiring labels" checkbox toggles between antenna names and raw inputs (persisted in `localStorage`). Lab/test setups with no wiring get `label=null` and silently fall back to raw inputs — no crash, no half-mapped labels.

## Test plan

- [x] `pytest tests/test_live_status_aggregator.py tests/test_live_status_app.py` — 35 passed (added regression test for backlog drain + new test for wiring labels in corr & ADC routes).
- [x] `ruff check` and `ruff format --check` clean across `live_status/` and the touched tests.
- [ ] Visually confirm in a browser on the field LattePanda: plot stays current under load, axes don't jitter, toggle flips legend/ADC tile labels live and persists across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)