### PR TITLE
feat(live-status): add VNA S11 pane with ideal-OSL calibration

### DIFF
--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -57,8 +57,10 @@ from ..io import RFSWITCH_TRANSITION_WINDOW_S, reshape_data
 from ..run_tag import read as read_run_tag
 from ..snap_reinit import read as read_snap_reinit
 from ..utils import calc_freqs_dfreq
+from ..vna import VnaReader
 from .signals import SIGNAL_REGISTRY
 from .thresholds import Thresholds
+from .vna_calibration import VnaCache
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +71,13 @@ STATUS_LOG_MAXLEN = 500
 # full name.
 _ADC_STATS_KEY = "adc_stats"
 _ADC_STATS_STREAM = f"stream:{_ADC_STATS_KEY}"
+
+# VnaReader.read blocks inside Redis xread for at most this long per
+# call. Longer = lower CPU between sweeps, but stop_event observation
+# slows correspondingly (the drain wakes for the stop check at most
+# every _VNA_BLOCK_S). 1.0 s is a comfortable middle ground for a
+# ~1/hour producer.
+_VNA_BLOCK_S = 1.0
 
 
 @dataclass
@@ -125,6 +134,14 @@ class StateSnapshot:
     last_rfnon_pairs: Optional[dict[str, np.ndarray]] = None
     last_rfnon_unix: Optional[float] = None
     last_rfnon_acc_cnt: Optional[int] = None
+
+    # Most recent VNA payload, cached per-mode. The route handler
+    # calibrates lazily off these (see live_status/vna_calibration.py)
+    # so the drain thread doesn't pay the calkit cost when nobody's
+    # rendering the pane. ``ant`` and ``rec`` evict independently, so
+    # the operator can flip between them without losing the other view.
+    last_vna_ant: Optional[VnaCache] = None
+    last_vna_rec: Optional[VnaCache] = None
 
     # Panda status log (ring buffer).
     status_log: deque = field(
@@ -232,6 +249,7 @@ class LiveStatusAggregator:
         self.metadata_snapshot = MetadataSnapshotReader(transport_panda)
         self.status_reader = StatusReader(transport_panda)
         self.heartbeat_reader = HeartbeatReader(transport_panda)
+        self.vna_reader = VnaReader(transport_panda)
 
         self.state = StateSnapshot()
         self._lock = threading.Lock()
@@ -251,12 +269,17 @@ class LiveStatusAggregator:
 
         self._snap_thread: Optional[threading.Thread] = None
         self._panda_thread: Optional[threading.Thread] = None
+        self._vna_thread: Optional[threading.Thread] = None
 
     # -- lifecycle -------------------------------------------------
 
     def start(self) -> None:
-        """Start both drain threads."""
-        if self._snap_thread is not None or self._panda_thread is not None:
+        """Start the drain threads."""
+        if (
+            self._snap_thread is not None
+            or self._panda_thread is not None
+            or self._vna_thread is not None
+        ):
             raise RuntimeError("LiveStatusAggregator already started")
         self._snap_thread = threading.Thread(
             target=self._snap_loop,
@@ -268,8 +291,18 @@ class LiveStatusAggregator:
             name="live-status-panda-drain",
             daemon=True,
         )
+        # VNA writes are ~1/hour. A dedicated thread blocks inside
+        # Redis xread for ``_VNA_BLOCK_S`` between checks of the stop
+        # event, so a triggered measurement surfaces in the dashboard
+        # within ~1 s of arrival without polling cost between sweeps.
+        self._vna_thread = threading.Thread(
+            target=self._vna_loop,
+            name="live-status-vna-drain",
+            daemon=True,
+        )
         self._snap_thread.start()
         self._panda_thread.start()
+        self._vna_thread.start()
 
     def stop(self, timeout: float = 2.0) -> None:
         """Signal both threads to exit and join with a finite timeout.
@@ -280,7 +313,7 @@ class LiveStatusAggregator:
         subsequent ``stop()`` will re-attempt the join.
         """
         self._stop_event.set()
-        for attr in ("_snap_thread", "_panda_thread"):
+        for attr in ("_snap_thread", "_panda_thread", "_vna_thread"):
             thread = getattr(self, attr)
             if thread is None:
                 continue
@@ -746,6 +779,128 @@ class LiveStatusAggregator:
             out.append((level, msg))
         return out, True
 
+    # -- VNA drain loop --------------------------------------------
+
+    def _vna_loop(self) -> None:
+        """Block on the VNA stream; cache by mode when an entry arrives.
+
+        VNA cadence is ~1/hour, so this thread spends almost all its
+        wallclock parked inside ``VnaReader.read`` and only does work
+        when ``PandaClient.measure_s11`` actually publishes.
+        """
+        while not self._stop_event.is_set():
+            try:
+                self._vna_tick()
+            except Exception as exc:  # pragma: no cover - diagnostic
+                logger.error("VNA drain tick failed: %s", exc)
+                # No connectivity flag for VNA: it shares the panda
+                # transport, so panda_connected already covers the
+                # underlying bus. Sleep on the stop event to avoid a
+                # tight retry loop on a persistent error.
+                self._stop_event.wait(self._panda_tick_s)
+
+    def _vna_tick(self) -> None:
+        """Single drain step: one blocking read, one cache write."""
+        try:
+            data, header, _metadata = self.vna_reader.read(
+                timeout=_VNA_BLOCK_S
+            )
+        except TimeoutError:
+            return
+        except RedisError as exc:
+            logger.error("vna_reader.read transport failure: %s", exc)
+            self._stop_event.wait(self._panda_tick_s)
+            return
+        if data is None:
+            # VnaReader.read returns (None, None, None) when the stream
+            # hasn't been registered yet (no producer has written).
+            # That's normal startup; back off briefly to avoid spinning.
+            self._stop_event.wait(self._panda_tick_s)
+            return
+
+        # The producer's contract pins ``header['mode']`` to exactly
+        # "ant" or "rec" (PandaClient.measure_s11). Anything else is a
+        # producer bug or a stream cross-talk; log loudly and drop the
+        # entry rather than caching it under a guessed slot.
+        mode = (header or {}).get("mode")
+        if mode not in ("ant", "rec"):
+            logger.error(
+                "VNA payload arrived with unexpected mode=%r; "
+                "dropping. Producer contract: header['mode'] must be "
+                "'ant' or 'rec'.",
+                mode,
+            )
+            return
+
+        cache = self._build_vna_cache(data, header)
+        if cache is None:
+            return
+        with self._lock:
+            if mode == "ant":
+                self.state.last_vna_ant = cache
+            else:
+                self.state.last_vna_rec = cache
+
+    @staticmethod
+    def _build_vna_cache(
+        data: dict[str, np.ndarray], header: dict
+    ) -> Optional[VnaCache]:
+        """Project a raw VNA stream entry into a :class:`VnaCache`.
+
+        Caller must have already validated ``header['mode']`` is
+        ``"ant"`` or ``"rec"``. Returns ``None`` (and logs at ERROR)
+        on any further contract violation — missing data keys, missing
+        ``freqs`` — so the corr / metadata panes keep painting even
+        when the VNA producer publishes garbage.
+        """
+        dut_key = header["mode"]
+        try:
+            raw_s11 = data[dut_key]
+            cal_o = data["cal:VNAO"]
+            cal_s = data["cal:VNAS"]
+            cal_l = data["cal:VNAL"]
+        except KeyError as exc:
+            logger.error(
+                "VNA payload missing required key %s; dropping entry. "
+                "Producer contract: data must include %r and "
+                "cal:VNAO/VNAS/VNAL.",
+                exc,
+                dut_key,
+            )
+            return None
+        freqs_raw = header.get("freqs")
+        if freqs_raw is None:
+            logger.error(
+                "VNA header missing 'freqs'; dropping entry. Producer "
+                "contract: header must include the frequency axis."
+            )
+            return None
+        freqs = np.asarray(freqs_raw, dtype=float)
+        try:
+            metadata_snapshot_unix = (
+                float(header["metadata_snapshot_unix"])
+                if "metadata_snapshot_unix" in header
+                else None
+            )
+        except (TypeError, ValueError) as exc:
+            logger.error(
+                "VNA header has unparseable metadata_snapshot_unix=%r "
+                "(%s); dropping field. Producer contract: when present, "
+                "the value must be a float-castable wallclock seconds.",
+                header.get("metadata_snapshot_unix"),
+                exc,
+            )
+            metadata_snapshot_unix = None
+        return VnaCache(
+            freqs=freqs,
+            raw_s11=np.asarray(raw_s11),
+            cal_o=np.asarray(cal_o),
+            cal_s=np.asarray(cal_s),
+            cal_l=np.asarray(cal_l),
+            received_unix=time.time(),
+            metadata_snapshot_unix=metadata_snapshot_unix,
+        )
+
     # -- error-swallowing helpers ----------------------------------
 
     @staticmethod
@@ -800,6 +955,7 @@ class LiveStatusAggregator:
             "metadata_snapshot",
             "status_reader",
             "heartbeat_reader",
+            "vna_reader",
             "thresholds",
             "state",
         }

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -29,6 +29,7 @@ from .calibration import (
 )
 from .signals import enabled_signals
 from .thresholds import Thresholds
+from .vna_calibration import VnaCache, calibrate_s11
 
 
 logger = logging.getLogger(__name__)
@@ -417,6 +418,79 @@ def _status_payload(state: StateSnapshot) -> list:
     return list(state.status_log)
 
 
+# A VNA measurement that's older than this is flagged ``stale`` in the
+# /api/vna response. The producer cadence is ~1/hour; 1.5× gives one
+# missed sweep of slack before the dashboard turns the bar red.
+_VNA_STALE_AGE_S = 5400.0
+
+
+def _vna_payload(state: StateSnapshot, mode: str, now: float) -> dict:
+    """Calibrated VNA pane payload for ``mode in {"ant", "rec"}``.
+
+    Calibration is computed lazily here so the drain thread never pays
+    the calkit cost when the pane isn't visible. A failure of the cal
+    math (NaN OSL, unequal shapes, cmt_vna raising) logs at ERROR and
+    surfaces ``available=false`` to the front-end — corr / metadata
+    panes stay unaffected.
+    """
+    if mode not in ("ant", "rec"):
+        return {
+            "available": False,
+            "mode": mode,
+            "reason": f"unknown mode {mode!r}",
+        }
+    cache: Optional[VnaCache] = (
+        state.last_vna_ant if mode == "ant" else state.last_vna_rec
+    )
+    if cache is None:
+        return {
+            "available": False,
+            "mode": mode,
+            "reason": "no measurement received yet",
+        }
+    age_s = max(0.0, now - cache.received_unix)
+    try:
+        cal = calibrate_s11(
+            cache.raw_s11, cache.cal_o, cache.cal_s, cache.cal_l
+        )
+    except (ValueError, np.linalg.LinAlgError) as exc:
+        logger.error(
+            "Live-status VNA cal failed for mode=%r (received_unix=%s): "
+            "%s. Producer-side payload likely violated the cmt_vna "
+            "calibration contract; check cal:VNAO/VNAS/VNAL shapes "
+            "and finiteness.",
+            mode,
+            cache.received_unix,
+            exc,
+        )
+        return {
+            "available": False,
+            "mode": mode,
+            "reason": "calibration_failed",
+            "age_s": age_s,
+        }
+    mag = np.abs(cal)
+    # Replace zeros with NaN so log10 returns NaN (a hole in the plot)
+    # rather than -inf (which Plotly renders as a spike to the bottom
+    # of the axis).
+    with np.errstate(divide="ignore", invalid="ignore"):
+        mag_safe = np.where(mag > 0, mag, np.nan)
+        s11_db = 20.0 * np.log10(mag_safe)
+    # Drop non-finite values to None so JSON encodes them as null —
+    # plotly draws a gap rather than crashing on NaN/Inf.
+    s11_db_list = [float(v) if np.isfinite(v) else None for v in s11_db]
+    freqs_mhz = (cache.freqs * 1e-6).tolist()
+    return {
+        "available": True,
+        "mode": mode,
+        "freqs_mhz": freqs_mhz,
+        "s11_db": s11_db_list,
+        "age_s": age_s,
+        "stale": age_s > _VNA_STALE_AGE_S,
+        "metadata_snapshot_unix": cache.metadata_snapshot_unix,
+    }
+
+
 def _corr_observing_timeout_s(state: StateSnapshot) -> float:
     """Infer a reasonable observing-idle timeout from corr cadence.
 
@@ -563,6 +637,12 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
     def api_status():
         state = aggregator.snapshot()
         return jsonify(_envelope(_status_payload(state)))
+
+    @app.route("/api/vna")
+    def api_vna():
+        state = aggregator.snapshot()
+        mode = request.args.get("mode", "ant")
+        return jsonify(_envelope(_vna_payload(state, mode, time.time())))
 
     @app.route("/api/config")
     def api_config():

--- a/src/eigsep_observing/live_status/static/css/dashboard.css
+++ b/src/eigsep_observing/live_status/static/css/dashboard.css
@@ -127,3 +127,41 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
 
 #status-log li.level-30 { color: var(--warn); }
 #status-log li.level-40 { color: var(--danger); }
+
+/* VNA pane: card-header lays out the title and the mode toggle on
+   one row so the toggle doesn't push the plot down. */
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.card-header h2 { margin: 0; }
+
+.vna-mode-toggle { display: inline-flex; gap: 4px; }
+
+.vna-mode-btn {
+  background: var(--card);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.vna-mode-btn.active {
+  background: var(--ok);
+  color: #fff;
+  border-color: var(--ok);
+}
+
+.vna-status {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.vna-status.stale { color: var(--warn); }
+.vna-status.error { color: var(--danger); }

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -3,6 +3,7 @@
 const POLL_MS = 1000;
 const WIRING_TOGGLE_KEY = "eigsep.useWiringLabels";
 const CALIBRATED_TOGGLE_KEY = "eigsep.useCalibrated";
+const VNA_MODE_KEY = "eigsep.vnaMode";
 
 // Wiring-labels toggle. Persisted in localStorage so the user's
 // choice survives reloads; gracefully no-ops when no labels are
@@ -36,6 +37,26 @@ function getUseCalibrated() {
 function setUseCalibrated(on) {
   try {
     localStorage.setItem(CALIBRATED_TOGGLE_KEY, on ? "1" : "0");
+  } catch (e) {
+    // see setUseWiringLabels
+  }
+}
+
+// VNA pane mode (antenna or receiver). Persisted so the operator's
+// choice survives reloads. Defaults to "ant" — that's the
+// science-interesting one.
+function getVnaMode() {
+  try {
+    const v = localStorage.getItem(VNA_MODE_KEY);
+    return v === "rec" ? "rec" : "ant";
+  } catch (e) {
+    return "ant";
+  }
+}
+
+function setVnaMode(mode) {
+  try {
+    localStorage.setItem(VNA_MODE_KEY, mode === "rec" ? "rec" : "ant");
   } catch (e) {
     // see setUseWiringLabels
   }
@@ -232,6 +253,85 @@ function updateCorr(corr) {
     }
   }
   renderCalibrationBar(corr.calibration_meta);
+}
+
+// ---- vna ------------------------------------------------------------
+
+const vnaLayout = {
+  margin: { l: 50, r: 20, t: 10, b: 40 },
+  paper_bgcolor: "#1a1a1a",
+  plot_bgcolor: "#111",
+  font: { color: "#eee" },
+  xaxis: { title: "Frequency [MHz]", gridcolor: "#333" },
+  yaxis: {
+    title: "|S11| [dB]",
+    autorange: true,
+    gridcolor: "#333",
+  },
+  showlegend: false,
+};
+
+let vnaPlotInitialized = false;
+
+function renderVnaStatus(vna) {
+  const el = document.getElementById("vna-status");
+  if (!el) return;
+  if (!vna) {
+    el.className = "vna-status error";
+    el.textContent = "VNA pane unavailable.";
+    return;
+  }
+  if (!vna.available) {
+    el.className = "vna-status";
+    if (vna.reason === "calibration_failed") {
+      el.className = "vna-status error";
+      el.textContent =
+        `Calibration failed for ${vna.mode}. Check server logs and ` +
+        "OSL standards.";
+    } else if (vna.reason === "no measurement received yet") {
+      el.textContent = `No ${vna.mode} measurement received yet.`;
+    } else {
+      el.textContent = `No data: ${vna.reason || "unknown"}.`;
+    }
+    return;
+  }
+  const ageStr = fmtDuration(vna.age_s);
+  const modeLabel = vna.mode === "ant" ? "Antenna" : "Receiver";
+  if (vna.stale) {
+    el.className = "vna-status stale";
+    el.textContent =
+      `${modeLabel} S11 — ${ageStr} old (stale; producer cadence is ~1/hour).`;
+  } else {
+    el.className = "vna-status";
+    el.textContent = `${modeLabel} S11 — ${ageStr} old.`;
+  }
+}
+
+function updateVna(vna) {
+  renderVnaStatus(vna);
+  if (!vna || !vna.available) {
+    // Clear the plot so the operator doesn't see a stale trace under
+    // an "unavailable" status banner.
+    if (vnaPlotInitialized) {
+      Plotly.react("plot-vna", [], vnaLayout, { displayModeBar: false });
+    }
+    return;
+  }
+  const traces = [
+    {
+      x: vna.freqs_mhz,
+      y: vna.s11_db,
+      type: "scatter",
+      mode: "lines",
+      line: { width: 1.5 },
+    },
+  ];
+  if (!vnaPlotInitialized) {
+    Plotly.newPlot("plot-vna", traces, vnaLayout, { displayModeBar: false });
+    vnaPlotInitialized = true;
+  } else {
+    Plotly.react("plot-vna", traces, vnaLayout, { displayModeBar: false });
+  }
 }
 
 // ---- health --------------------------------------------------------
@@ -431,7 +531,8 @@ let lastAdc = null;
 async function tick() {
   try {
     const corrPath = getUseCalibrated() ? "/api/corr?calibrated=1" : "/api/corr";
-    const [health, corr, metadata, adc, rfswitch, file, status] = await Promise.all([
+    const vnaPath = `/api/vna?mode=${encodeURIComponent(getVnaMode())}`;
+    const [health, corr, metadata, adc, rfswitch, file, status, vna] = await Promise.all([
       fetchJson("/api/health"),
       fetchJson(corrPath),
       fetchJson("/api/metadata"),
@@ -439,6 +540,7 @@ async function tick() {
       fetchJson("/api/rfswitch"),
       fetchJson("/api/file"),
       fetchJson("/api/status"),
+      fetchJson(vnaPath),
     ]);
     lastCorr = corr.data;
     lastAdc = adc.data;
@@ -449,6 +551,7 @@ async function tick() {
     renderAdcTiles(adc.data);
     renderRfswitch(rfswitch.data);
     renderStatusLog(status.data);
+    updateVna(vna.data);
   } catch (e) {
     console.error("poll failed:", e);
   }
@@ -477,7 +580,28 @@ function initCalibratedToggle() {
   });
 }
 
+function initVnaModeToggle() {
+  const buttons = document.querySelectorAll(".vna-mode-btn");
+  if (!buttons.length) return;
+  const apply = (mode) => {
+    for (const btn of buttons) {
+      btn.classList.toggle("active", btn.dataset.vnaMode === mode);
+    }
+  };
+  apply(getVnaMode());
+  for (const btn of buttons) {
+    btn.addEventListener("click", () => {
+      const mode = btn.dataset.vnaMode === "rec" ? "rec" : "ant";
+      setVnaMode(mode);
+      apply(mode);
+      // Refetch immediately so the swap doesn't wait for the next poll.
+      tick();
+    });
+  }
+}
+
 initWiringToggle();
 initCalibratedToggle();
+initVnaModeToggle();
 tick();
 setInterval(tick, POLL_MS);

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -35,6 +35,18 @@
     <div id="plot-phase" class="plot"></div>
   </section>
 
+  <section class="card wide">
+    <div class="card-header">
+      <h2>VNA S11 (ideal-OSL calibrated)</h2>
+      <div class="vna-mode-toggle" role="group" aria-label="VNA mode">
+        <button type="button" class="vna-mode-btn active" data-vna-mode="ant" aria-pressed="true">Antenna</button>
+        <button type="button" class="vna-mode-btn" data-vna-mode="rec" aria-pressed="false">Receiver</button>
+      </div>
+    </div>
+    <div id="vna-status" class="vna-status">No measurement yet.</div>
+    <div id="plot-vna" class="plot"></div>
+  </section>
+
   <section class="card">
     <h2>RF switch</h2>
     <div id="rfswitch"></div>

--- a/src/eigsep_observing/live_status/vna_calibration.py
+++ b/src/eigsep_observing/live_status/vna_calibration.py
@@ -1,0 +1,92 @@
+"""Field-grade OSL calibration for the live-status VNA pane.
+
+The deployed system uses generic SMA open / short / load caps as
+calibration standards, not the metrology-grade S911T calkit that
+:class:`cmt_vna.calkit.S911T` models. We therefore assume **ideal**
+reflection coefficients — ``+1`` open, ``-1`` short, ``0`` load — and
+accept the systematic error that introduces. The dashboard is a
+quick-look monitor; lab post-processing on the saved ``.h5`` files
+re-applies a precise calkit model when needed.
+
+Pure numpy / cmt_vna primitives. No Redis, no Flask, no aggregator —
+the route handler in ``app.py`` and the cache in ``aggregator.py`` are
+the only callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from cmt_vna.calkit import de_embed_sparams, network_sparams
+
+
+@dataclass(frozen=True)
+class VnaCache:
+    """Most recent VNA payload of one mode (``"ant"`` or ``"rec"``).
+
+    Holds exactly what the route handler needs to (a) calibrate the
+    measurement on demand and (b) display its age. Stored as a frozen
+    dataclass so the aggregator's snapshot lock can hand a reference to
+    a Flask handler without copying — the arrays themselves are never
+    mutated in place after a write.
+    """
+
+    freqs: np.ndarray  # (Nfreq,) float, Hz
+    raw_s11: np.ndarray  # (Nfreq,) complex, the DUT trace
+    cal_o: np.ndarray  # (Nfreq,) complex, raw OSL Open
+    cal_s: np.ndarray  # (Nfreq,) complex, raw OSL Short
+    cal_l: np.ndarray  # (Nfreq,) complex, raw OSL Load
+    received_unix: float  # wallclock at which this entry was drained
+    metadata_snapshot_unix: Optional[float]  # producer's trigger time
+
+
+def calibrate_s11(
+    raw_s11: np.ndarray,
+    cal_o: np.ndarray,
+    cal_s: np.ndarray,
+    cal_l: np.ndarray,
+) -> np.ndarray:
+    """Apply ideal-OSL calibration to a raw DUT S11 trace.
+
+    Builds the one-port error model from the measured OSL standards
+    against ideal ``[+1, -1, 0]`` reference reflections, then de-embeds
+    the network from ``raw_s11``. All input arrays must share the same
+    ``(Nfreq,)`` shape.
+
+    Returns the calibrated complex S11 at the OSL reference plane.
+    """
+    raw = np.asarray(raw_s11, dtype=complex)
+    open_ = np.asarray(cal_o, dtype=complex)
+    short = np.asarray(cal_s, dtype=complex)
+    load = np.asarray(cal_l, dtype=complex)
+
+    if not (raw.ndim == open_.ndim == short.ndim == load.ndim == 1):
+        raise ValueError(
+            "calibrate_s11: raw_s11 and OSL standards must all be 1-D; "
+            "got "
+            f"raw ndim={raw.ndim}, shape={raw.shape}, "
+            f"O ndim={open_.ndim}, shape={open_.shape}, "
+            f"S ndim={short.ndim}, shape={short.shape}, "
+            f"L ndim={load.ndim}, shape={load.shape}"
+        )
+
+    n = raw.shape[0]
+    if not (open_.shape == short.shape == load.shape == (n,)):
+        raise ValueError(
+            "calibrate_s11: raw_s11 and OSL standards must share "
+            "length; got "
+            f"raw={raw.shape}, O={open_.shape}, "
+            f"S={short.shape}, L={load.shape}"
+        )
+    gamma_true = np.stack(
+        [
+            np.ones(n, dtype=complex),
+            -np.ones(n, dtype=complex),
+            np.zeros(n, dtype=complex),
+        ]
+    )
+    gamma_meas = np.stack([open_, short, load])
+    sprms = network_sparams(gamma_true, gamma_meas)
+    return de_embed_sparams(sprms, raw)

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -27,6 +27,7 @@ from eigsep_observing.live_status import (
     create_app,
 )
 from eigsep_observing.live_status.app import _solve_calibration
+from eigsep_observing.vna import VnaWriter
 
 
 NCHAN = 1024
@@ -819,6 +820,197 @@ def test_solve_calibration_logs_error_on_compute_gain_trx_failure(
         "compute_gain_trx failed" in r.message and r.levelname == "ERROR"
         for r in caplog.records
     )
+
+
+# ---- VNA pane -------------------------------------------------------
+
+
+# Smaller than the production sweep (npoints=1000 in
+# config/dummy_config.yaml) to keep these route tests fast — the
+# calibration math is shape-agnostic and tested independently in
+# test_live_status_vna_calibration.py.
+_VNA_NFREQ = 32
+
+
+def _publish_vna(
+    transport,
+    mode,
+    *,
+    raw_s11=None,
+    cal_o=None,
+    cal_s=None,
+    cal_l=None,
+    metadata_snapshot_unix=None,
+):
+    """Publish one synthetic VNA entry to the given transport.
+
+    Defaults model a no-error VNA: ideal OSL standards (+1, -1, 0) and
+    a constant raw S11 of 0.3+0j across the band. With those, the
+    calibrated output equals the input — which is what the route's
+    s11_db assertion exploits.
+    """
+    if raw_s11 is None:
+        raw_s11 = np.full(_VNA_NFREQ, 0.3 + 0.0j, dtype=complex)
+    if cal_o is None:
+        cal_o = np.ones(_VNA_NFREQ, dtype=complex)
+    if cal_s is None:
+        cal_s = -np.ones(_VNA_NFREQ, dtype=complex)
+    if cal_l is None:
+        cal_l = np.zeros(_VNA_NFREQ, dtype=complex)
+    if metadata_snapshot_unix is None:
+        metadata_snapshot_unix = time.time()
+
+    data = {
+        mode: raw_s11,
+        "cal:VNAO": cal_o,
+        "cal:VNAS": cal_s,
+        "cal:VNAL": cal_l,
+    }
+    header = {
+        "mode": mode,
+        "freqs": np.linspace(50e6, 250e6, _VNA_NFREQ).tolist(),
+        "metadata_snapshot_unix": metadata_snapshot_unix,
+    }
+    VnaWriter(transport).add(data, header=header)
+
+
+def test_vna_route_returns_unavailable_before_first_measurement(client):
+    """No VNA writes yet: the pane should render an explicit unavailable
+    payload, not a 500 or a stale trace."""
+    body = client.get("/api/vna?mode=ant").get_json()
+    assert body["ok"] is True
+    assert body["data"]["available"] is False
+    assert body["data"]["mode"] == "ant"
+
+
+def test_vna_route_ant_calibrated_with_ideal_osl(agg_primed):
+    """Publish an ant payload with ideal OSL standards; the route must
+    return calibrated |S11| in dB, computed from the cached entry.
+
+    With the ideal-OSL standards baked into the helper, calibrated
+    output equals the raw DUT, so a flat 0.3 raw S11 must come back as
+    a flat 20*log10(0.3) ≈ -10.46 dB trace.
+    """
+    panda = agg_primed.transport_panda
+    _publish_vna(panda, "ant")
+    _rewind(panda, ["stream:vna"])
+    agg_primed._vna_tick()
+
+    body = client_for(agg_primed).get("/api/vna?mode=ant").get_json()
+    data = body["data"]
+    assert data["available"] is True
+    assert data["mode"] == "ant"
+    assert len(data["s11_db"]) == _VNA_NFREQ
+    assert len(data["freqs_mhz"]) == _VNA_NFREQ
+    expected_db = 20.0 * math.log10(0.3)
+    for v in data["s11_db"]:
+        assert v == pytest.approx(expected_db, rel=1e-9)
+    # Frequency axis converted Hz → MHz.
+    assert data["freqs_mhz"][0] == pytest.approx(50.0)
+    assert data["freqs_mhz"][-1] == pytest.approx(250.0)
+    # Just-published, so not stale.
+    assert data["stale"] is False
+    assert data["age_s"] >= 0.0
+
+
+def test_vna_route_rec_independent_of_ant(agg_primed):
+    """ant and rec caches evict independently. Publishing one mode must
+    not surface the other; publishing both leaves both queryable."""
+    panda = agg_primed.transport_panda
+    _publish_vna(
+        panda,
+        "rec",
+        raw_s11=np.full(_VNA_NFREQ, 0.5 + 0.0j, dtype=complex),
+    )
+    _rewind(panda, ["stream:vna"])
+    agg_primed._vna_tick()
+
+    client = client_for(agg_primed)
+    rec = client.get("/api/vna?mode=rec").get_json()["data"]
+    assert rec["available"] is True
+    assert rec["s11_db"][0] == pytest.approx(20.0 * math.log10(0.5), rel=1e-9)
+
+    ant = client.get("/api/vna?mode=ant").get_json()["data"]
+    assert ant["available"] is False  # ant never published
+
+
+def test_vna_route_unknown_mode_returns_unavailable(client):
+    """Mode is a query param; an unknown value must be a clean
+    'available=false' response, not a 500 or a leaked default."""
+    body = client.get("/api/vna?mode=bogus").get_json()
+    assert body["ok"] is True
+    assert body["data"]["available"] is False
+    assert "unknown mode" in body["data"]["reason"]
+
+
+def test_vna_payload_stale_flag_fires_past_threshold(agg_primed):
+    """Drive _vna_payload directly with a synthetic now far in the
+    future; the stale flag must flip past _VNA_STALE_AGE_S without
+    mutating the underlying cache."""
+    from eigsep_observing.live_status.app import _VNA_STALE_AGE_S, _vna_payload
+
+    panda = agg_primed.transport_panda
+    _publish_vna(panda, "ant")
+    _rewind(panda, ["stream:vna"])
+    agg_primed._vna_tick()
+
+    state = agg_primed.snapshot()
+    received = state.last_vna_ant.received_unix
+    fresh = _vna_payload(state, "ant", now=received + 10.0)
+    assert fresh["stale"] is False
+    stale = _vna_payload(state, "ant", now=received + _VNA_STALE_AGE_S + 60.0)
+    assert stale["stale"] is True
+    assert stale["age_s"] >= _VNA_STALE_AGE_S
+
+
+def test_vna_drain_drops_payload_with_unknown_mode(agg_primed, caplog):
+    """The producer contract pins header['mode'] to 'ant' or 'rec'. An
+    out-of-contract value must log at ERROR and leave the cache empty
+    rather than poisoning either slot with a guessed assignment."""
+    panda = agg_primed.transport_panda
+    _publish_vna(
+        panda,
+        "ant",  # data uses the 'ant' DUT key
+    )
+    # Drain the well-formed entry first so it doesn't satisfy the test.
+    _rewind(panda, ["stream:vna"])
+    agg_primed._vna_tick()
+    # Confirm the well-formed one landed.
+    assert agg_primed.state.last_vna_ant is not None
+    agg_primed.state.last_vna_ant = None  # reset for the violation test
+
+    raw = np.full(_VNA_NFREQ, 0.3 + 0.0j, dtype=complex)
+    bad_data = {
+        "ant": raw,
+        "cal:VNAO": np.ones(_VNA_NFREQ, dtype=complex),
+        "cal:VNAS": -np.ones(_VNA_NFREQ, dtype=complex),
+        "cal:VNAL": np.zeros(_VNA_NFREQ, dtype=complex),
+    }
+    bad_header = {
+        "mode": "WAT",  # contract violation
+        "freqs": np.linspace(50e6, 250e6, _VNA_NFREQ).tolist(),
+        "metadata_snapshot_unix": time.time(),
+    }
+    VnaWriter(panda).add(bad_data, header=bad_header)
+
+    with caplog.at_level(
+        "ERROR", logger="eigsep_observing.live_status.aggregator"
+    ):
+        agg_primed._vna_tick()
+
+    assert agg_primed.state.last_vna_ant is None
+    assert agg_primed.state.last_vna_rec is None
+    assert any(
+        "unexpected mode" in r.message and r.levelname == "ERROR"
+        for r in caplog.records
+    )
+
+
+def client_for(agg):
+    """Helper: build a Flask test_client for a primed aggregator."""
+    app = create_app(agg)
+    app.config.update(TESTING=True)
+    return app.test_client()
 
 
 def test_index_renders_with_aggregator_cfg(client):

--- a/tests/test_live_status_vna_calibration.py
+++ b/tests/test_live_status_vna_calibration.py
@@ -1,0 +1,141 @@
+"""Tests for the live-status ideal-OSL VNA calibration helpers.
+
+The cal is display-only — operator-visible S11 in dB on the live
+dashboard. Field deployment uses generic SMA caps as OSL standards;
+the math here assumes ideal reflection coefficients (+1 / -1 / 0) and
+relies on lab post-processing for precise correction (see
+``vna_calibration.py``).
+
+Round-trip pattern: synthesize a known network and a known DUT, embed
+the DUT through the network, plus measure the OSL standards through
+the same network, then run the calibration and assert we recover the
+DUT trace within tight tolerance.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from cmt_vna.calkit import embed_sparams
+
+from eigsep_observing.live_status.vna_calibration import (
+    VnaCache,
+    calibrate_s11,
+)
+
+
+# Smaller than the production sweep (npoints=1000 in
+# config/dummy_config.yaml) — the math here is shape-agnostic, so a
+# short axis exercises the same code path with cheaper tests.
+NFREQ = 64
+
+
+def _trivial_ideal_osl():
+    """OSL measurements for an *ideal* (no-error) VNA.
+
+    With these standards the cal should reduce to the identity: any
+    DUT trace should pass through ``calibrate_s11`` unchanged.
+    """
+    cal_o = np.ones(NFREQ, dtype=complex)
+    cal_s = -np.ones(NFREQ, dtype=complex)
+    cal_l = np.zeros(NFREQ, dtype=complex)
+    return cal_o, cal_s, cal_l
+
+
+def test_calibrate_s11_ideal_osl_is_identity():
+    """If the OSL standards arrived ideal, calibration must be a no-op.
+
+    Sanity check that pins the math: a system whose error network is
+    truly identity has nothing to de-embed.
+    """
+    raw = np.linspace(0.1, 0.5, NFREQ).astype(complex) * np.exp(
+        1j * np.linspace(0, np.pi / 2, NFREQ)
+    )
+    cal_o, cal_s, cal_l = _trivial_ideal_osl()
+
+    out = calibrate_s11(raw, cal_o, cal_s, cal_l)
+
+    np.testing.assert_allclose(out, raw, atol=1e-12)
+
+
+def test_calibrate_s11_recovers_dut_through_known_network():
+    """Round-trip: embed a known DUT through a known error network,
+    embed the ideal standards through the same network, calibrate.
+
+    The de-embed is just the inverse of the embed; with the OSL
+    standards measured through the same path, we should recover the
+    intrinsic DUT to numerical precision.
+    """
+    # A non-trivial 3-vector S-parameter set per frequency, varying
+    # across the band so any frequency-axis-mixup would surface as a
+    # mismatch rather than a constant offset.
+    f_norm = np.linspace(0, 1, NFREQ)
+    s11_e = (0.05 + 0.03j) * (1 + 0.1 * f_norm)
+    s12s21_e = (0.9 + 0.05j) * (1 - 0.05 * f_norm)
+    s22_e = (-0.02 + 0.04j) * (1 + 0.2 * f_norm)
+    sparams = np.stack([s11_e, s12s21_e, s22_e])  # (3, NFREQ)
+
+    # Ideal standards at the antenna plane.
+    gamma_open = np.ones(NFREQ, dtype=complex)
+    gamma_short = -np.ones(NFREQ, dtype=complex)
+    gamma_load = np.zeros(NFREQ, dtype=complex)
+
+    # What the VNA would have measured for each: embedded through the
+    # error network.
+    cal_o = embed_sparams(sparams, gamma_open)
+    cal_s = embed_sparams(sparams, gamma_short)
+    cal_l = embed_sparams(sparams, gamma_load)
+
+    # A known DUT at the antenna plane, also embedded through the
+    # same network.
+    dut_true = 0.3 * np.exp(1j * np.pi * f_norm)
+    dut_meas = embed_sparams(sparams, dut_true)
+
+    out = calibrate_s11(dut_meas, cal_o, cal_s, cal_l)
+
+    np.testing.assert_allclose(out, dut_true, atol=1e-10)
+
+
+def test_calibrate_s11_rejects_shape_mismatch():
+    """Shape contract is enforced loudly. A producer-side bug that
+    publishes mismatched arrays must surface as a ValueError, not a
+    silent broadcast or a numpy-level cryptic error."""
+    raw = np.zeros(NFREQ, dtype=complex)
+    cal_o = np.zeros(NFREQ, dtype=complex)
+    cal_s = np.zeros(NFREQ, dtype=complex)
+    cal_l = np.zeros(NFREQ - 1, dtype=complex)  # wrong length
+
+    with pytest.raises(ValueError, match="must all be 1-D"):
+        calibrate_s11(raw, cal_o, cal_s, cal_l)
+
+
+def test_calibrate_s11_accepts_lists():
+    """The route hands cmtvna numpy arrays today, but the math should
+    accept anything ``np.asarray`` can swallow so a future caller
+    (e.g. a JSON-roundtripped fixture) doesn't have to pre-cast."""
+    raw = [0.1 + 0j] * NFREQ
+    cal_o = [1.0 + 0j] * NFREQ
+    cal_s = [-1.0 + 0j] * NFREQ
+    cal_l = [0.0 + 0j] * NFREQ
+
+    out = calibrate_s11(raw, cal_o, cal_s, cal_l)
+
+    assert out.shape == (NFREQ,)
+    np.testing.assert_allclose(out, np.asarray(raw, dtype=complex), atol=1e-12)
+
+
+def test_vna_cache_is_frozen():
+    """VnaCache is the type the aggregator hands to the route handler
+    under the snapshot lock. Freezing it makes accidental mutation
+    surface as a TypeError instead of a hard-to-debug data-race."""
+    cache = VnaCache(
+        freqs=np.array([1.0]),
+        raw_s11=np.array([0.1 + 0j]),
+        cal_o=np.array([1.0 + 0j]),
+        cal_s=np.array([-1.0 + 0j]),
+        cal_l=np.array([0.0 + 0j]),
+        received_unix=123.0,
+        metadata_snapshot_unix=120.0,
+    )
+    with pytest.raises(AttributeError):
+        cache.received_unix = 999.0  # type: ignore[misc]

--- a/tests/test_live_status_vna_calibration.py
+++ b/tests/test_live_status_vna_calibration.py
@@ -105,7 +105,7 @@ def test_calibrate_s11_rejects_shape_mismatch():
     cal_s = np.zeros(NFREQ, dtype=complex)
     cal_l = np.zeros(NFREQ - 1, dtype=complex)  # wrong length
 
-    with pytest.raises(ValueError, match="must all be 1-D"):
+    with pytest.raises(ValueError, match="must share length"):
         calibrate_s11(raw, cal_o, cal_s, cal_l)
 
 


### PR DESCRIPTION
## Summary

- Adds a calibrated VNA S11 pane to the live-status dashboard, sitting next to the calibrated corr pane from #98.
- Calibration uses **ideal-OSL** standards (+1 / -1 / 0) — field deployment uses generic SMA caps, so a precise calkit (S911T) is reserved for lab post-processing on the saved `.h5` files. Math runs through `cmt_vna.calkit.network_sparams` + `de_embed_sparams` directly; no new cmt_vna types.
- Aggregator gains a dedicated VNA drain thread that blocks inside Redis `xread` (1 s) between sweeps, caches the latest `ant` and `rec` payloads independently in `StateSnapshot`. Producer contract violations (unexpected `header['mode']`, missing OSL keys, missing `freqs`) log at ERROR and drop the entry — corr / metadata panes keep painting.
- `/api/vna?mode=ant|rec` calibrates lazily on request, returns `freqs_mhz`, `s11_db`, `age_s`, `stale` (>1.5× nominal 1/hr cadence). Cal failure surfaces `available=false`, never a 500.
- Frontend: new wide card under Correlation spectra, ant/rec button toggle (persisted via localStorage), Plotly trace of |S11| in dB, status banner for stale / unavailable / cal-failed states.

## Test plan

- [x] `pytest tests/test_live_status_vna_calibration.py` — ideal-OSL identity, round-trip through known error network, shape-mismatch ValueError, list inputs, frozen dataclass.
- [x] `pytest tests/test_live_status_app.py` — new tests for `/api/vna` happy path (ant + rec), no-measurement, unknown mode, stale boundary, drain-side contract violation.
- [x] `pytest tests/test_live_status_aggregator.py tests/test_redis.py` — role-surface contract still holds with `vna_reader` added.
- [x] `ruff check . && ruff format --check .`
- [ ] End-to-end manual on the deployed dashboard once a real VNA sweep lands — confirm pane renders, ant/rec toggle works without a page reload, stale banner fires after 1.5 hr without a new measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)