### PR TITLE
feat(capture-spectrum)!: write HDF5 with full header and optional panda metadata

### DIFF
--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -144,9 +144,7 @@ all_data = reshape_data(
     {k: np.array(v) for k, v in all_data.items()},
     avg_even_odd=avg_even_odd,
 )
-header = append_corr_header(
-    header, np.array(acc_cnts), header["sync_time"]
-)
+header = append_corr_header(header, np.array(acc_cnts), header["sync_time"])
 
 write_hdf5(args.out_filename, all_data, header, metadata=metadata_lists)
 logger.info(f"Saved captured spectra to {args.out_filename}")

--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -24,6 +24,7 @@ want full timestream observing files. Output is the standard
 
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import logging
+import sys
 
 import numpy as np
 
@@ -93,7 +94,13 @@ corr_reader = CorrReader(transport_snap)
 corr_store = CorrConfigStore(transport_snap)
 logger.info(f"Connected to SNAP Redis at {args.redis_host}:{args.redis_port}")
 
-header = corr_store.get_header()
+try:
+    header = corr_store.get_header()
+except ValueError:
+    sys.exit(
+        "No corr header found in Redis. Run fpga_init.py --reinit to "
+        "initialize the SNAP and publish the header first."
+    )
 avg_even_odd = header["avg_even_odd"]
 
 snapshot_reader = None

--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -127,10 +127,17 @@ for i in range(args.num_spec):
     for k, v in data.items():
         all_data.setdefault(k, []).append(v)
     if snapshot_reader is not None:
-        snap = snapshot_reader.get()
-        for k, v in snap.items():
+        try:
+            snap = snapshot_reader.get()
+        except Exception as e:
+            logger.error(
+                f"Failed to get metadata snapshot for spectrum {i}: {e}."
+            )
+            snap = {}
+        for k in snap.keys() | metadata_lists.keys():
             if k.endswith("_ts"):
                 continue
+            v = snap.get(k, None)
             metadata_lists.setdefault(k, []).append(v)
 
 all_data = reshape_data(

--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -1,11 +1,12 @@
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import logging
+
 import numpy as np
 
-from eigsep_redis import Transport
+from eigsep_redis import MetadataSnapshotReader, Transport
 
-from eigsep_observing.corr import CorrReader
-from eigsep_observing.io import reshape_data
+from eigsep_observing.corr import CorrConfigStore, CorrReader
+from eigsep_observing.io import append_corr_header, reshape_data, write_hdf5
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -24,7 +25,7 @@ parser.add_argument(
     "out_filename",
     type=str,
     help="Output filename to save the spectrum data.",
-    default="spectrum.npz",
+    default="spectrum.h5",
 )
 parser.add_argument(
     "--pairs",
@@ -37,35 +38,74 @@ parser.add_argument(
     "--redis-host",
     type=str,
     default="10.10.10.10",
-    help="Hostname or IP address of the Redis server.",
+    help="Hostname or IP address of the SNAP Redis server.",
 )
 parser.add_argument(
     "--redis-port",
     type=int,
     default=6379,
-    help="Port number of the Redis server.",
+    help="Port number of the SNAP Redis server.",
+)
+parser.add_argument(
+    "--panda-host",
+    type=str,
+    default=None,
+    help=(
+        "Hostname or IP of the LattePanda Redis. If set, a metadata "
+        "snapshot is captured per spectrum; if unset, no metadata is "
+        "saved."
+    ),
+)
+parser.add_argument(
+    "--panda-port",
+    type=int,
+    default=6379,
+    help="Port number of the LattePanda Redis server.",
 )
 args = parser.parse_args()
 
-transport = Transport(host=args.redis_host, port=args.redis_port)
-corr_reader = CorrReader(transport)
-logger.info(
-    f"Connected to Redis server at {args.redis_host}:{args.redis_port}"
-)
+transport_snap = Transport(host=args.redis_host, port=args.redis_port)
+corr_reader = CorrReader(transport_snap)
+corr_store = CorrConfigStore(transport_snap)
+logger.info(f"Connected to SNAP Redis at {args.redis_host}:{args.redis_port}")
+
+header = corr_store.get_header()
+avg_even_odd = header["avg_even_odd"]
+
+snapshot_reader = None
+if args.panda_host is not None:
+    transport_panda = Transport(host=args.panda_host, port=args.panda_port)
+    snapshot_reader = MetadataSnapshotReader(transport_panda)
+    logger.info(
+        f"Connected to LattePanda Redis at {args.panda_host}:{args.panda_port}"
+    )
 
 all_autos = [str(i) for i in range(6)]
 all_cross = ["02", "04", "13", "15", "24", "35"]
 pairs = args.pairs or all_autos + all_cross
+
 all_data = {}
+acc_cnts = []
+metadata_lists = {} if snapshot_reader is not None else None
+
 logger.info(f"Capturing {args.num_spec} spectra for pairs: {pairs}")
 for i in range(args.num_spec):
-    data = corr_reader.read(pairs=pairs, timeout=10)[-1]
-    data = reshape_data(data, avg_even_odd=True)
+    acc_cnt, data = corr_reader.read(pairs=pairs, timeout=10)
+    data = reshape_data(data, avg_even_odd=avg_even_odd)
+    acc_cnts.append(acc_cnt)
     for k, v in data.items():
-        if k not in all_data:
-            all_data[k] = [v]
-        all_data[k].append(v)
+        all_data.setdefault(k, []).append(v)
+    if snapshot_reader is not None:
+        snap = snapshot_reader.get()
+        for k, v in snap.items():
+            if k.endswith("_ts"):
+                continue
+            metadata_lists.setdefault(k, []).append(v)
 
 all_data = {k: np.array(v) for k, v in all_data.items()}
-np.savez(args.out_filename, **all_data)
+header = append_corr_header(
+    header, np.array(acc_cnts), header["sync_time"]
+)
+
+write_hdf5(args.out_filename, all_data, header, metadata=metadata_lists)
 logger.info(f"Saved captured spectra to {args.out_filename}")

--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -48,6 +48,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "out_filename",
+    nargs="?",
     type=str,
     help="Output filename to save the spectrum data.",
     default="spectrum.h5",
@@ -122,7 +123,6 @@ metadata_lists = {} if snapshot_reader is not None else None
 logger.info(f"Capturing {args.num_spec} spectra for pairs: {pairs}")
 for i in range(args.num_spec):
     acc_cnt, data = corr_reader.read(pairs=pairs, timeout=10)
-    data = reshape_data(data, avg_even_odd=avg_even_odd)
     acc_cnts.append(acc_cnt)
     for k, v in data.items():
         all_data.setdefault(k, []).append(v)
@@ -133,7 +133,10 @@ for i in range(args.num_spec):
                 continue
             metadata_lists.setdefault(k, []).append(v)
 
-all_data = {k: np.array(v) for k, v in all_data.items()}
+all_data = reshape_data(
+    {k: np.array(v) for k, v in all_data.items()},
+    avg_even_odd=avg_even_odd,
+)
 header = append_corr_header(
     header, np.array(acc_cnts), header["sync_time"]
 )

--- a/scripts/capture_spectrum.py
+++ b/scripts/capture_spectrum.py
@@ -1,3 +1,27 @@
+"""Capture N spectra from the SNAP correlator into a single HDF5 file.
+
+Used for testing / on-off measurements where we deliberately do *not*
+want full timestream observing files. Output is the standard
+``io.write_hdf5`` shape, so it's read back with::
+
+    from eigsep_observing.io import read_hdf5
+    data, header, metadata = read_hdf5("spectrum.h5")
+
+- ``data``: ``dict[str, np.ndarray]`` keyed by pair name. Autos
+  (``"0"``..``"5"``) are int32 shape ``(num_spec, nchan)``; cross
+  pairs (``"02"``, ``"04"``, ...) are reconstructed to complex128
+  shape ``(num_spec, nchan)``.
+- ``header``: every ``CORR_HEADER_SCHEMA`` field
+  (``nchan``, ``sample_rate``, ``integration_time``, ``acc_bins``,
+  ``dtype``, ``avg_even_odd``, ``wiring``) plus ``sync_time``,
+  ``header_upload_unix``, ``acc_cnt`` (one per spectrum), and
+  ``times``/``freqs``/``dfreq`` computed by ``append_corr_header``.
+- ``metadata``: ``{}`` when ``--panda-host`` is not set. Otherwise a
+  per-key list of length ``num_spec`` with one
+  ``MetadataSnapshotReader.get()`` value per spectrum (point-in-time,
+  mirroring the VNA path). ``_ts`` freshness keys are filtered out.
+"""
+
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import logging
 


### PR DESCRIPTION
## Summary

- `scripts/capture_spectrum.py` now writes an HDF5 file via `io.write_hdf5` instead of a headerless `.npz`. The header is pulled from `CorrConfigStore.get_header()` and passed through `append_corr_header` so it carries every `CORR_HEADER_SCHEMA` field plus computed `times`/`freqs`/`dfreq`.
- New `--panda-host` / `--panda-port` flags. When set, a `MetadataSnapshotReader` captures the panda metadata hash once per spectrum (point-in-time, mirroring the VNA path); when unset, no metadata group is written. Matches the "if the panda is connected we're using it" testing pattern.
- `avg_even_odd` is now read from the header and passed to `reshape_data`, so the on-disk `avg_even_odd` field is honest about what was actually averaged. `acc_cnt` (previously discarded) is now used to compute `times`.

## Breaking

- Default output filename: `spectrum.npz` → `spectrum.h5`. Any consumers reading the old `.npz` need to switch to `eigsep_observing.io.read_hdf5`.

## Test plan

- [x] Targeted `pytest tests/test_io.py -k "header or write_hdf5 or read_hdf5 or end_to_end"` — 9 passed.
- [x] End-to-end smoke test against `DummyTransport` (fakeredis): captured spectra round-trip through `write_hdf5` → `read_hdf5`, header has all required fields, autos return as int32, crosses reconstruct as complex128, panda metadata stacks per-spectrum with `_ts` keys filtered.
- [ ] Manual test on a real SNAP: `python scripts/capture_spectrum.py 5 /tmp/cap.h5 --redis-host 10.10.10.10` then `read_hdf5('/tmp/cap.h5')`.
- [ ] Manual test with panda connected: re-run with `--panda-host <panda-ip>`, confirm `metadata` is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)