### PR TITLE
fix(fpga): align adc_stats sensor_name with schema key

### DIFF
--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -226,6 +226,17 @@ def test_every_schema_has_conforming_emulator(sensor_name):
         f"in this sensor is caught by CI."
     )
     reading = SENSOR_EMULATORS[sensor_name]()
+    # Consumer dispatch in `avg_metadata` keys SENSOR_SCHEMAS by the
+    # producer-emitted ``sensor_name`` field, not by the stream name.
+    # If the producer drifts away from the schema key, validation is
+    # silently skipped — surfacing only as the "No schema for sensor X"
+    # warning at runtime. Pin the convention here so the mismatch
+    # fails CI loudly instead.
+    assert reading.get("sensor_name") == sensor_name, (
+        f"Producer for '{sensor_name}' emits sensor_name="
+        f"{reading.get('sensor_name')!r}; consumer dispatch keys on "
+        f"this value, so a mismatch causes silent validation skip."
+    )
     violations = io._validate_metadata(reading, io.SENSOR_SCHEMAS[sensor_name])
     assert violations == [], f"{sensor_name} producer drift: {violations}"
 

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -1022,7 +1022,7 @@ class EigsepFpga:
             return
         try:
             means, powers, rmss = self.inp.get_stats(sum_cores=False)
-            payload = {"sensor_name": "adc", "status": "update"}
+            payload = {"sensor_name": "adc_stats", "status": "update"}
             # get_stats returns 12 values where indices 2N and 2N+1 are
             # the interleaved ADC cores of snap input N. Label with the
             # same input index the corr file uses for autos.

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -107,7 +107,7 @@ class TestAdcStatsSchemaReduction:
     mirror what ``EigsepFpga._publish_adc_stats`` actually emits."""
 
     def _sample(self, rms_offset=0.0, status="update"):
-        out = {"sensor_name": "adc", "status": status}
+        out = {"sensor_name": "adc_stats", "status": status}
         for i in range(12):
             n, c = i // 2, i % 2
             out[f"input{n}_core{c}_mean"] = 0.01 + 0.001 * i
@@ -120,7 +120,7 @@ class TestAdcStatsSchemaReduction:
         samples = [self._sample(rms_offset=o) for o in (0.0, 2.0, 4.0)]
         avg = io._avg_sensor_values(samples, schema=schema)
         assert avg["status"] == "update"
-        assert avg["sensor_name"] == "adc"
+        assert avg["sensor_name"] == "adc_stats"
         for i in range(12):
             n, c = i // 2, i % 2
             # power mean over (10+i, 12+i, 14+i) is 12+i
@@ -154,7 +154,7 @@ class TestPublishAdcStats:
         raw = fpga.transport.r.hget("metadata", "adc_stats")
         assert raw is not None
         payload = json.loads(raw)
-        assert payload["sensor_name"] == "adc"
+        assert payload["sensor_name"] == "adc_stats"
         assert payload["status"] == "update"
         for i in range(12):
             n, c = i // 2, i % 2


### PR DESCRIPTION
## Summary
- `_publish_adc_stats` emitted `sensor_name="adc"` while `SENSOR_SCHEMAS` is keyed `"adc_stats"`. Consumer dispatch in `_avg_metadata` keys on `sensor_name`, so lookups missed and a `WARNING:eigsep_observing.io:No schema for sensor 'adc'; skipping validation` fired once per integration. Aligns the producer with the existing convention `sensor_name == stream_name == schema_key` (used by every other producer).
- Closes the contract-test gap that let it slip past CI: `test_every_schema_has_conforming_emulator` now asserts `reading["sensor_name"] == sensor_name`. Type-only validation passed because `"adc"` is a `str`, but dispatch keys on the *value*, not the type.
- Same surface as the motor schema gap fixed in d3e7b26 (silent no-schema branch on a real producer), but a key-mismatch flavor instead of a missing entry.

## Test plan
- [x] `pytest tests/test_adc.py src/eigsep_observing/contract_tests/test_producer_contracts.py` — 35 passed
- [x] Verified the new contract-test guard catches the original bug: locally reverted just `fpga.py:1025`, re-ran the contract test, confirmed it fails with `Producer for 'adc_stats' emits sensor_name='adc'; consumer dispatch keys on this value...`
- [x] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)