### PR TITLE
fix(fpga): propagate producer-thread failures so systemd restarts

### DIFF
--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -1169,12 +1169,13 @@ class EigsepFpga:
             if not self.event.is_set():
                 self._producer_timeout = True
         except Exception as exc:
-            # Capture for observe() to re-raise from the main thread.
-            # Not re-raising here keeps journalctl to one continuous
-            # traceback (the exception's __traceback__ rides with the
-            # object) instead of doubling up via threading.excepthook.
+            # Capture for observe() to re-raise from the main thread —
+            # the exception's __traceback__ rides with the object, so
+            # systemd gets one clean traceback. Logging here with
+            # logger.error (no exc_info) instead of logger.exception
+            # avoids printing the traceback twice in journalctl.
             self._producer_exc = exc
-            self.logger.exception("Producer thread caught exception")
+            self.logger.error("Producer thread caught exception: %s", exc)
         finally:
             self.event.set()
             try:
@@ -1248,18 +1249,20 @@ class EigsepFpga:
             target=self._read_integrations,
             args=(pairs,),
             kwargs={"timeout": timeout},
+            daemon=True,
         )
         thd.start()
 
         try:
+            # Drain until the event is set AND the queue is empty: the
+            # producer (and end_observing) may enqueue None *before*
+            # the last real integration lands, so an early break on
+            # None would silently drop it. Sentinels are skipped; the
+            # while-condition is the only exit path.
             while not self.event.is_set() or not self.queue.empty():
                 d = self.queue.get()
                 if d is None:
-                    if self.event.is_set():
-                        self.logger.info("End of queue, processing finished.")
-                        break
-                    else:
-                        continue
+                    continue
                 data = d["data"]
                 cnt = d["cnt"]
                 sync_time = self.sync_time if self.is_synchronized else 0

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -1185,9 +1185,14 @@ class EigsepFpga:
                 pass
 
     def end_observing(self):
+        # Setting the event is enough: the producer's while-condition
+        # picks it up at its next iteration top, runs its finally, and
+        # the finally's queue.put(None) is the single wake-up that
+        # unblocks the consumer's queue.get(). Enqueuing a None here
+        # too would race the producer's mid-iteration put and cause
+        # the consumer to exit before the last integration lands.
         try:
             self.event.set()
-            self.queue.put(None)  # signals end of observing
         except AttributeError:
             self.logger.error("Observation not started or already ended.")
 
@@ -1254,11 +1259,12 @@ class EigsepFpga:
         thd.start()
 
         try:
-            # Drain until the event is set AND the queue is empty: the
-            # producer (and end_observing) may enqueue None *before*
-            # the last real integration lands, so an early break on
-            # None would silently drop it. Sentinels are skipped; the
-            # while-condition is the only exit path.
+            # The producer's finally is the sole source of the None
+            # sentinel and it always fires after the producer's last
+            # queue.put — so the None can never precede a real
+            # integration. We skip it (it's only a wake-up for the
+            # blocking queue.get) and let the while-condition exit
+            # the loop once event is set AND queue is empty.
             while not self.event.is_set() or not self.queue.empty():
                 d = self.queue.get()
                 if d is None:

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -1124,34 +1124,64 @@ class EigsepFpga:
         pairs : list
             List of pairs to read.
         timeout : float
-            Number of seconds to wait for a new integration before
-            timing out.
+            No-progress window: the producer exits if it sees no new
+            ``corr_acc_cnt`` for this many seconds.
 
+        Notes
+        -----
+        The finally block always wakes the consumer (sets
+        ``self.event``, puts ``None`` on ``self.queue``) so a producer
+        exit — clean stop, no-progress timeout, or unhandled hardware
+        exception — never leaves ``observe()`` blocked on
+        ``queue.get()``. Exceptions are captured into
+        ``self._producer_exc`` and an internal no-progress timeout
+        flips ``self._producer_timeout`` so ``observe()`` can
+        distinguish those from an external stop (``end_observing``)
+        and re-raise.
         """
-        cnt = self.fpga.read_int("corr_acc_cnt")
-        t = time.time()
-
-        while time.time() < t + timeout and not self.event.is_set():
-            new_cnt = self.fpga.read_int("corr_acc_cnt")
-            if new_cnt == cnt:
-                time.sleep(0.01)
-                continue
-            if new_cnt > cnt + 1:
-                self.logger.warning(
-                    f"Missed {new_cnt - cnt - 1} integration(s)."
-                )
-            cnt = new_cnt
-            self.logger.info(f"Reading acc_cnt={cnt}")
-            data = self.read_data(pairs=pairs, unpack=False)
-            if cnt != self.fpga.read_int("corr_acc_cnt"):
-                self.logger.error(
-                    f"Read of acc_cnt={cnt} FAILED to complete before "
-                    "next integration."
-                )
-            self.queue.put({"data": data, "cnt": cnt})
-            if self.is_synchronized:
-                self._publish_adc_stats()
+        try:
+            cnt = self.fpga.read_int("corr_acc_cnt")
             t = time.time()
+
+            while time.time() < t + timeout and not self.event.is_set():
+                new_cnt = self.fpga.read_int("corr_acc_cnt")
+                if new_cnt == cnt:
+                    time.sleep(0.01)
+                    continue
+                if new_cnt > cnt + 1:
+                    self.logger.warning(
+                        f"Missed {new_cnt - cnt - 1} integration(s)."
+                    )
+                cnt = new_cnt
+                self.logger.info(f"Reading acc_cnt={cnt}")
+                data = self.read_data(pairs=pairs, unpack=False)
+                if cnt != self.fpga.read_int("corr_acc_cnt"):
+                    self.logger.error(
+                        f"Read of acc_cnt={cnt} FAILED to complete "
+                        "before next integration."
+                    )
+                self.queue.put({"data": data, "cnt": cnt})
+                if self.is_synchronized:
+                    self._publish_adc_stats()
+                t = time.time()
+            # No external stop → loop exited because the no-progress
+            # window elapsed; flag so observe() raises TimeoutError.
+            if not self.event.is_set():
+                self._producer_timeout = True
+        except Exception as exc:
+            # Capture for observe() to re-raise from the main thread.
+            # Not re-raising here keeps journalctl to one continuous
+            # traceback (the exception's __traceback__ rides with the
+            # object) instead of doubling up via threading.excepthook.
+            self._producer_exc = exc
+            self.logger.exception("Producer thread caught exception")
+        finally:
+            self.event.set()
+            try:
+                self.queue.put(None)
+            except AttributeError:
+                # queue may not exist if observe() never built it.
+                pass
 
     def end_observing(self):
         try:
@@ -1170,16 +1200,26 @@ class EigsepFpga:
             List of correlation pairs to read. If None, all pairs are
             read and streamed.
         timeout : int
-            Timeout in seconds for reading data from the correlator.
+            Per-integration no-progress window passed to
+            ``_read_integrations`` (seconds).
 
         Raises
-        -------
+        ------
         TimeoutError
-            If the read operation times out.
-
+            The producer thread saw no new ``corr_acc_cnt`` within
+            ``timeout`` seconds. Re-raising here lets the supervisor
+            (``eigsep-observe.service``) restart with a fresh
+            ``--reinit`` rather than silently stalling.
+        Exception
+            Any unhandled exception from the producer thread is
+            re-raised (typically a casperfpga register-read
+            ``RuntimeError`` when the SNAP becomes unreachable).
+            Same recovery path as ``TimeoutError``.
         """
         self.queue = Queue(maxsize=0)
         self.event = Event()
+        self._producer_exc = None
+        self._producer_timeout = False
         self.upload_config(validate=True)
         t_int = self.header["integration_time"]
         self.logger.info(f"Integration time is {t_int} seconds.")
@@ -1211,15 +1251,30 @@ class EigsepFpga:
         )
         thd.start()
 
-        while not self.event.is_set() or not self.queue.empty():
-            d = self.queue.get()
-            if d is None:
-                if self.event.is_set():
-                    self.logger.info("End of queue, processing finished.")
-                    break
-                else:
-                    continue
-            data = d["data"]
-            cnt = d["cnt"]
-            sync_time = self.sync_time if self.is_synchronized else 0
-            self.corr.add(data, cnt, sync_time, dtype=self.cfg["dtype"])
+        try:
+            while not self.event.is_set() or not self.queue.empty():
+                d = self.queue.get()
+                if d is None:
+                    if self.event.is_set():
+                        self.logger.info("End of queue, processing finished.")
+                        break
+                    else:
+                        continue
+                data = d["data"]
+                cnt = d["cnt"]
+                sync_time = self.sync_time if self.is_synchronized else 0
+                self.corr.add(data, cnt, sync_time, dtype=self.cfg["dtype"])
+        finally:
+            # Set event so the producer's while-condition exits on its
+            # next iteration even when the consumer is unwinding from
+            # an exception (e.g. SIGINT-driven KeyboardInterrupt).
+            self.event.set()
+            thd.join(timeout=5)
+
+        if self._producer_exc is not None:
+            raise self._producer_exc
+        if self._producer_timeout:
+            raise TimeoutError(
+                f"Producer saw no new corr_acc_cnt within {timeout}s; "
+                "SNAP appears unresponsive."
+            )

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -538,9 +538,13 @@ class TestEigsepFpga:
         spy.assert_called_once()
 
     def test_read_integrations_no_new_data(self, fpga_instance):
-        """No new cnt → loop exits via pre-set event, queue stays empty."""
+        """No new cnt + event pre-set → loop exits via the external-
+        stop branch (``_producer_timeout`` stays False). Finally
+        wakes the consumer with a single ``None`` sentinel."""
         fpga_instance.queue = Queue()
         fpga_instance.event = Event()
+        fpga_instance._producer_exc = None
+        fpga_instance._producer_timeout = False
         # Pre-set so the loop's while-condition fails after the first
         # read_int, before it has a chance to enter the iteration body.
         fpga_instance.event.set()
@@ -550,7 +554,10 @@ class TestEigsepFpga:
         ) as mock_read_int:
             fpga_instance._read_integrations(["0", "1"], timeout=0.1)
 
-        assert fpga_instance.queue.empty()
+        assert fpga_instance.queue.get_nowait() is None
+        assert fpga_instance.queue.empty()  # only the sentinel
+        assert fpga_instance._producer_exc is None
+        assert fpga_instance._producer_timeout is False
         mock_read_int.assert_called_with("corr_acc_cnt")
 
     def test_read_integrations_new_data(self, fpga_instance, caplog):
@@ -851,6 +858,113 @@ class TestEigsepFpga:
         # the stream.
         r = fpga_instance.transport.r
         assert r.xlen(CORR_STREAM) == 0
+
+    def test_read_integrations_finally_signals_consumer_on_exception(
+        self, fpga_instance
+    ):
+        """A hardware exception in the producer body (the SNAP-power-
+        cut failure mode: casperfpga RuntimeError) must capture the
+        exception, wake the consumer, and not propagate out of the
+        thread. Pre-fix, the bare exception killed the thread and the
+        consumer hung forever on ``queue.get()``.
+        """
+        fpga_instance.queue = Queue()
+        fpga_instance.event = Event()
+        fpga_instance._producer_exc = None
+        fpga_instance._producer_timeout = False
+
+        boom = RuntimeError("Failed to read corr_cross_15_dout")
+        with patch.object(fpga_instance.fpga, "read_int", side_effect=boom):
+            # Captured, not propagated — observe() re-raises from the
+            # main thread so journalctl sees one clean traceback.
+            fpga_instance._read_integrations(["0"], timeout=1)
+
+        assert fpga_instance.event.is_set()
+        assert fpga_instance.queue.get_nowait() is None
+        assert fpga_instance._producer_exc is boom
+        assert fpga_instance._producer_timeout is False
+
+    def test_read_integrations_no_progress_flags_producer_timeout(
+        self, fpga_instance
+    ):
+        """``corr_acc_cnt`` frozen for >timeout → loop exits, finally
+        wakes the consumer, and ``_producer_timeout`` flips True (the
+        external-stop branch — event-set-by-end_observing — leaves
+        it False; see test_read_integrations_no_new_data)."""
+        fpga_instance.queue = Queue()
+        fpga_instance.event = Event()
+        fpga_instance._producer_exc = None
+        fpga_instance._producer_timeout = False
+
+        with patch.object(fpga_instance.fpga, "read_int", return_value=42):
+            fpga_instance._read_integrations(["0"], timeout=0.05)
+
+        assert fpga_instance.event.is_set()
+        assert fpga_instance.queue.get_nowait() is None
+        assert fpga_instance._producer_exc is None
+        assert fpga_instance._producer_timeout is True
+
+    def test_observe_re_raises_producer_exception(self, fpga_instance):
+        """End-to-end with a real producer thread: a casperfpga
+        ``RuntimeError`` propagates out of ``observe()`` so the
+        supervisor (``eigsep-observe.service``) sees a non-zero exit
+        and restarts with ``--reinit``.
+        """
+        fpga_instance.upload_config = Mock()
+        boom = RuntimeError("Failed to read corr_cross_15_dout")
+
+        with (
+            patch.object(fpga_instance.fpga, "read_int", side_effect=boom),
+            patch.object(fpga_instance.corr, "add"),
+            pytest.raises(RuntimeError, match="corr_cross_15_dout"),
+        ):
+            fpga_instance.observe(pairs=["0"], timeout=1)
+
+    def test_observe_raises_timeouterror_on_producer_silence(
+        self, fpga_instance
+    ):
+        """``corr_acc_cnt`` never advances → producer's no-progress
+        window elapses → ``observe()`` raises ``TimeoutError`` so the
+        supervisor restarts rather than hanging silently.
+        """
+        fpga_instance.upload_config = Mock()
+
+        with (
+            patch.object(fpga_instance.fpga, "read_int", return_value=42),
+            patch.object(fpga_instance.corr, "add"),
+            pytest.raises(TimeoutError, match="SNAP appears unresponsive"),
+        ):
+            fpga_instance.observe(pairs=["0"], timeout=0.05)
+
+    def test_observe_clean_stop_via_end_observing_does_not_raise(
+        self, fpga_instance
+    ):
+        """External stop via ``end_observing`` (interactive shell
+        exit, or SIGINT path in fpga_init.py) must remain a clean
+        return — only producer-side failures should raise.
+        """
+        fpga_instance.upload_config = Mock()
+
+        def stop_after_delay():
+            time.sleep(0.05)
+            fpga_instance.end_observing()
+
+        stopper = threading.Thread(target=stop_after_delay, daemon=True)
+
+        with (
+            patch.object(fpga_instance.fpga, "read_int", return_value=42),
+            patch.object(fpga_instance.corr, "add"),
+        ):
+            stopper.start()
+            # timeout=5 is the producer's no-progress window; if the
+            # external stop is missed the test hangs ~5s and then
+            # fails on TimeoutError, which is a louder symptom than
+            # any silent skip.
+            fpga_instance.observe(pairs=["0"], timeout=5)
+
+        stopper.join(timeout=1)
+        assert fpga_instance._producer_exc is None
+        assert fpga_instance._producer_timeout is False
 
 
 class TestFpgaLockProxy:

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -773,7 +773,6 @@ class TestEigsepFpga:
             fpga_instance.observe(pairs=["0"], timeout=1)
 
         mock_add.assert_not_called()
-        assert "End of queue, processing finished." in caplog.text
 
     def test_observe_logging(self, fpga_instance, caplog):
         """observe() emits the expected info log lines."""
@@ -791,7 +790,6 @@ class TestEigsepFpga:
 
         assert f"Integration time is {expected_t_int} seconds." in caplog.text
         assert "Starting observation for pairs: ['0']." in caplog.text
-        assert "End of queue, processing finished." in caplog.text
 
     def test_observe_integration_loop(self, fpga_instance):
         """
@@ -859,6 +857,37 @@ class TestEigsepFpga:
         r = fpga_instance.transport.r
         assert r.xlen(CORR_STREAM) == 0
 
+    def test_observe_drains_queue_when_sentinel_precedes_late_data(
+        self, fpga_instance
+    ):
+        """Race regression: ``end_observing`` can enqueue ``None``
+        between a producer's ``read_data`` and its ``queue.put`` of
+        the resulting integration. Pre-fix, the consumer broke on
+        the first sentinel and silently dropped any data queued
+        after it. Post-fix, the consumer drains until the queue is
+        empty.
+        """
+        expected_dtype = fpga_instance.cfg["dtype"]
+        # data1, then end_observing's None, then a late integration,
+        # then producer's finally None.
+        items = [
+            {"data": "early", "cnt": 1},
+            None,
+            {"data": "late", "cnt": 2},
+            None,
+        ]
+        with (
+            patch.object(fpga_instance.corr, "add") as mock_add,
+            _patch_observe_thread(fpga_instance, items),
+        ):
+            fpga_instance.observe(pairs=["0"], timeout=10)
+
+        assert mock_add.call_count == 2
+        assert mock_add.call_args_list[0].args == ("early", 1, 0)
+        assert mock_add.call_args_list[1].args == ("late", 2, 0)
+        for call in mock_add.call_args_list:
+            assert call.kwargs == {"dtype": expected_dtype}
+
     def test_read_integrations_finally_signals_consumer_on_exception(
         self, fpga_instance
     ):
@@ -910,10 +939,10 @@ class TestEigsepFpga:
         supervisor (``eigsep-observe.service``) sees a non-zero exit
         and restarts with ``--reinit``.
         """
-        fpga_instance.upload_config = Mock()
         boom = RuntimeError("Failed to read corr_cross_15_dout")
 
         with (
+            patch.object(fpga_instance, "upload_config"),
             patch.object(fpga_instance.fpga, "read_int", side_effect=boom),
             patch.object(fpga_instance.corr, "add"),
             pytest.raises(RuntimeError, match="corr_cross_15_dout"),
@@ -927,9 +956,8 @@ class TestEigsepFpga:
         window elapses → ``observe()`` raises ``TimeoutError`` so the
         supervisor restarts rather than hanging silently.
         """
-        fpga_instance.upload_config = Mock()
-
         with (
+            patch.object(fpga_instance, "upload_config"),
             patch.object(fpga_instance.fpga, "read_int", return_value=42),
             patch.object(fpga_instance.corr, "add"),
             pytest.raises(TimeoutError, match="SNAP appears unresponsive"),
@@ -943,7 +971,6 @@ class TestEigsepFpga:
         exit, or SIGINT path in fpga_init.py) must remain a clean
         return — only producer-side failures should raise.
         """
-        fpga_instance.upload_config = Mock()
 
         def stop_after_delay():
             time.sleep(0.05)
@@ -952,6 +979,7 @@ class TestEigsepFpga:
         stopper = threading.Thread(target=stop_after_delay, daemon=True)
 
         with (
+            patch.object(fpga_instance, "upload_config"),
             patch.object(fpga_instance.fpga, "read_int", return_value=42),
             patch.object(fpga_instance.corr, "add"),
         ):

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -857,36 +857,20 @@ class TestEigsepFpga:
         r = fpga_instance.transport.r
         assert r.xlen(CORR_STREAM) == 0
 
-    def test_observe_drains_queue_when_sentinel_precedes_late_data(
-        self, fpga_instance
-    ):
-        """Race regression: ``end_observing`` can enqueue ``None``
-        between a producer's ``read_data`` and its ``queue.put`` of
-        the resulting integration. Pre-fix, the consumer broke on
-        the first sentinel and silently dropped any data queued
-        after it. Post-fix, the consumer drains until the queue is
-        empty.
+    def test_end_observing_does_not_enqueue_sentinel(self, fpga_instance):
+        """``end_observing`` only sets the event — the producer's
+        ``finally`` is the sole source of the ``None`` sentinel. A
+        second sentinel from ``end_observing`` would race the
+        producer's mid-iteration ``queue.put`` and let the consumer
+        exit before the last integration lands.
         """
-        expected_dtype = fpga_instance.cfg["dtype"]
-        # data1, then end_observing's None, then a late integration,
-        # then producer's finally None.
-        items = [
-            {"data": "early", "cnt": 1},
-            None,
-            {"data": "late", "cnt": 2},
-            None,
-        ]
-        with (
-            patch.object(fpga_instance.corr, "add") as mock_add,
-            _patch_observe_thread(fpga_instance, items),
-        ):
-            fpga_instance.observe(pairs=["0"], timeout=10)
+        fpga_instance.queue = Queue()
+        fpga_instance.event = Event()
 
-        assert mock_add.call_count == 2
-        assert mock_add.call_args_list[0].args == ("early", 1, 0)
-        assert mock_add.call_args_list[1].args == ("late", 2, 0)
-        for call in mock_add.call_args_list:
-            assert call.kwargs == {"dtype": expected_dtype}
+        fpga_instance.end_observing()
+
+        assert fpga_instance.event.is_set()
+        assert fpga_instance.queue.empty()
 
     def test_read_integrations_finally_signals_consumer_on_exception(
         self, fpga_instance


### PR DESCRIPTION
## Summary

- A SNAP power-cut leaves `eigsep-fpga-init` hung instead of exiting non-zero: casperfpga's register-read `RuntimeError` kills the producer thread, but `observe()`'s consumer keeps blocking on `queue.get()` because the producer never signals it. The 10 s no-progress timeout has the same failure mode (loop exits without waking the consumer). `Restart=on-failure` therefore never fires.
- Wrap `_read_integrations` in `try/except/finally` so the consumer is always woken (event set, `None` on queue) on every exit path — clean stop, no-progress timeout, or hardware exception. Capture any exception into `self._producer_exc` and the no-progress case into `self._producer_timeout`.
- `observe()` re-raises the captured exception or raises `TimeoutError` after the consume loop, so the process exits non-zero and the systemd supervisor restarts with `--reinit -p` as documented in `deploy/systemd/README.md`.

## Reproduction this fixes

User simulated a SNAP failure by cutting power. Journal showed:

```
RuntimeError: Failed to read size 4096 from register corr_cross_15_dout at offset 0
```

…raised inside the producer thread (`Thread-1 (_read_integrations)`) and then the process hung indefinitely. The fix turns that into a clean propagation: the exception bubbles out of `observe()`, the script exits non-zero, and systemd restarts after `RestartSec=30s`.

## Test plan

- [x] `pytest tests/test_fpga.py` — 53 pass (5 new, 1 updated).
- [x] `ruff check` / `ruff format --check` on the two changed files.
- [ ] Field repro: pull SNAP power on a live deployment and confirm the supervisor restarts within ~30 s (end-to-end timing: producer's no-progress / TAPCP-retry window, plus `RestartSec=30s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)