### PR TITLE
fix(fpga): serialize TAPCP transactions via lock proxy

### DIFF
--- a/scripts/adc_snapshot_bench.py
+++ b/scripts/adc_snapshot_bench.py
@@ -1,0 +1,332 @@
+"""ADC snapshot bench: measure corr-poll latency under contention.
+
+Spins up the real ``EigsepFpga`` corr poll thread (and optionally the
+ADC snapshot thread) against a live SNAP, while a timing-instrumented
+``_FpgaLockProxy`` records every TAPCP transaction. Compares two
+runs — baseline (``--snapshot-period 0``) and loaded (``--snapshot-
+period 1.0``) — to verify that enabling the snapshot publisher does
+not regress the corr-poll latency past the acceptance bar:
+
+  * Loaded ``corr_acc_cnt`` p99 within ~2x baseline.
+  * Loaded corr-thread lock-wait p99 <= 30 ms.
+  * Zero ``Missed N integration(s)`` warnings.
+  * Zero ``Read of acc_cnt=X FAILED to complete`` errors.
+  * Zero ``Disabling adc_*_publisher`` warnings.
+
+Pre-conditions: SNAP is reachable at ``--snap-ip``, has been programmed
+and synced (e.g. via ``eigsep-fpga-init --reinit``), and is producing
+correlator data. The bench wires Redis I/O through a fakeredis
+``DummyTransport`` so the real Redis bus is left alone.
+"""
+
+import argparse
+import logging
+import queue
+import sys
+import threading
+import time
+from collections import Counter, deque
+
+import numpy as np
+
+from eigsep_redis.testing import DummyTransport
+
+from eigsep_observing.fpga import (
+    EigsepFpga,
+    _FpgaLockProxy,
+    default_config,
+    default_wiring,
+)
+from eigsep_observing.utils import configure_eig_logger
+
+
+class _TimingFpgaLockProxy(_FpgaLockProxy):
+    """Lock proxy that appends ``(thread, method, reg_or_arg, t_request,
+    t_acquire, t_complete)`` to a thread-safe ``deque`` per call.
+
+    ``t_request`` is captured before the lock acquire so
+    ``t_acquire - t_request`` measures contention; ``t_complete -
+    t_acquire`` is the TAPCP-only walltime.
+    """
+
+    def __init__(self, fpga, lock, collector):
+        super().__init__(fpga, lock)
+        self._collector = collector
+
+    def __getattr__(self, name):
+        attr = getattr(self._fpga, name)
+        if not callable(attr):
+            return attr
+        lock = self._lock
+        collector = self._collector
+
+        def wrapped(*args, **kwargs):
+            reg = args[0] if args else ""
+            t_request = time.perf_counter()
+            with lock:
+                t_acquire = time.perf_counter()
+                try:
+                    return attr(*args, **kwargs)
+                finally:
+                    collector.append(
+                        (
+                            threading.current_thread().name,
+                            name,
+                            str(reg),
+                            t_request,
+                            t_acquire,
+                            time.perf_counter(),
+                        )
+                    )
+
+        return wrapped
+
+
+class _BenchFpga(EigsepFpga):
+    """``EigsepFpga`` whose lock proxy records timings."""
+
+    def __init__(self, *args, collector, **kwargs):
+        # Set before super().__init__ so _wrap_fpga can see it.
+        self._bench_collector = collector
+        super().__init__(*args, **kwargs)
+
+    def _wrap_fpga(self, raw):
+        return _TimingFpgaLockProxy(
+            raw, self._fpga_lock, self._bench_collector
+        )
+
+
+class _LogCounter(logging.Handler):
+    """Logging handler that counts records by message-prefix substring.
+
+    The acceptance criteria look for specific phrases emitted by
+    ``_read_integrations`` and the f177dff sticky-disable path, so
+    a substring match is sufficient.
+    """
+
+    PHRASES = (
+        "Missed",
+        "FAILED to complete",
+        "Disabling adc_stats publisher",
+        "Disabling adc_snapshot publisher",
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.counts = Counter()
+
+    def emit(self, record):
+        msg = record.getMessage()
+        for phrase in self.PHRASES:
+            if phrase in msg:
+                self.counts[phrase] += 1
+
+
+def _percentiles_ms(values_s):
+    if not values_s:
+        return {f"p{p}": float("nan") for p in (50, 95, 99, 100)}
+    arr = np.asarray(values_s) * 1000.0
+    return {f"p{p}": float(np.percentile(arr, p)) for p in (50, 95, 99, 100)}
+
+
+def _summarize(rows, label, log_counts):
+    print(f"\n=== {label} ===")
+    print(f"total tapcp ops: {len(rows)}")
+
+    corr_polls = [
+        r for r in rows if r[1] == "read_int" and r[2] == "corr_acc_cnt"
+    ]
+    snap_reads = [
+        r for r in rows if r[1] == "read" and r[2] == "input_snapshot_bram"
+    ]
+
+    def report(name, rs):
+        if not rs:
+            print(f"  {name}: 0 calls")
+            return
+        latency = [r[5] - r[3] for r in rs]
+        wait = [r[4] - r[3] for r in rs]
+        txn = [r[5] - r[4] for r in rs]
+        latency_pct = _percentiles_ms(latency)
+        wait_pct = _percentiles_ms(wait)
+        txn_pct = _percentiles_ms(txn)
+        print(
+            f"  {name}: count={len(rs)} "
+            f"latency_ms_p50/p95/p99/max="
+            f"{latency_pct['p50']:.2f}/"
+            f"{latency_pct['p95']:.2f}/"
+            f"{latency_pct['p99']:.2f}/"
+            f"{latency_pct['p100']:.2f} "
+            f"wait_ms_p50/p95/p99/max="
+            f"{wait_pct['p50']:.2f}/"
+            f"{wait_pct['p95']:.2f}/"
+            f"{wait_pct['p99']:.2f}/"
+            f"{wait_pct['p100']:.2f} "
+            f"txn_ms_p50/p95/p99/max="
+            f"{txn_pct['p50']:.2f}/"
+            f"{txn_pct['p95']:.2f}/"
+            f"{txn_pct['p99']:.2f}/"
+            f"{txn_pct['p100']:.2f}"
+        )
+
+    report("corr_acc_cnt polls", corr_polls)
+    report("snapshot bram reads", snap_reads)
+    print("log warnings:")
+    for phrase in _LogCounter.PHRASES:
+        print(f"  {phrase!r}: {log_counts.get(phrase, 0)}")
+
+
+def _build_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--snap-ip",
+        required=True,
+        help="IP of the SNAP correlator board (already programmed/synced).",
+    )
+    p.add_argument(
+        "--duration",
+        type=float,
+        default=600.0,
+        help="Seconds to run before stopping the corr/snapshot threads.",
+    )
+    p.add_argument(
+        "--snapshot-period",
+        type=float,
+        default=0.0,
+        help=(
+            "adc_snapshot_period_s in seconds. 0 disables the snapshot "
+            "thread (baseline run); typical loaded value is 1.0."
+        ),
+    )
+    p.add_argument(
+        "--out",
+        default="adc_snapshot_bench.npz",
+        help="npz path for raw timing rows (one row per TAPCP op).",
+    )
+    return p
+
+
+def main():
+    configure_eig_logger(level=logging.INFO)
+    args = _build_parser().parse_args()
+
+    # Capture eigsep_observing's logger so we count warnings emitted
+    # from inside the fpga module.
+    log_counter = _LogCounter()
+    eig_logger = logging.getLogger("eigsep_observing")
+    eig_logger.addHandler(log_counter)
+
+    collector = deque()
+    cfg = dict(default_config)
+    cfg["snap_ip"] = args.snap_ip
+    cfg["adc_snapshot_period_s"] = args.snapshot_period
+
+    fpga = _BenchFpga(
+        cfg=cfg,
+        wiring=default_wiring,
+        transport=DummyTransport(),
+        program=False,
+        collector=collector,
+    )
+
+    # The corr loop is gated on is_synchronized for the stats publisher
+    # branch; assume the SNAP was synced by eigsep-fpga-init and stamp
+    # the cached value. sync_time only needs to be present, not exact —
+    # it's not used in the timing measurement itself.
+    fpga.is_synchronized = True
+    fpga.sync_time = time.time()
+
+    # Drive _read_integrations and (optionally) _publish_snapshots_loop
+    # directly. We intentionally skip ``observe()``'s upload_config /
+    # CorrWriter dance — the bench is measuring FPGA contention, not
+    # the file-writer pipeline.
+    fpga.queue = queue.Queue(maxsize=0)
+    fpga.event = threading.Event()
+
+    poll_thd = threading.Thread(
+        target=fpga._read_integrations,
+        args=(["0"],),
+        # Larger than --duration so the loop doesn't time out before we
+        # set the stop event.
+        kwargs={"timeout": args.duration + 60},
+        name="corr-poll",
+    )
+    poll_thd.start()
+
+    snap_thd = None
+    if args.snapshot_period > 0:
+        snap_thd = threading.Thread(
+            target=fpga._publish_snapshots_loop,
+            args=(args.snapshot_period,),
+            daemon=True,
+            name="adc-snap",
+        )
+        snap_thd.start()
+
+    # Drain the queue in a sidecar so the corr thread isn't backpressured
+    # waiting on an unbounded queue.
+    drain_stop = threading.Event()
+
+    def _drain():
+        while not drain_stop.is_set():
+            try:
+                fpga.queue.get(timeout=0.5)
+            except Exception as e:
+                eig_logger.warning("Exception while draining queue: %s", e)
+                continue
+
+    drain_thd = threading.Thread(target=_drain, daemon=True, name="drain")
+    drain_thd.start()
+
+    eig_logger.info(
+        "bench started: duration=%.1fs snapshot_period=%.2fs",
+        args.duration,
+        args.snapshot_period,
+    )
+    time.sleep(args.duration)
+
+    fpga.event.set()
+    poll_thd.join(timeout=30)
+    if snap_thd is not None:
+        snap_thd.join(timeout=30)
+    drain_stop.set()
+    drain_thd.join(timeout=5)
+
+    rows = list(collector)
+    if not rows:
+        print("WARNING: no timing rows recorded; check FPGA reachability")
+        return 1
+
+    label = f"snapshot_period={args.snapshot_period}"
+    _summarize(rows, label, log_counter.counts)
+
+    threads = np.array([r[0] for r in rows])
+    methods = np.array([r[1] for r in rows])
+    regs = np.array([r[2] for r in rows])
+    t_request = np.asarray([r[3] for r in rows])
+    t_acquire = np.asarray([r[4] for r in rows])
+    t_complete = np.asarray([r[5] for r in rows])
+    log_warnings = {
+        p: log_counter.counts.get(p, 0) for p in _LogCounter.PHRASES
+    }
+    np.savez(
+        args.out,
+        threads=threads,
+        methods=methods,
+        regs=regs,
+        t_request=t_request,
+        t_acquire=t_acquire,
+        t_complete=t_complete,
+        snapshot_period=args.snapshot_period,
+        duration=args.duration,
+        log_warnings=log_warnings,
+    )
+    print(f"\nWrote {len(rows)} rows to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eigsep_observing/blocks.py
+++ b/src/eigsep_observing/blocks.py
@@ -276,6 +276,11 @@ class Input(Block):
         self.USE_ZERO = 2
         self.INT_TIME = 2**20 / 250.0e6
         self._SNAPSHOT_SAMPLES_PER_POL = 2048
+        # Cached result of ``"snap_sel" in self.listdev()``. The
+        # bitstream's register map is fixed for the run, so dispatch
+        # only needs to check once. Lazy-evaluated on first use to
+        # keep ``__init__`` from hitting the FPGA.
+        self._has_snap_sel = None
 
     def get_status(self):
         """Return dict of current status."""
@@ -303,7 +308,9 @@ class Input(Block):
         Get a block of samples from both pols of `antenna`
         returns samples_x, samples_y
         """
-        if "snap_sel" in self.listdev():
+        if self._has_snap_sel is None:
+            self._has_snap_sel = "snap_sel" in self.listdev()
+        if self._has_snap_sel:
             return self._get_adc_snapshot_single_ant(antenna)
         else:
             return self._get_adc_snapshot_all_ants(antenna)

--- a/src/eigsep_observing/config/corr_config.yaml
+++ b/src/eigsep_observing/config/corr_config.yaml
@@ -27,6 +27,15 @@ pairs: ["0", "1", "2", "3", "4", "5", "02", "04", "13", "15", "24", "35"]
 # ADC core) publish every integration regardless and land in the
 # corr file via the metadata-averaging path — this period only
 # controls the raw-samples stream, which is diagnostic-only.
-adc_snapshot_period_s: 1.0
+#
+# Default off: the snapshot publisher shares one casperfpga TAPCP
+# transport with the corr loop, so enabling it puts the corr poll
+# in contention with the snapshot reads. The transport is
+# serialized via ``_FpgaLockProxy``, but the loaded path has not
+# been validated on the deployment hardware — run
+# ``scripts/adc_snapshot_bench.py`` against the target SNAP and
+# confirm corr-poll latency stays inside the acceptance bar before
+# flipping a nonzero value here.
+adc_snapshot_period_s: 0
 # Hardware wiring (antenna → FEM → PAM → SNAP input mapping) lives in
 # `wiring.yaml`, not here. This file is software-only.

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -16,7 +16,7 @@ import logging
 import time
 from pathlib import Path
 from queue import Queue
-from threading import Event, Thread
+from threading import Event, Lock, Thread
 
 import numpy as np
 import yaml
@@ -79,6 +79,43 @@ def _cfg_diff_summary(disk_cfg, redis_cfg):
 
     _walk(disk_cfg, redis_cfg, "")
     return "\n".join(lines) if lines else "  <identical>"
+
+
+class _FpgaLockProxy:
+    """
+    Serialize every call into a casperfpga (or DummyFpga) instance
+    behind a shared ``threading.Lock``.
+
+    The casperfpga TAPCP transport is built on a single tftpy context
+    with no internal locking. Two threads issuing reads/writes against
+    the same instance can interleave UDP packets and corrupt each
+    other's responses, which surfaces as ``RuntimeError("Failed to
+    read … from register X …")`` even when the register exists. The
+    EIGSEP correlator runs the corr-acc-cnt poll on one thread and the
+    ADC snapshot publisher on another; this proxy lets blocks and
+    direct ``self.fpga.*`` callers share one lock without each site
+    having to wrap itself in a context manager.
+
+    Non-callable attributes are returned without locking — they're
+    pure state lookups (``host``, ``snap_ip``, etc.) that don't touch
+    the transport.
+    """
+
+    def __init__(self, fpga, lock):
+        self._fpga = fpga
+        self._lock = lock
+
+    def __getattr__(self, name):
+        attr = getattr(self._fpga, name)
+        if not callable(attr):
+            return attr
+        lock = self._lock
+
+        def wrapped(*args, **kwargs):
+            with lock:
+                return attr(*args, **kwargs)
+
+        return wrapped
 
 
 class EigsepFpga:
@@ -144,7 +181,14 @@ class EigsepFpga:
             self.fpg_file = str(fpg_file.resolve())
         self.cfg["fpg_file"] = self.fpg_file
 
-        self.fpga = self._make_fpga()
+        # Single lock guards every TAPCP transaction. Wrapping
+        # ``_make_fpga``'s result in ``_FpgaLockProxy`` means every
+        # block and every direct ``self.fpga.*`` call serializes on
+        # the same lock — required because casperfpga's transport is
+        # not thread-safe and the corr loop, the snapshot loop, and
+        # ``_publish_adc_stats`` all share one connection.
+        self._fpga_lock = Lock()
+        self.fpga = self._wrap_fpga(self._make_fpga())
         if program:
             force = program == "force"
             self.fpga.upload_to_ram_and_program(self.fpg_file, force=force)
@@ -183,6 +227,15 @@ class EigsepFpga:
         return casperfpga.CasperFpga(
             self.cfg["snap_ip"], transport=TapcpTransport
         )
+
+    def _wrap_fpga(self, raw):
+        """
+        Wrap the raw casperfpga (or DummyFpga) in the lock proxy.
+        Hookable so the ADC bench in ``scripts/adc_snapshot_bench.py``
+        can subclass with a timing-instrumented proxy without
+        re-pointing every block's ``host`` attribute after the fact.
+        """
+        return _FpgaLockProxy(raw, self._fpga_lock)
 
     def _make_adc(self, ref):
         """

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+import time
 from contextlib import contextmanager
 from queue import Queue
 from threading import Event
@@ -7,6 +9,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from eigsep_observing import corr as corr_mod
+from eigsep_observing.fpga import _FpgaLockProxy
 from eigsep_observing.keys import CORR_STREAM
 from eigsep_observing.testing import DummyEigsepFpga, utils
 
@@ -848,3 +851,109 @@ class TestEigsepFpga:
         # the stream.
         r = fpga_instance.transport.r
         assert r.xlen(CORR_STREAM) == 0
+
+
+class TestFpgaLockProxy:
+    """``EigsepFpga.fpga`` is wrapped in ``_FpgaLockProxy`` so the corr
+    poll thread, the snapshot loop, and ``_publish_adc_stats`` cannot
+    interleave TAPCP transactions on the casperfpga transport (which
+    is not thread-safe). Without serialization, two concurrent threads
+    can corrupt each other's responses and surface as ``RuntimeError(
+    "Failed to read ... from register X")`` even when the register
+    exists. These tests guard the structural contract and the
+    serialization invariant."""
+
+    def test_self_fpga_is_lock_proxy(self, fpga_instance):
+        """``self.fpga`` is the proxy, not the raw casperfpga/DummyFpga."""
+        assert isinstance(fpga_instance.fpga, _FpgaLockProxy)
+
+    def test_blocks_share_the_proxied_fpga(self, fpga_instance):
+        """Every block routes through the same proxied object so they
+        all serialize on the same lock. If a block held a reference to
+        the unwrapped fpga, its calls would bypass the lock entirely."""
+        assert fpga_instance.sync.host is fpga_instance.fpga
+        assert fpga_instance.noise.host is fpga_instance.fpga
+        assert fpga_instance.inp.host is fpga_instance.fpga
+        assert fpga_instance.pfb.host is fpga_instance.fpga
+
+    def test_concurrent_calls_do_not_overlap(self, fpga_instance):
+        """Two threads hammering the proxy never enter the underlying
+        DummyFpga method concurrently. We slow the underlying call
+        down so a missing lock would produce overlapping (enter, exit)
+        intervals; with the lock all intervals must be sequential.
+        """
+        intervals = []
+        intervals_lock = threading.Lock()
+
+        def slow_read_int(reg, **kw):
+            t_enter = time.perf_counter()
+            time.sleep(0.005)  # widen the contention window
+            t_exit = time.perf_counter()
+            with intervals_lock:
+                intervals.append((t_enter, t_exit))
+            return 0
+
+        # Patch the underlying DummyFpga's read_int — the proxy's
+        # __getattr__ resolves this every call, so the patched version
+        # is what runs inside the lock.
+        with patch.object(
+            fpga_instance.fpga._fpga, "read_int", side_effect=slow_read_int
+        ):
+            threads = [
+                threading.Thread(
+                    target=lambda: fpga_instance.fpga.read_int("foo")
+                )
+                for _ in range(8)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(intervals) == 8
+        intervals.sort()
+        # Each interval must end before the next begins. A small
+        # epsilon avoids spurious failures from clock-resolution jitter
+        # on heavily-loaded CI runners.
+        eps = 1e-6
+        for (e1, x1), (e2, x2) in zip(intervals, intervals[1:]):
+            assert e2 + eps >= x1, (
+                f"overlapping intervals: ({e1:.6f},{x1:.6f}) "
+                f"and ({e2:.6f},{x2:.6f})"
+            )
+
+    def test_proxy_passes_non_callable_attributes_through(self, fpga_instance):
+        """State-only attributes don't hit the lock — they're plain
+        lookups on the underlying object."""
+        # DummyFpga sets ``snap_ip`` as a plain attribute.
+        assert fpga_instance.fpga.snap_ip == fpga_instance.fpga._fpga.snap_ip
+
+
+class TestInputSnapSelCache:
+    """``Input.get_adc_snapshot`` caches the ``snap_sel`` listdev
+    dispatch instead of probing the FPGA on every call. Saves one UDP
+    roundtrip per antenna per snapshot tick (six per tick at standard
+    wiring)."""
+
+    def test_listdev_called_once_across_many_snapshots(self, fpga_instance):
+        """Calling ``get_adc_snapshot`` repeatedly hits ``listdev``
+        exactly once."""
+        # The Dummy doesn't seed snapshot_bram, but ``get_adc_snapshot``
+        # works regardless because DummyFpga.read returns a fixed-fill
+        # bytestring of the requested size.
+        with patch.object(
+            fpga_instance.inp,
+            "listdev",
+            wraps=fpga_instance.inp.listdev,
+        ) as listdev_spy:
+            for ant in range(3):
+                fpga_instance.inp.get_adc_snapshot(ant)
+
+        assert listdev_spy.call_count == 1
+
+    def test_cache_initially_unset(self, fpga_instance):
+        """The cache is lazy — fresh ``Input`` has no decision yet."""
+        # Build a fresh fpga so we can inspect the cache before any
+        # ``get_adc_snapshot`` runs.
+        fresh = DummyEigsepFpga(program=False)
+        assert fresh.inp._has_snap_sel is None


### PR DESCRIPTION
## Summary

- The intermittent \"missing register\" errors from \`_publish_adc_snapshot\` / \`_publish_adc_stats\` are TAPCP transport races, not real bitstream issues: \`casperfpga.transport_tapcp\` wraps a single tftpy context with no locking, so when the corr poll thread and the snapshot/stats publishers share one \`CasperFpga\`, UDP packets interleave and one side gets \`RuntimeError(\"Failed to read ... from register X\")\` even though X exists.
- Wraps the raw fpga in \`_FpgaLockProxy\` so every block call and every direct \`self.fpga.*\` call serializes on a shared \`threading.Lock\`. Caches \`Input._has_snap_sel\` so dispatch hits the FPGA once per run instead of once per antenna per snapshot tick.
- Defaults \`adc_snapshot_period_s\` to \`0\` because the snapshot publisher has never been load-tested against a real SNAP; production keeps the snapshot thread off until the new \`scripts/adc_snapshot_bench.py\` validates the loaded path. With snapshot off, the lock is uncontended (~100 ns per acquire) and the corr loop is unaffected.

## Test plan

- [x] \`pytest tests/test_fpga.py tests/test_adc.py -x\` passes (69 tests, including 6 new ones in \`TestFpgaLockProxy\` / \`TestInputSnapSelCache\`).
- [x] \`ruff check\` and \`ruff format --check\` clean.
- [ ] Run \`scripts/adc_snapshot_bench.py --snap-ip <ip> --duration 1800 --snapshot-period 0 --out baseline.npz\` against the deployment SNAP.
- [ ] Run the same with \`--snapshot-period 1.0 --out loaded.npz\`.
- [ ] Compare against the acceptance bar (loaded \`corr_acc_cnt\` p99 ≤ ~2x baseline, lock-wait p99 ≤ 30 ms, zero \`Missed N integration(s)\` / \`FAILED to complete\` / \`Disabling adc_*_publisher\` warnings).
- [ ] If the bench passes, open a follow-up PR flipping \`adc_snapshot_period_s\` to a nonzero value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)