### PR TITLE
fix(io): strict float check in _validate_metadata

### DIFF
--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -764,7 +764,14 @@ def _validate_metadata(entry, schema):
             continue
         expected = schema[key]
         if expected is float:
-            ok = isinstance(val, (int, float)) and not isinstance(val, bool)
+            # Strict float check matches `_avg_sensor_values`, which
+            # rejects ints at reduction time. If the validator were
+            # lenient (`isinstance(val, (int, float))`) an int-emitting
+            # producer would pass validation silently and then be
+            # dropped to None by the float reducer — silent data loss.
+            # Keep them aligned so contract drift surfaces as a
+            # WARNING here, not a None at write time.
+            ok = isinstance(val, float) and not isinstance(val, bool)
         elif expected is int:
             ok = isinstance(val, int) and not isinstance(val, bool)
         else:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1737,9 +1737,15 @@ def test_validate_metadata():
     none_entry = {**valid, "distance_m": None}
     assert io._validate_metadata(none_entry, schema) == []
 
-    # int accepted for float field
+    # int rejected for float field — the validator's strictness mirrors
+    # `_avg_sensor_values`, which drops ints to None at reduction time.
+    # Flagging here surfaces producer drift as a WARNING in
+    # `avg_metadata` instead of silent data loss in the file.
     int_entry = {**valid, "distance_m": 2}
-    assert io._validate_metadata(int_entry, schema) == []
+    violations = io._validate_metadata(int_entry, schema)
+    assert len(violations) == 1
+    assert "expected float" in violations[0]
+    assert "got int" in violations[0]
 
     # missing key
     missing = {k: v for k, v in valid.items() if k != "distance_m"}


### PR DESCRIPTION
## Summary

Follow-up to #89. Aligns `_validate_metadata` with `_avg_sensor_values` so the validator and reducer agree on what "float schema field" means.

## Why

Today the two layers disagree:

- `_validate_metadata` (io.py:766) — lenient: `isinstance(val, (int, float))` accepts int for float fields.
- `_avg_sensor_values` (io.py:1231) — strict: `isinstance(s, float)` rejects int.

A producer that emits int for a `float` schema field passes validation silently, then gets dropped to `None` by the reducer with no log line. That's the silent-data-loss window flagged on the #89 review. The reducer's own comment already invokes "producer contract violation" — it's catching what the validator should have caught.

This PR makes the validator strict to match the reducer. An int-on-float now trips the existing per-violation `WARNING` path in `avg_metadata` instead of producing a quiet `None` in the saved file.

## Why this isn't load-bearing for #89

#89's contract test (`_motor_post_handler_reading`) already asserts `isinstance(value, float)` post-handler, so the silent-None scenario is structurally prevented at CI for the motor sensor specifically. This PR closes the same gap for *every* current and future float-schema field by tightening the runtime validator — defense in depth, with the contract test as the primary CI gate.

## Test plan

- [x] `pytest tests/test_io.py src/eigsep_observing/contract_tests/test_producer_contracts.py` — 88 passed locally.
- [x] Updated `test_validate_metadata` to assert int now produces a violation (was previously asserting int passes).

## Base branch

Targets `fix/motor-schema` so the diff stays scoped to the validator change. Will auto-retarget to `main` when #89 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)