### PR TITLE
fix(systemd): gate observe + writer on chrony-wait.service

### DIFF
--- a/deploy/systemd/eigsep-observe-writer.service
+++ b/deploy/systemd/eigsep-observe-writer.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=EIGSEP corr-data file writer (observe.py)
 Documentation=https://github.com/EIGSEP/eigsep_observing/blob/main/deploy/systemd/README.md
-After=network-online.target redis-server.service eigsep-observe.service
-Wants=network-online.target redis-server.service eigsep-observe.service
+# chrony-wait.service: needs its own ordering (systemd `After=` does not
+# transitively delay this unit behind the supervisor's predecessors).
+# See eigsep-observe.service for the sync_time rationale.
+After=network-online.target redis-server.service eigsep-observe.service chrony-wait.service
+Wants=network-online.target redis-server.service eigsep-observe.service chrony-wait.service
 # Unbounded retries — see eigsep-observe.service for rationale.
 StartLimitIntervalSec=0
 

--- a/deploy/systemd/eigsep-observe.service
+++ b/deploy/systemd/eigsep-observe.service
@@ -1,8 +1,18 @@
 [Unit]
 Description=EIGSEP SNAP supervisor (fpga_init.py --reinit -p)
 Documentation=https://github.com/EIGSEP/eigsep_observing/blob/main/deploy/systemd/README.md
-After=network-online.target redis-server.service
-Wants=network-online.target redis-server.service
+# chrony-wait.service blocks until chronyd has disciplined the kernel
+# clock to within 0.1s (or its 3 min timeout fires). Required because
+# fpga_init captures `sync_time = time.time()` once at startup and
+# stamps it into the corr header — every integration's UTC timestamp
+# is anchored to that value, so a clock step after sync_time was read
+# would silently corrupt every file until the next --reinit.
+# chrony-wait ships with the Debian chrony package and is a
+# Type=oneshot RemainAfterExit=yes unit, so it costs nothing on
+# subsequent restarts. `After=` on a missing unit is a no-op for
+# non-field consumers without chrony installed.
+After=network-online.target redis-server.service chrony-wait.service
+Wants=network-online.target redis-server.service chrony-wait.service
 # Unbounded retries: the field deployment has no wifi, prime
 # observing is overnight, and a SNAP that thermal-cycles overnight
 # will self-heal as it cools. The operator-visible signal lives on


### PR DESCRIPTION
## Summary

- Adds `After=chrony-wait.service` + `Wants=chrony-wait.service` to both `deploy/systemd/eigsep-observe.service` and `deploy/systemd/eigsep-observe-writer.service` so the SNAP supervisor doesn't capture `sync_time = time.time()` before chrony has disciplined the kernel clock.
- Comment in `eigsep-observe.service` documents the `sync_time` rationale (anchor for every integration's UTC timestamp in every HDF5 file until the next `--reinit`). Comment in the writer documents why it needs its own ordering — systemd `After=` is not transitive, so `After=eigsep-observe.service` does not delay the writer behind the supervisor's predecessors.
- `chrony-wait.service` is `Type=oneshot RemainAfterExit=yes` shipped by the Debian chrony package — it costs nothing on subsequent restarts (already "active" from first boot), and `After=` on a missing unit is a systemd no-op for non-field consumers without chrony installed.

## Why now

First real hardware bring-up exposed that nothing today gates the observe supervisor on time discipline. The risk window is narrow in steady-state — the EIGSEP field deployment has a battery-backed RTC on the Pi 5 and the operator connects an NTP-serving laptop 2–3x/day — but a cold boot before the laptop is present would have the supervisor write `sync_time` against an undisciplined clock, and a subsequent step would skew every timestamp in the resulting HDF5 file.

## Downstream coordination

The image-layout copies in `eigsep-field` (`image/pi-gen-config/.../files/systemd/eigsep-observe*.service`) are byte-checked against this upstream by `scripts/check_services_drift.py` on tracked fields including `After=`/`Wants=`. The field-side draft PR mirroring this change is gated on `v2.2.1` being tagged here so its CI passes.

## Test plan

- [ ] release-please opens a release PR bumping to 2.2.1
- [ ] After v2.2.1 is tagged, eigsep-field's draft PR bumps its `[packages.eigsep_observing]` and `[services.eigsep_observe*]` pins and the drift check passes
- [ ] Backend Pi cold boot with operator laptop connected: `systemd-analyze critical-chain eigsep-observe.service` shows chrony-wait gate; first HDF5 file's `corr_sync_time` matches `chronyc tracking` offset to within a few ms
- [ ] `systemctl restart eigsep-observe.service` after first boot returns promptly (chrony-wait already in `RemainAfterExit=yes` active state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)