### PR TITLE
fix(live-status): source switch_schedule from Redis; suppress fake "next change"

### DIFF
--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -43,6 +43,7 @@ from typing import Any, Optional
 import numpy as np
 from redis.exceptions import RedisError
 
+from eigsep_redis.config import ConfigStore
 from eigsep_redis.heartbeat import HeartbeatReader
 from eigsep_redis.metadata import (
     MetadataSnapshotReader,
@@ -152,6 +153,17 @@ class StateSnapshot:
     panda_heartbeat: bool = False
     panda_heartbeat_last_check_unix: Optional[float] = None
 
+    # Latest obs_config dict read from the panda's Redis ``ConfigStore``
+    # (key ``"config"``). ``None`` when no panda script has ever uploaded
+    # its config to this Redis. The dashboard reads ``switch_schedule``
+    # from here rather than from the on-disk YAML, so a parked switch
+    # with no panda running shows no countdown.
+    # ``panda_config_upload_unix`` carries the ``upload_time`` field that
+    # ``Transport.upload_dict`` stamps on every upload, so the dashboard
+    # can show operators how old the published config is.
+    panda_config_latest: Optional[dict] = None
+    panda_config_upload_unix: Optional[float] = None
+
     # Active panda script tag (panda_observe / no_switch_observation /
     # vna_position_sweep). ``None`` means no script is currently
     # running (cleared on clean exit, or never published).
@@ -199,8 +211,11 @@ class LiveStatusAggregator:
         Must not be shared with any other consumer.
     obs_cfg
         Loaded ``obs_config.yaml``. Read for ``corr_save_dir``,
-        ``corr_ntimes``, ``use_tempctrl``, ``switch_schedule``,
-        ``tempctrl_settings``.
+        ``corr_ntimes``, ``use_tempctrl``, ``tempctrl_settings``
+        — Thresholds/signal-enablement plumbing. The active
+        ``switch_schedule`` comes from the panda's ``ConfigStore``
+        (Redis), not from this dict, so the dashboard's "next change"
+        countdown reflects what panda is actually running.
     thresholds
         Optional pre-built :class:`Thresholds`. If ``None``, one is
         built from the bundled YAML and the first corr header seen.
@@ -250,6 +265,7 @@ class LiveStatusAggregator:
         self.status_reader = StatusReader(transport_panda)
         self.heartbeat_reader = HeartbeatReader(transport_panda)
         self.vna_reader = VnaReader(transport_panda)
+        self.panda_config_store = ConfigStore(transport_panda)
 
         self.state = StateSnapshot()
         self._lock = threading.Lock()
@@ -693,6 +709,16 @@ class LiveStatusAggregator:
         )
         any_ok = any_ok or ok
 
+        # Panda-side obs_config (key ``"config"``). ConfigStore.get
+        # raises ValueError when the key is missing — handled as a
+        # benign no-data result by _read_benign_missing.
+        panda_cfg, ok = self._read_benign_missing(
+            "panda_config_store.get",
+            self.panda_config_store.get,
+            errors,
+        )
+        any_ok = any_ok or ok
+
         with self._lock:
             s = self.state
             s.panda_last_tick_unix = now
@@ -730,10 +756,16 @@ class LiveStatusAggregator:
                             if isinstance(new_value, dict)
                             else None
                         )
-                        if (
-                            s.rfswitch_state_entered_unix is None
-                            or prev_name != new_name
-                        ):
+                        # Only latch on a real observed transition. On
+                        # the first metadata arrival (``prev_name is
+                        # None``) we have no idea when the switch
+                        # actually entered its current state — could be
+                        # seconds ago, could be hours. Leaving
+                        # ``entered_unix`` at None propagates that
+                        # "we don't know" to the dashboard, which then
+                        # shows N/A for dwell + countdown instead of
+                        # claiming a freshly-entered state.
+                        if prev_name is not None and prev_name != new_name:
                             s.rfswitch_state_entered_unix = now
                     s.metadata_latest[name] = new_value
                     s.metadata_last_stream_unix[name] = now
@@ -753,6 +785,15 @@ class LiveStatusAggregator:
             if rt is not None:
                 s.run_tag = rt.get("run_tag")
                 s.run_started_at_unix = rt.get("run_started_at_unix")
+
+            if panda_cfg is not None:
+                s.panda_config_latest = panda_cfg
+                upload_time = panda_cfg.get("upload_time")
+                s.panda_config_upload_unix = (
+                    float(upload_time)
+                    if isinstance(upload_time, (int, float))
+                    else None
+                )
 
     def _drain_status(self) -> tuple[list[tuple[int, str]], bool]:
         """Drain StatusReader until the next call times out.
@@ -956,6 +997,7 @@ class LiveStatusAggregator:
             "status_reader",
             "heartbeat_reader",
             "vna_reader",
+            "panda_config_store",
             "thresholds",
             "state",
         }

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -788,12 +788,21 @@ class LiveStatusAggregator:
 
             if panda_cfg is not None:
                 s.panda_config_latest = panda_cfg
-                upload_time = panda_cfg.get("upload_time")
-                s.panda_config_upload_unix = (
-                    float(upload_time)
-                    if isinstance(upload_time, (int, float))
-                    else None
-                )
+                try:
+                    s.panda_config_upload_unix = float(
+                        panda_cfg["upload_time"]
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    logger.error(
+                        "panda config missing/unparseable "
+                        "upload_time=%r (%s); dropping field. "
+                        "Producer contract: Transport.upload_dict "
+                        "injects upload_time on every ConfigStore "
+                        "upload as float-castable wallclock seconds.",
+                        panda_cfg.get("upload_time"),
+                        exc,
+                    )
+                    s.panda_config_upload_unix = None
 
     def _drain_status(self) -> tuple[list[tuple[int, str]], bool]:
         """Drain StatusReader until the next call times out.

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -43,7 +43,7 @@ from typing import Any, Optional
 import numpy as np
 from redis.exceptions import RedisError
 
-from eigsep_redis.config import ConfigStore
+from eigsep_redis import ConfigStore
 from eigsep_redis.heartbeat import HeartbeatReader
 from eigsep_redis.metadata import (
     MetadataSnapshotReader,

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -382,22 +382,42 @@ def _adc_payload(state: StateSnapshot) -> dict:
     }
 
 
-def _rfswitch_payload(state: StateSnapshot, obs_cfg: dict) -> dict:
+def _rfswitch_payload(state: StateSnapshot) -> dict:
+    """Project the current RF-switch state for the dashboard.
+
+    ``state`` (the current sw_state_name from the pico) is reported
+    unconditionally — it's a fact the pico publishes whether or not
+    panda_observe is running. ``time_in_state_s`` and
+    ``next_expected_change_s`` are gated on whether we actually know
+    them: dwell requires an observed transition (so we know when this
+    state was entered, not just when we first saw it), and the
+    countdown additionally requires both a schedule published to Redis
+    and a live panda heartbeat. Any missing input returns ``None``,
+    which the dashboard renders as N/A rather than a misleading
+    projection of an idle schedule.
+    """
     latest = state.metadata_latest.get("rfswitch") or {}
     name = latest.get("sw_state_name")
     entered_unix = state.rfswitch_state_entered_unix
-    schedule = obs_cfg.get("switch_schedule", {}) or {}
+    schedule = (state.panda_config_latest or {}).get(
+        "switch_schedule", {}
+    ) or {}
+
     time_in_state_s = None
     if entered_unix is not None:
         time_in_state_s = max(0.0, time.time() - entered_unix)
+
     expected_dwell = schedule.get(name) if name else None
-    on_schedule = True
     next_expected_change_s = None
-    if expected_dwell is not None and time_in_state_s is not None:
+    on_schedule: Optional[bool] = None
+    if (
+        expected_dwell is not None
+        and time_in_state_s is not None
+        and state.panda_heartbeat
+    ):
         next_expected_change_s = expected_dwell - time_in_state_s
-        # If we're past the expected dwell by more than 10%, flag as off-schedule.
-        if time_in_state_s > expected_dwell * 1.1:
-            on_schedule = False
+        on_schedule = time_in_state_s <= expected_dwell * 1.1
+
     return {
         "state": name,
         "time_in_state_s": time_in_state_s,
@@ -556,9 +576,24 @@ def _health_payload(state: StateSnapshot, now: float) -> dict:
     }
 
 
-def _config_payload(obs_cfg: dict, thresholds: Thresholds) -> dict:
+def _config_payload(
+    state: StateSnapshot, obs_cfg: dict, thresholds: Thresholds
+) -> dict:
+    """Surface configuration to the dashboard.
+
+    ``switch_schedule`` and ``config_upload_unix`` come from the
+    panda-side ``ConfigStore`` (Redis), so the panel shows what panda
+    last uploaded. They persist after panda exits — operators can read
+    ``config_upload_unix`` to see how stale the published config is.
+    The other fields (``tempctrl_settings``, ``corr_*``, ``use_*``)
+    still come from the on-disk ``obs_config.yaml`` the dashboard was
+    started with; they drive ``Thresholds`` rendering decisions, not
+    runtime claims about what panda is doing.
+    """
+    panda_cfg = state.panda_config_latest or {}
     return {
-        "switch_schedule": obs_cfg.get("switch_schedule", {}) or {},
+        "switch_schedule": panda_cfg.get("switch_schedule", {}) or {},
+        "config_upload_unix": state.panda_config_upload_unix,
         "tempctrl_settings": obs_cfg.get("tempctrl_settings", {}) or {},
         "corr_save_dir": obs_cfg.get("corr_save_dir"),
         "corr_ntimes": obs_cfg.get("corr_ntimes"),
@@ -626,7 +661,7 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
     @app.route("/api/rfswitch")
     def api_rfswitch():
         state = aggregator.snapshot()
-        return jsonify(_envelope(_rfswitch_payload(state, aggregator.obs_cfg)))
+        return jsonify(_envelope(_rfswitch_payload(state)))
 
     @app.route("/api/file")
     def api_file():
@@ -646,9 +681,12 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
 
     @app.route("/api/config")
     def api_config():
+        state = aggregator.snapshot()
         return jsonify(
             _envelope(
-                _config_payload(aggregator.obs_cfg, aggregator.thresholds)
+                _config_payload(
+                    state, aggregator.obs_cfg, aggregator.thresholds
+                )
             )
         )
 

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -476,7 +476,13 @@ function renderRfswitch(rf) {
     el.textContent = "no switch data";
     return;
   }
-  const cls = rf.on_schedule ? "ok" : "warn";
+  // on_schedule is tri-state: true = ok, false = warn, null = undefined
+  // (no schedule in Redis, no observed transition yet, or panda
+  // heartbeat dead). Treat null as neutral, not a failure.
+  let cls;
+  if (rf.on_schedule === true) cls = "ok";
+  else if (rf.on_schedule === false) cls = "warn";
+  else cls = "unknown";
   const timeStr =
     rf.time_in_state_s !== null && rf.time_in_state_s !== undefined
       ? fmt(rf.time_in_state_s, 0) + "s"

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -14,6 +14,7 @@ import time
 import numpy as np
 import pytest
 from eigsep_redis import (
+    ConfigStore,
     HeartbeatWriter,
     MetadataWriter,
     StatusWriter,
@@ -86,16 +87,24 @@ def _cross_bytes(value=5):
 
 @pytest.fixture
 def agg_primed():
-    """Aggregator with state populated by one SNAP tick + one panda tick.
+    """Aggregator with state populated by SNAP + panda ticks.
 
     Producers publish corr + adc_stats + heartbeat + rfswitch + tempctrl
-    + lidar; the test then ticks the aggregator once per bus so the
-    Flask handlers have something to project.
+    + lidar + obs_config; the panda side also drives one observed
+    rfswitch transition (RFNOFF → RFANT) during the prime so
+    ``rfswitch_state_entered_unix`` is latched and the dashboard's
+    dwell-time / on-schedule projections have a real entry timestamp
+    to work from. The first metadata arrival never latches
+    ``entered_unix`` on its own (see aggregator.py), so a single push
+    would leave it ``None``.
     """
     snap = DummyTransport()
     panda = DummyTransport()
     CorrConfigStore(snap).upload(CORR_CONFIG)
     CorrConfigStore(snap).upload_header(CORR_HEADER)
+    # Panda-side obs_config: drives ``_rfswitch_payload``'s schedule
+    # (the on-disk obs_cfg only seeds Thresholds now).
+    ConfigStore(panda).upload(OBS_CFG)
 
     # Corr row.
     CorrWriter(snap).add(
@@ -143,14 +152,17 @@ def agg_primed():
             "distance_m": 1.4,
         },
     )
+    # Seed a prior rfswitch state — required so the next push lands as
+    # an observed transition (entered_unix latches only on a real
+    # prev->new change, never on first arrival).
     panda_md.add(
         "rfswitch",
         {
             "sensor_name": "rfswitch",
             "app_id": 7,
             "status": "update",
-            "sw_state": 1,
-            "sw_state_name": "RFANT",
+            "sw_state": 2,
+            "sw_state_name": "RFNOFF",
         },
     )
     panda_md.add(
@@ -211,6 +223,19 @@ def agg_primed():
         read_timeout_s=0.05,
     )
     agg._snap_tick()
+    agg._panda_tick()
+    # Now drive the observed RFNOFF → RFANT transition so entered_unix
+    # latches and the dashboard's dwell-window projections work.
+    panda_md.add(
+        "rfswitch",
+        {
+            "sensor_name": "rfswitch",
+            "app_id": 7,
+            "status": "update",
+            "sw_state": 1,
+            "sw_state_name": "RFANT",
+        },
+    )
     agg._panda_tick()
     yield agg
     agg.stop(timeout=1.0)
@@ -431,7 +456,8 @@ def test_rfswitch_time_in_state_tracks_transitions_not_push_cadence(
     app.config.update(TESTING=True)
     client = app.test_client()
 
-    # Fixture already published RFANT once; capture the entry time.
+    # Fixture observed a RFNOFF -> RFANT transition during prime, so
+    # entered_unix is latched to the RFANT tick time.
     entered_after_prime = agg.state.rfswitch_state_entered_unix
     assert entered_after_prime is not None
 
@@ -497,6 +523,191 @@ def test_rfswitch_on_schedule_flips_false_when_dwell_exceeded(
     assert data["time_in_state_s"] > 66.0
     assert data["on_schedule"] is False
     assert data["next_expected_change_s"] < 0
+
+
+def test_rfswitch_payload_no_countdown_without_observed_transition():
+    """No latch on first metadata arrival — dashboard shows N/A.
+
+    A fresh aggregator that has only seen the switch parked (one
+    arrival, no transition) does not know when the switch actually
+    entered its current state. ``time_in_state_s`` and
+    ``next_expected_change_s`` must both be ``None`` so the dashboard
+    renders N/A rather than a misleading "just entered" countdown.
+    """
+    snap = DummyTransport()
+    panda = DummyTransport()
+    CorrConfigStore(snap).upload(CORR_CONFIG)
+    ConfigStore(panda).upload(OBS_CFG)
+
+    panda_md = MetadataWriter(panda)
+    panda_md.add(
+        "rfswitch",
+        {
+            "sensor_name": "rfswitch",
+            "app_id": 7,
+            "status": "update",
+            "sw_state": 1,
+            "sw_state_name": "RFANT",
+        },
+    )
+    HeartbeatWriter(panda, name="client").set(ex=60, alive=True)
+    _rewind(panda, ["stream:rfswitch", "stream:status"])
+
+    agg = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+        read_timeout_s=0.05,
+    )
+    try:
+        agg._panda_tick()
+        assert agg.state.rfswitch_state_entered_unix is None
+
+        app = create_app(agg)
+        app.config.update(TESTING=True)
+        data = app.test_client().get("/api/rfswitch").get_json()["data"]
+        assert data["state"] == "RFANT"
+        assert data["time_in_state_s"] is None
+        assert data["next_expected_change_s"] is None
+        assert data["on_schedule"] is None
+    finally:
+        agg.stop(timeout=1.0)
+
+
+def test_rfswitch_payload_no_countdown_without_schedule_in_redis():
+    """No config in Redis -> no schedule -> no countdown.
+
+    Mimics the "panda_observe never ran on this Redis" case: the pico
+    publishes rfswitch state but no panda script has uploaded an
+    obs_config. The dashboard must show current state but N/A for the
+    countdown — the schedule from the live-status app's on-disk
+    obs_config.yaml is no longer consulted for runtime claims.
+    """
+    snap = DummyTransport()
+    panda = DummyTransport()
+    CorrConfigStore(snap).upload(CORR_CONFIG)
+    # NO ConfigStore(panda).upload — Redis "config" key is empty.
+
+    panda_md = MetadataWriter(panda)
+    panda_md.add(
+        "rfswitch",
+        {
+            "sensor_name": "rfswitch",
+            "app_id": 7,
+            "status": "update",
+            "sw_state": 2,
+            "sw_state_name": "RFNOFF",
+        },
+    )
+    HeartbeatWriter(panda, name="client").set(ex=60, alive=True)
+    _rewind(panda, ["stream:rfswitch", "stream:status"])
+
+    agg = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+        read_timeout_s=0.05,
+    )
+    try:
+        # First tick: drain seeds metadata_latest["rfswitch"] = RFNOFF,
+        # prev was None → no latch (correct: first arrival).
+        agg._panda_tick()
+        # Now publish a real transition (RFNOFF → RFANT).
+        panda_md.add(
+            "rfswitch",
+            {
+                "sensor_name": "rfswitch",
+                "app_id": 7,
+                "status": "update",
+                "sw_state": 1,
+                "sw_state_name": "RFANT",
+            },
+        )
+        agg._panda_tick()
+        assert agg.state.panda_config_latest is None
+        assert agg.state.rfswitch_state_entered_unix is not None
+
+        app = create_app(agg)
+        app.config.update(TESTING=True)
+        data = app.test_client().get("/api/rfswitch").get_json()["data"]
+        assert data["state"] == "RFANT"
+        assert data["schedule"] == {}
+        assert data["time_in_state_s"] is not None
+        assert data["next_expected_change_s"] is None
+        assert data["on_schedule"] is None
+    finally:
+        agg.stop(timeout=1.0)
+
+
+def test_rfswitch_payload_no_countdown_when_heartbeat_dead(agg_primed):
+    """Schedule + transition observed, but panda heartbeat dead → N/A.
+
+    Models 'panda_observe was running, observed at least one switch,
+    then died'. The schedule remains in Redis, entered_unix remains
+    latched, but the dashboard must stop projecting a countdown
+    because no scheduler is actually driving the next transition.
+    """
+    agg = agg_primed
+    # Force heartbeat dead despite the fixture's prior tick reading it
+    # alive. Use the lock to mirror the way drain threads update state.
+    with agg._lock:
+        agg.state.panda_heartbeat = False
+
+    app = create_app(agg)
+    app.config.update(TESTING=True)
+    data = app.test_client().get("/api/rfswitch").get_json()["data"]
+    assert data["state"] == "RFANT"
+    # entered_unix is still latched from the prime, so we still know
+    # how long the switch has been in state — that's a fact.
+    assert data["time_in_state_s"] is not None
+    # But the countdown is gated on heartbeat liveness.
+    assert data["next_expected_change_s"] is None
+    assert data["on_schedule"] is None
+
+
+def test_config_route_surfaces_redis_schedule_and_upload_time(client):
+    """``_config_payload.switch_schedule`` comes from Redis ConfigStore
+    (uploaded by panda), and ``config_upload_unix`` carries the
+    ``upload_time`` ``Transport.upload_dict`` stamps on every upload.
+    """
+    body = client.get("/api/config").get_json()
+    data = body["data"]
+    assert data["switch_schedule"] == OBS_CFG["switch_schedule"]
+    assert data["config_upload_unix"] is not None
+    # upload_time must be a Unix timestamp near now.
+    assert abs(data["config_upload_unix"] - time.time()) < 60.0
+
+
+def test_config_route_schedule_empty_when_no_config_in_redis():
+    """No panda config uploaded → ``switch_schedule`` is ``{}`` and
+    ``config_upload_unix`` is ``None``. The disk-loaded obs_cfg's
+    ``switch_schedule`` is no longer consulted.
+    """
+    snap = DummyTransport()
+    panda = DummyTransport()
+    CorrConfigStore(snap).upload(CORR_CONFIG)
+    # No ConfigStore upload.
+    _rewind(panda, ["stream:status"])
+
+    agg = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+        read_timeout_s=0.05,
+    )
+    try:
+        agg._panda_tick()
+        assert agg.state.panda_config_latest is None
+        app = create_app(agg)
+        app.config.update(TESTING=True)
+        data = app.test_client().get("/api/config").get_json()["data"]
+        assert data["switch_schedule"] == {}
+        assert data["config_upload_unix"] is None
+        # But disk-backed fields still come through (Thresholds-driving
+        # rendering decisions, not runtime claims).
+        assert data["use_tempctrl"] is True
+    finally:
+        agg.stop(timeout=1.0)
 
 
 def test_file_route(client):


### PR DESCRIPTION
## Summary

The live-status dashboard was showing a "next change" countdown for the RF switch even when `panda_observe` wasn't running. Two bugs combined:

1. **Schedule source was wrong.** `_rfswitch_payload` read `switch_schedule` from the on-disk `obs_config.yaml` loaded at script startup, so there was no way for the dashboard to know "nothing is currently driving the switches."
2. **`rfswitch_state_entered_unix` latched on startup.** The `or s.rfswitch_state_entered_unix is None` clause in `aggregator.py` meant the first metadata sample of the aggregator's lifetime set entry-time to "now," even when the switch had been parked in that state for hours.

This PR sources the schedule from the panda's Redis `ConfigStore`, fixes the startup latch, and gates the countdown on heartbeat liveness. Any of the three inputs missing (schedule in Redis, observed transition, alive heartbeat) → `time_in_state_s` / `next_expected_change_s` / `on_schedule` come back as `None` and the dashboard renders N/A instead of fake info.

`on_schedule` is now tri-state (`true` / `false` / `null`). `dashboard.js` renders `null` as a neutral "unknown" tile rather than red.

`_config_payload` keeps showing the last-known Redis schedule (with `config_upload_unix`) even after heartbeat dies — it's the "what panda was last configured with" view, intentionally not heartbeat-gated.

## Test plan

- [x] `pytest tests/test_live_status_app.py` — 46 passed (incl. 5 new tests)
- [x] `pytest tests/test_live_status_aggregator.py` — 30 passed
- [x] `pytest tests/test_redis.py` — 36 passed (structural role-surface guard updated for the new `panda_config_store`)
- [x] `ruff check .` + `ruff format --check .` clean
- [ ] Manual E2E: start aggregator with no `panda_observe` → dashboard shows `sw_state_name` (from pico) but N/A for dwell + countdown
- [ ] Manual E2E: start `panda_observe` → after first scheduled transition, countdown becomes live
- [ ] Manual E2E: `kill -9` panda → within ~60s (heartbeat TTL) countdown returns to N/A; `/api/config` panel still shows last-known schedule + `config_upload_unix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)