### PR TITLE
fix(fpga): disable ADC diag publishers on first failure

### DIFF
--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -166,6 +166,14 @@ class EigsepFpga:
         self.pams_initialized = False
         self.is_synchronized = False
 
+        # ADC diagnostic publishers are best-effort and degrade
+        # gracefully: a bitstream that lacks ``input_rms_*`` (adc_stats)
+        # or has an incompatible snapshot BRAM (adc_snapshot) flips the
+        # corresponding flag off on first failure so the per-integration
+        # ERROR spam doesn't drown the journal. Restart to retry.
+        self._adc_stats_enabled = True
+        self._adc_snapshot_enabled = True
+
     def _make_fpga(self):
         """
         Construct the underlying CasperFpga object. Hookable so tests
@@ -952,9 +960,13 @@ class EigsepFpga:
         publish them on the metadata bus.
 
         Called from ``_read_integrations`` on every corr integration.
-        Failures are logged at ERROR and swallowed — corr data is
-        sacred, and a missing ADC stats row is strictly diagnostic.
+        First failure flips ``_adc_stats_enabled`` off and emits a
+        single WARNING; subsequent calls no-op until restart. Corr
+        data is sacred, and a missing ADC stats row is strictly
+        diagnostic.
         """
+        if not self._adc_stats_enabled:
+            return
         try:
             means, powers, rmss = self.inp.get_stats(sum_cores=False)
             payload = {"sensor_name": "adc", "status": "update"}
@@ -968,7 +980,13 @@ class EigsepFpga:
                 payload[f"input{n}_core{c}_rms"] = float(rmss[i])
             self.adc_metadata_writer.add("adc_stats", payload)
         except Exception as e:
-            self.logger.error(f"Failed to publish adc_stats: {e}")
+            self._adc_stats_enabled = False
+            self.logger.warning(
+                "Disabling adc_stats publisher for this run after "
+                "failure: %s. Restart eigsep-observe to retry. "
+                "(Likely cause: bitstream lacks input_rms_* registers.)",
+                e,
+            )
 
     def _publish_adc_snapshot(self):
         """
@@ -976,8 +994,11 @@ class EigsepFpga:
         frame on the diagnostic stream.
 
         Called from ``_publish_snapshots_loop`` at the configured
-        cadence. Failures are logged at ERROR and swallowed.
+        cadence. First failure flips ``_adc_snapshot_enabled`` off and
+        emits a single WARNING; subsequent calls no-op until restart.
         """
+        if not self._adc_snapshot_enabled:
+            return
         try:
             ant_ids = list(self.wiring["ants"].keys())
             n_snap_inputs = self.inp.nstreams // 2
@@ -1010,15 +1031,26 @@ class EigsepFpga:
                 wiring={"ants": {k: self.wiring["ants"][k] for k in ant_ids}},
             )
         except Exception as e:
-            self.logger.error(f"Failed to publish adc_snapshot: {e}")
+            self._adc_snapshot_enabled = False
+            self.logger.warning(
+                "Disabling adc_snapshot publisher for this run after "
+                "failure: %s. Restart eigsep-observe to retry. "
+                "(Likely cause: bitstream's snapshot BRAM is "
+                "incompatible with the consumer.)",
+                e,
+            )
 
     def _publish_snapshots_loop(self, period):
         """Background thread: publish one ADC snapshot every
         ``period`` seconds until ``self.event`` is set. Gated on
-        ``is_synchronized`` so pre-sync noise doesn't fill the stream."""
+        ``is_synchronized`` so pre-sync noise doesn't fill the stream.
+        Exits early once ``_adc_snapshot_enabled`` flips off so a
+        broken bitstream doesn't keep waking the thread for a no-op."""
         while not self.event.wait(period):
             if not self.is_synchronized:
                 continue
+            if not self._adc_snapshot_enabled:
+                return
             self._publish_adc_snapshot()
 
     def _read_integrations(self, pairs, timeout=10):

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -164,14 +164,38 @@ class TestPublishAdcStats:
             )
             assert payload[f"input{n}_core{c}_rms"] == pytest.approx(rmss[i])
 
-    def test_publish_failure_is_logged_not_raised(self, fpga, caplog):
-        caplog.set_level(logging.ERROR)
+    def test_publish_failure_disables_publisher_with_warning(
+        self, fpga, caplog
+    ):
+        caplog.set_level(logging.WARNING)
         with patch.object(
             fpga.inp, "get_stats", side_effect=RuntimeError("FPGA dead")
         ):
             # Must not raise — corr data is sacred.
             fpga._publish_adc_stats()
-        assert "Failed to publish adc_stats" in caplog.text
+        assert fpga._adc_stats_enabled is False
+        assert "Disabling adc_stats publisher" in caplog.text
+        assert "FPGA dead" in caplog.text
+
+    def test_publish_after_disable_is_no_op(self, fpga, caplog):
+        caplog.set_level(logging.WARNING)
+        with patch.object(
+            fpga.inp, "get_stats", side_effect=RuntimeError("FPGA dead")
+        ) as get_stats:
+            fpga._publish_adc_stats()  # first call: fails, disables
+            assert get_stats.call_count == 1
+            assert fpga._adc_stats_enabled is False
+            # Subsequent calls must not touch the FPGA again.
+            fpga._publish_adc_stats()
+            fpga._publish_adc_stats()
+            assert get_stats.call_count == 1
+        # Only one WARNING line for the whole run.
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "adc_stats" in r.getMessage()
+        ]
+        assert len(warnings) == 1
 
 
 class TestPublishAdcSnapshot:
@@ -191,15 +215,40 @@ class TestPublishAdcSnapshot:
         assert sidecar["wiring"]["ants"]  # non-empty
         assert "unix_ts" in sidecar
 
-    def test_publish_snapshot_failure_logged_not_raised(self, fpga, caplog):
-        caplog.set_level(logging.ERROR)
+    def test_publish_snapshot_failure_disables_publisher_with_warning(
+        self, fpga, caplog
+    ):
+        caplog.set_level(logging.WARNING)
         with patch.object(
             fpga.inp,
             "get_adc_snapshot",
             side_effect=RuntimeError("snapshot bram misaligned"),
         ):
             fpga._publish_adc_snapshot()
-        assert "Failed to publish adc_snapshot" in caplog.text
+        assert fpga._adc_snapshot_enabled is False
+        assert "Disabling adc_snapshot publisher" in caplog.text
+        assert "snapshot bram misaligned" in caplog.text
+
+    def test_publish_snapshot_after_disable_is_no_op(self, fpga, caplog):
+        caplog.set_level(logging.WARNING)
+        with patch.object(
+            fpga.inp,
+            "get_adc_snapshot",
+            side_effect=RuntimeError("snapshot bram misaligned"),
+        ) as snap:
+            fpga._publish_adc_snapshot()  # first call: fails, disables
+            assert snap.call_count == 1
+            assert fpga._adc_snapshot_enabled is False
+            fpga._publish_adc_snapshot()
+            fpga._publish_adc_snapshot()
+            assert snap.call_count == 1
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "adc_snapshot" in r.getMessage()
+        ]
+        assert len(warnings) == 1
 
 
 class TestReadIntegrationsPublishesStats:
@@ -337,6 +386,23 @@ class TestPublishSnapshotsLoopShutdown:
         # True immediately and the function returns.
         fpga.event.set()
         fpga._publish_snapshots_loop(0.01)  # returns cleanly
+
+    def test_loop_exits_when_publisher_disabled(self, fpga):
+        """Once ``_adc_snapshot_enabled`` flips off the loop must
+        return rather than spin forever calling a no-op publisher."""
+        fpga.event = Event()
+        fpga.is_synchronized = True
+        fpga._adc_snapshot_enabled = False
+        from threading import Thread as RealThread
+
+        t = RealThread(
+            target=fpga._publish_snapshots_loop,
+            args=(0.01,),
+            daemon=True,
+        )
+        t.start()
+        t.join(timeout=1)
+        assert not t.is_alive()
 
     def test_loop_skips_publish_when_unsynced(self, fpga):
         fpga.event = Event()


### PR DESCRIPTION
## Summary

- ADC stats / snapshot publishers now flip their own `_*_enabled` flag off on first exception and emit a single WARNING naming the cause and the recovery (restart `eigsep-observe`), instead of ERROR-logging every cycle.
- `_publish_snapshots_loop` exits early once disabled so the thread stops waking for no-ops.

## Why

Caught during a fresh RPi deploy: the .fpg shipped in `data/` was missing the `input_rms_*` registers and the snapshot BRAM read returned tftp "Access violation". Both publishers swallowed the exception (per "corr data is sacred") but kept retrying forever, producing ~4 ERROR/s in the journal indefinitely. New behavior: one WARNING per publisher per run, then silent until restart.

Corr data path is untouched — these publishers were already best-effort, the change is just in how the failure surfaces.

## Test plan

- [x] `pytest tests/test_adc.py` — 21 passed, including new tests for `disable + WARNING`, `subsequent calls no-op`, and `loop exits when disabled`.
- [x] `pytest tests/test_fpga.py src/eigsep_observing/contract_tests/` — 58 passed (no regression in producer-contract or fpga surface).
- [x] `ruff check` / `ruff format --check` clean.
- [ ] Manual deploy verification: pull on the affected RPi, restart `eigsep-observe.service`, confirm the journal shows one WARNING per publisher and then nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)