### PR TITLE
feat(tempctrl): consume per-channel Redis streams; drop _avg_temp_metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ disagreement (`min`/`any`/`"UNKNOWN"`) and downstream can detect it from the
 file. Logging every cal-level wobble would generate ~14k events/hour during
 normal operation.
 
-**Two paths that bypass `_avg_sensor_values`:**
+**One path that bypasses `_avg_sensor_values`:**
 
 - `_avg_rfswitch_metadata` returns the bare switch-state *name* string
   (`"RFANT"`, `"VNAO"`, ...) or `"UNKNOWN"` (not a dict). It reads
@@ -211,12 +211,12 @@ normal operation.
   `RFSWITCH_TRANSITION_WINDOW_S` block in `io.py` for the additional
   forward-window flagging that fires on consecutive-sample switch state
   changes.
-- `_avg_temp_metadata` first averages the top-level (non-prefixed) fields via
-  `_avg_sensor_values`, then splits the `LNA_*`/`LOAD_*` channel keys into
-  `tempctrl_lna`/`tempctrl_load` sub-dicts and runs `_avg_sensor_values` on
-  each. The split happens in `File.add_data`, not here, so the streams in the
-  saved file are flat per-channel. Only `tempctrl` exercises this helper —
-  the standalone `temp_mon` Pico app was retired in picohost 1.0.0.
+
+`tempctrl_lna` and `tempctrl_load` are ordinary streams handled by the
+generic `_avg_sensor_values` path — picohost publishes them as
+separate per-channel streams, so the consumer no longer needs a custom
+splitter. (The standalone `temp_mon` Pico app was retired in picohost
+1.0.0.)
 
 **IMU mode (picohost 1.0.0).** The two IMU picos (`imu_el` panda elevation,
 app_id 3; `imu_az` antenna azimuth, app_id 6) emit BNO085 UART RVC payloads:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=3.1",
+  "picohost>=3.3.0",
   "eigsep-vna>=1.3",
   "eigsep_redis>=2.1",
 ]

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -26,6 +26,8 @@ without significant test rewrites.
 """
 
 import numpy as np
+from picohost.base import PicoPeltier
+from picohost.testing import TempCtrlEmulator
 
 # One corr file accumulates NTIMES integrations, each of duration
 # INTEGRATION_TIME seconds. FILE_TIME = NTIMES * INTEGRATION_TIME is the
@@ -119,34 +121,44 @@ def _lidar_avg_entry(distance_m):
     }
 
 
+def tempctrl_post_handler_reading(stream_name):
+    """One per-channel tempctrl reading after ``_peltier_redis_handler``.
+
+    The firmware/emulator emits one combined ``sensor_name="tempctrl"``
+    dict per status tick; ``PicoPeltier._peltier_redis_handler`` fans
+    that into two ``writer.add(...)`` calls — one per channel — and is
+    the boundary that produces the actual Redis-stream shapes. Composing
+    the emulator with the handler here means every test fixture downstream
+    is anchored to the real producer output rather than drifting on
+    hand-typed steady-state values.
+    """
+    pel = PicoPeltier.__new__(PicoPeltier)
+    captured = []
+    pel._base_redis_handler = lambda d: captured.append(dict(d))
+    pel._peltier_redis_handler(TempCtrlEmulator().get_status())
+    for entry in captured:
+        if entry.get("sensor_name") == stream_name:
+            return entry
+    raise AssertionError(
+        f"_peltier_redis_handler did not emit a {stream_name!r} entry; "
+        f"got sensor_names={[e.get('sensor_name') for e in captured]}"
+    )
+
+
 def _tempctrl_channel_entry(sensor_name, t_now, timestamp):
     """One per-sample tempctrl channel (``tempctrl_lna`` or ``tempctrl_load``).
 
-    Picohost's ``PicoPeltier._peltier_redis_handler`` fans the firmware's
-    combined status tick into two flat streams; each stream then flows
-    through the generic ``_avg_sensor_values`` reduction like every
-    other sensor. The fixture mirrors the per-stream shape: a top-level
-    ``status`` plus the channel-data fields with the prefix stripped,
-    and the device-wide watchdog fields duplicated into both streams by
-    the handler. Steady-state values (``T_target``, drive flags) are
-    hard-coded to match the inline tempctrl fixtures in ``test_io.py``.
+    Steady-state fields are derived from
+    ``tempctrl_post_handler_reading`` so the fixture stays anchored to
+    real ``TempCtrlEmulator`` + ``PicoPeltier._peltier_redis_handler``
+    output. Only ``T_now`` and ``timestamp`` are per-sample test inputs;
+    everything else (``T_target``, drive flags, watchdog) is the
+    emulator's steady-state value.
     """
-    return {
-        "sensor_name": sensor_name,
-        "status": "update",
-        "app_id": 1,
-        "watchdog_tripped": False,
-        "watchdog_timeout_ms": 5000,
-        "T_now": t_now,
-        "timestamp": timestamp,
-        "T_target": 25.0,
-        "drive_level": 0.0,
-        "enabled": True,
-        "active": True,
-        "int_disabled": False,
-        "hysteresis": 0.5,
-        "clamp": 100.0,
-    }
+    entry = tempctrl_post_handler_reading(sensor_name)
+    entry["T_now"] = t_now
+    entry["timestamp"] = timestamp
+    return entry
 
 
 def _potmon_avg_entry(pot_el_voltage):

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -119,21 +119,24 @@ def _lidar_avg_entry(distance_m):
     }
 
 
-def _tempctrl_channel_entry(t_now, timestamp):
-    """One per-sample tempctrl channel (LNA or LOAD) after add_data's split.
+def _tempctrl_channel_entry(sensor_name, t_now, timestamp):
+    """One per-sample tempctrl channel (``tempctrl_lna`` or ``tempctrl_load``).
 
-    The top-level fields returned by ``_avg_temp_metadata`` are dropped
-    by the LNA/LOAD split in ``File.add_data``; only the per-channel
-    sub-dict survives. The bool/float fault flags are constant in this
-    fixture (steady-state operation); tests that need to exercise
-    fault-flag transitions construct their own samples. ``T_target`` is
-    a user-configured setpoint that is constant over the lifetime of a
-    real run, so it is hard-coded to ``25.0`` here rather than tracking
-    the per-sample ``t_now`` — matching the pattern used by every
-    inline tempctrl fixture in ``test_io.py``.
+    Picohost's ``PicoPeltier._peltier_redis_handler`` fans the firmware's
+    combined status tick into two flat streams; each stream then flows
+    through the generic ``_avg_sensor_values`` reduction like every
+    other sensor. The fixture mirrors the per-stream shape: a top-level
+    ``status`` plus the channel-data fields with the prefix stripped,
+    and the device-wide watchdog fields duplicated into both streams by
+    the handler. Steady-state values (``T_target``, drive flags) are
+    hard-coded to match the inline tempctrl fixtures in ``test_io.py``.
     """
     return {
+        "sensor_name": sensor_name,
         "status": "update",
+        "app_id": 1,
+        "watchdog_tripped": False,
+        "watchdog_timeout_ms": 5000,
         "T_now": t_now,
         "timestamp": timestamp,
         "T_target": 25.0,
@@ -202,11 +205,11 @@ CORR_METADATA = {
     "lidar": [_lidar_avg_entry(1.5 + 0.001 * i) for i in range(NTIMES)],
     "potmon": [_potmon_avg_entry(1.5 + 0.001 * i) for i in range(NTIMES)],
     "tempctrl_lna": [
-        _tempctrl_channel_entry(30.0 + 0.01 * i, 1.0 + i)
+        _tempctrl_channel_entry("tempctrl_lna", 30.0 + 0.01 * i, 1.0 + i)
         for i in range(NTIMES)
     ],
     "tempctrl_load": [
-        _tempctrl_channel_entry(25.0 + 0.01 * i, 1.0 + i)
+        _tempctrl_channel_entry("tempctrl_load", 25.0 + 0.01 * i, 1.0 + i)
         for i in range(NTIMES)
     ],
     "rfswitch": (

--- a/src/eigsep_observing/config/live_status_thresholds.yaml
+++ b/src/eigsep_observing/config/live_status_thresholds.yaml
@@ -2,8 +2,8 @@
 #
 # Signals whose bands follow from obs_config / corr_header are
 # computed in eigsep_observing.live_status.signals.default_thresholds
-# and do NOT need to appear here. Examples: tempctrl.LNA_T_now,
-# tempctrl.LNA_drive_level, corr.acc_cadence_s,
+# and do NOT need to appear here. Examples: tempctrl_lna.T_now,
+# tempctrl_lna.drive_level, corr.acc_cadence_s,
 # file.seconds_since_write.
 #
 # This file holds:
@@ -47,6 +47,6 @@ potmon.pot_az_angle:
 
 # Escape hatch: any entry here overrides the derived default for that
 # signal. Example:
-# tempctrl.LNA_T_now:
+# tempctrl_lna.T_now:
 #   healthy: [22.0, 28.0]
 #   danger:  [18.0, 32.0]

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -33,7 +33,7 @@ import numpy as np
 import pytest
 import yaml
 from picohost import PicoPotentiometer
-from picohost.base import PicoPeltier, PicoRFSwitch
+from picohost.base import PicoRFSwitch
 from picohost.motor import PicoMotor
 from picohost.testing import (
     ImuEmulator,
@@ -41,7 +41,6 @@ from picohost.testing import (
     MotorEmulator,
     PotMonEmulator,
     RFSwitchEmulator,
-    TempCtrlEmulator,
 )
 
 from eigsep_redis.keys import STATUS_STREAM  # noqa: F401
@@ -49,7 +48,11 @@ from eigsep_redis.testing import DummyTransport
 
 import eigsep_observing
 from eigsep_observing import io
-from eigsep_observing._test_fixtures import HEADER, IMU_READING
+from eigsep_observing._test_fixtures import (
+    HEADER,
+    IMU_READING,
+    tempctrl_post_handler_reading,
+)
 from eigsep_observing.testing import (
     DummyEigsepFpga,
     DummyPandaClient,
@@ -124,25 +127,12 @@ def _motor_post_handler_reading():
 def _peltier_post_handler_reading(stream_name):
     """Return one per-channel tempctrl reading after _peltier_redis_handler.
 
-    The firmware/emulator emits one combined ``sensor_name="tempctrl"``
-    dict per status tick; ``PicoPeltier._peltier_redis_handler`` fans
-    that into two ``writer.add(...)`` calls — one per channel — and is
-    the boundary that produces the actual Redis-stream shapes. The
-    contract this test enforces is the *post-handler* per-stream shape,
-    so the fixture has to compose the emulator + the handler. Mirrors
-    ``_potmon_post_handler_reading``.
+    Delegates to ``tempctrl_post_handler_reading`` in ``_test_fixtures``
+    so the contract test and the shared golden fixtures (and the inline
+    fixtures in ``test_io.py``) are anchored to a single emulator-derived
+    source. Mirrors ``_potmon_post_handler_reading``.
     """
-    pel = PicoPeltier.__new__(PicoPeltier)
-    captured = []
-    pel._base_redis_handler = lambda d: captured.append(dict(d))
-    pel._peltier_redis_handler(TempCtrlEmulator().get_status())
-    for entry in captured:
-        if entry.get("sensor_name") == stream_name:
-            return entry
-    raise AssertionError(
-        f"_peltier_redis_handler did not emit a {stream_name!r} entry; "
-        f"got sensor_names={[e.get('sensor_name') for e in captured]}"
-    )
+    return tempctrl_post_handler_reading(stream_name)
 
 
 def _rfswitch_post_handler_reading():

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -33,7 +33,7 @@ import numpy as np
 import pytest
 import yaml
 from picohost import PicoPotentiometer
-from picohost.base import PicoRFSwitch
+from picohost.base import PicoPeltier, PicoRFSwitch
 from picohost.motor import PicoMotor
 from picohost.testing import (
     ImuEmulator,
@@ -121,6 +121,30 @@ def _motor_post_handler_reading():
     return captured
 
 
+def _peltier_post_handler_reading(stream_name):
+    """Return one per-channel tempctrl reading after _peltier_redis_handler.
+
+    The firmware/emulator emits one combined ``sensor_name="tempctrl"``
+    dict per status tick; ``PicoPeltier._peltier_redis_handler`` fans
+    that into two ``writer.add(...)`` calls — one per channel — and is
+    the boundary that produces the actual Redis-stream shapes. The
+    contract this test enforces is the *post-handler* per-stream shape,
+    so the fixture has to compose the emulator + the handler. Mirrors
+    ``_potmon_post_handler_reading``.
+    """
+    pel = PicoPeltier.__new__(PicoPeltier)
+    captured = []
+    pel._base_redis_handler = lambda d: captured.append(dict(d))
+    pel._peltier_redis_handler(TempCtrlEmulator().get_status())
+    for entry in captured:
+        if entry.get("sensor_name") == stream_name:
+            return entry
+    raise AssertionError(
+        f"_peltier_redis_handler did not emit a {stream_name!r} entry; "
+        f"got sensor_names={[e.get('sensor_name') for e in captured]}"
+    )
+
+
 def _rfswitch_post_handler_reading():
     """Return an rfswitch reading after _rfswitch_redis_handler.
 
@@ -179,7 +203,8 @@ SENSOR_EMULATORS = {
     "imu_el": lambda: ImuEmulator(app_id=3).get_status(),
     "imu_az": lambda: ImuEmulator(app_id=6).get_status(),
     "rfswitch": _rfswitch_post_handler_reading,
-    "tempctrl": lambda: TempCtrlEmulator().get_status(),
+    "tempctrl_lna": lambda: _peltier_post_handler_reading("tempctrl_lna"),
+    "tempctrl_load": lambda: _peltier_post_handler_reading("tempctrl_load"),
     "lidar": lambda: LidarEmulator().get_status(),
     "potmon": _potmon_post_handler_reading,
     "motor": _motor_post_handler_reading,

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -620,6 +620,31 @@ _IMU_SCHEMA = {
     "accel_z": float,
 }
 
+# tempctrl publishes two flat streams (one per Peltier channel), each
+# matching this schema. The producer is
+# `picohost.base.PicoPeltier._peltier_redis_handler`, which fans the
+# firmware's combined tick into two `writer.add(...)` calls, stripping
+# the `LNA_`/`LOAD_` prefix and duplicating the device-wide
+# `watchdog_tripped` / `watchdog_timeout_ms` fields into both streams.
+# With per-stream `status`, both streams flow through the generic
+# `_avg_sensor_values` reduction like every other sensor.
+_PELTIER_SCHEMA = {
+    "sensor_name": str,
+    "status": str,
+    "app_id": int,
+    "watchdog_tripped": bool,
+    "watchdog_timeout_ms": int,
+    "T_now": float,
+    "timestamp": float,
+    "T_target": float,
+    "drive_level": float,
+    "enabled": bool,
+    "active": bool,
+    "int_disabled": bool,
+    "hysteresis": float,
+    "clamp": float,
+}
+
 # `potmon` (potentiometer monitor): the producer is `PotMonEmulator` +
 # `PicoPotentiometer._pot_redis_handler`, which augments the raw
 # voltages with calibration slope/intercept and the derived angle.
@@ -633,32 +658,8 @@ _IMU_SCHEMA = {
 SENSOR_SCHEMAS = {
     "imu_el": _IMU_SCHEMA,
     "imu_az": _IMU_SCHEMA,
-    "tempctrl": {
-        "sensor_name": str,
-        "app_id": int,
-        "watchdog_tripped": bool,
-        "watchdog_timeout_ms": int,
-        "LNA_status": str,
-        "LNA_T_now": float,
-        "LNA_timestamp": float,
-        "LNA_T_target": float,
-        "LNA_drive_level": float,
-        "LNA_enabled": bool,
-        "LNA_active": bool,
-        "LNA_int_disabled": bool,
-        "LNA_hysteresis": float,
-        "LNA_clamp": float,
-        "LOAD_status": str,
-        "LOAD_T_now": float,
-        "LOAD_timestamp": float,
-        "LOAD_T_target": float,
-        "LOAD_drive_level": float,
-        "LOAD_enabled": bool,
-        "LOAD_active": bool,
-        "LOAD_int_disabled": bool,
-        "LOAD_hysteresis": float,
-        "LOAD_clamp": float,
-    },
+    "tempctrl_lna": _PELTIER_SCHEMA,
+    "tempctrl_load": _PELTIER_SCHEMA,
     "potmon": {
         "sensor_name": str,
         "status": str,
@@ -985,84 +986,11 @@ def avg_metadata(value):
             f"No schema for sensor '{app_name}'; skipping validation"
         )
 
-    if app_name == "tempctrl":
-        return _avg_temp_metadata(value, app_name, schema)
-
     if app_name == "rfswitch":
         return _avg_rfswitch_metadata(value)
 
-    # generic sensor (e.g. IMU, lidar)
+    # generic sensor (e.g. IMU, lidar, tempctrl_lna, tempctrl_load)
     return _avg_sensor_values(value, schema, app_name=app_name)
-
-
-def _avg_temp_metadata(value, app_name, schema):
-    """
-    Average tempctrl metadata, handling LNA/LOAD channels.
-
-    Three classes of fields:
-      - Top-level non-prefixed fields (``sensor_name``, ``app_id``,
-        ``watchdog_tripped``, ``watchdog_timeout_ms``). Run through
-        ``_avg_sensor_values`` against the top-level subset of *schema*
-        so they appear in the output dict.
-      - ``LNA_``/``LOAD_``-prefixed fields. The prefix is stripped and
-        each channel becomes its own sub-dict under key ``"LNA"`` /
-        ``"LOAD"``.
-      - ``sensor_name`` is always normalized to ``app_name`` (the schema
-        lookup key) rather than whatever the producer wrote.
-
-    Earlier versions of this function only forwarded ``sensor_name`` and
-    ``app_id`` and silently dropped any other top-level field — which
-    quietly lost tempctrl's watchdog state. Fixed by enumerating the
-    top-level schema keys explicitly.
-    """
-    avgs = {}
-
-    if schema is not None:
-        top_keys = [
-            k
-            for k in schema
-            if not k.startswith("LNA_") and not k.startswith("LOAD_")
-        ]
-        if top_keys:
-            top_sub_schema = {k: schema[k] for k in top_keys}
-            top_avgs = _avg_sensor_values(
-                value, top_sub_schema, app_name=app_name
-            )
-            if top_avgs:
-                avgs.update(top_avgs)
-    else:
-        # Schemaless fallback: not exercised in production today (every
-        # temp_* sensor has a schema), but preserves the historical
-        # "carry forward app_id" behavior so this branch is safe.
-        avgs["app_id"] = value[0].get("app_id")
-
-    avgs["sensor_name"] = app_name
-
-    # Per-channel LNA/LOAD extraction.
-    for subkey in ("LNA", "LOAD"):
-        prefix = f"{subkey}_"
-        if schema is not None:
-            keys = [k for k in schema if k.startswith(prefix)]
-            sub_schema = {k[len(prefix) :]: schema[k] for k in keys}
-        else:
-            keys = [k for k in value[0] if k.startswith(prefix)]
-            sub_schema = None
-        if not keys:
-            continue
-        subvals = []
-        for v in value:
-            sub = {}
-            for k in keys:
-                if k in v:
-                    sub[k[len(prefix) :]] = v[k]
-            if sub:
-                sub.setdefault("status", v.get(f"{subkey}_status"))
-                subvals.append(sub)
-        if subvals:
-            avgs[subkey] = _avg_sensor_values(
-                subvals, sub_schema, app_name=app_name
-            )
-    return avgs
 
 
 def _avg_rfswitch_metadata(value):
@@ -1498,14 +1426,7 @@ class File:
             try:
                 # strip stream prefix
                 name = key.removeprefix("stream:")
-                averaged = avg_metadata(value)
-                if isinstance(averaged, dict) and "LNA" in averaged:
-                    # tempctrl: split LNA/LOAD into separate flat entries
-                    for ch in ("LNA", "LOAD"):
-                        if ch in averaged:
-                            processed_md[f"{name}_{ch.lower()}"] = averaged[ch]
-                else:
-                    processed_md[name] = averaged
+                processed_md[name] = avg_metadata(value)
             except Exception as e:
                 self.logger.error(
                     f"Metadata contract violation processing stream "

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -144,22 +144,22 @@ def _solve_calibration(
     if state.last_rfnon_unix is not None:
         meta["last_rfnon_age_s"] = max(0.0, now - state.last_rfnon_unix)
 
-    tempctrl = state.metadata_snapshot.get("tempctrl")
+    tempctrl_load = state.metadata_snapshot.get("tempctrl_load")
     load_t_now = (
-        tempctrl.get("LOAD_T_now") if isinstance(tempctrl, dict) else None
+        tempctrl_load.get("T_now") if isinstance(tempctrl_load, dict) else None
     )
     try:
         load_t_now_f = float(load_t_now) if load_t_now is not None else None
     except (TypeError, ValueError):
         logger.error(
-            "Live-status cal: tempctrl.LOAD_T_now=%r is not coercible to "
-            "float; producer/schema contract violation (LOAD_T_now must be "
+            "Live-status cal: tempctrl_load.T_now=%r is not coercible to "
+            "float; producer/schema contract violation (T_now must be "
             "float per SENSOR_SCHEMAS).",
             load_t_now,
         )
         load_t_now_f = None
     if load_t_now_f is None:
-        meta["reason"] = "tempctrl.LOAD_T_now missing or non-numeric"
+        meta["reason"] = "tempctrl_load.T_now missing or non-numeric"
         return None, meta
     t_load_k = load_t_now_f + CELSIUS_TO_KELVIN
     meta["t_load_k"] = t_load_k

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -29,7 +29,7 @@ class Signal:
     Attributes
     ----------
     name
-        Dotted signal identifier (e.g. ``tempctrl.LNA_T_now``).
+        Dotted signal identifier (e.g. ``tempctrl_lna.T_now``).
     description
         Short human-readable label for the tile.
     unit
@@ -82,26 +82,29 @@ SIGNAL_REGISTRY: dict[str, Signal] = {
         unit="s",
         max_age_s=None,
     ),
-    # Tempctrl — derived from target_C / hysteresis_C / clamp.
-    "tempctrl.LNA_T_now": Signal(
-        "tempctrl.LNA_T_now",
+    # Tempctrl — derived from target_C / hysteresis_C / clamp. Each
+    # Peltier channel publishes its own Redis stream (tempctrl_lna,
+    # tempctrl_load), so signal names route through the standard
+    # `<domain>.<field>` form per channel.
+    "tempctrl_lna.T_now": Signal(
+        "tempctrl_lna.T_now",
         "LNA temperature",
         unit="C",
         enabled_by="use_tempctrl",
     ),
-    "tempctrl.LOAD_T_now": Signal(
-        "tempctrl.LOAD_T_now",
+    "tempctrl_load.T_now": Signal(
+        "tempctrl_load.T_now",
         "LOAD temperature",
         unit="C",
         enabled_by="use_tempctrl",
     ),
-    "tempctrl.LNA_drive_level": Signal(
-        "tempctrl.LNA_drive_level",
+    "tempctrl_lna.drive_level": Signal(
+        "tempctrl_lna.drive_level",
         "LNA drive level",
         enabled_by="use_tempctrl",
     ),
-    "tempctrl.LOAD_drive_level": Signal(
-        "tempctrl.LOAD_drive_level",
+    "tempctrl_load.drive_level": Signal(
+        "tempctrl_load.drive_level",
         "LOAD drive level",
         enabled_by="use_tempctrl",
     ),
@@ -196,13 +199,19 @@ def default_thresholds(
 
     if obs_cfg.get("use_tempctrl"):
         settings = obs_cfg.get("tempctrl_settings", {}) or {}
-        for channel in ("LNA", "LOAD"):
+        # YAML config still groups per-channel settings under {LNA, LOAD}
+        # — that's user-facing. Internal signal names follow the split
+        # stream model: tempctrl_lna.T_now etc.
+        for channel, stream in (
+            ("LNA", "tempctrl_lna"),
+            ("LOAD", "tempctrl_load"),
+        ):
             ch_cfg = settings.get(channel, {}) or {}
             target = ch_cfg.get("target_C")
             hyst = ch_cfg.get("hysteresis_C")
             clamp = ch_cfg.get("clamp")
             if target is not None and hyst is not None:
-                out[f"tempctrl.{channel}_T_now"] = {
+                out[f"{stream}.T_now"] = {
                     "healthy": [target - 2 * hyst, target + 2 * hyst],
                     # danger band filled in by Thresholds using
                     # tempctrl.danger_k_C from the YAML override
@@ -211,7 +220,7 @@ def default_thresholds(
                     "_target_C": target,
                 }
             if clamp is not None:
-                out[f"tempctrl.{channel}_drive_level"] = {
+                out[f"{stream}.drive_level"] = {
                     "healthy": [0.0, float(clamp)],
                     "danger": None,
                 }

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -425,25 +425,29 @@ function renderMetadataTiles(meta) {
 function renderTempctrlTiles(meta, classifiers) {
   const container = document.getElementById("tempctrl-tiles");
   container.replaceChildren();
-  const tc = meta.tempctrl;
-  if (!tc) {
-    container.textContent = "no tempctrl data";
-    return;
-  }
-  const value = tc.value || {};
-  for (const chan of ["LNA", "LOAD"]) {
-    const temp = value[`${chan}_T_now`];
-    const drive = value[`${chan}_drive_level`];
-    const tClass = (tc.classify || {})[`tempctrl.${chan}_T_now`] || "unknown";
-    const dClass = (tc.classify || {})[`tempctrl.${chan}_drive_level`] || "unknown";
+  const channels = [
+    { label: "LNA", stream: "tempctrl_lna" },
+    { label: "LOAD", stream: "tempctrl_load" },
+  ];
+  let any = false;
+  for (const { label, stream } of channels) {
+    const entry = meta[stream];
+    if (!entry) continue;
+    any = true;
+    const value = entry.value || {};
+    const tClass = (entry.classify || {})[`${stream}.T_now`] || "unknown";
+    const dClass = (entry.classify || {})[`${stream}.drive_level`] || "unknown";
     const row = document.createElement("div");
     row.className = "tempctrl-row";
     row.append(
-      makeSpan("label", chan),
-      makeSpan(tileClass(tClass), `${fmt(temp, 2)} C`),
-      makeSpan(tileClass(dClass), `drive ${fmt(drive, 2)}`)
+      makeSpan("label", label),
+      makeSpan(tileClass(tClass), `${fmt(value.T_now, 2)} C`),
+      makeSpan(tileClass(dClass), `drive ${fmt(value.drive_level, 2)}`)
     );
     container.appendChild(row);
+  }
+  if (!any) {
+    container.textContent = "no tempctrl data";
   }
 }
 

--- a/src/eigsep_observing/tempctrl_client.py
+++ b/src/eigsep_observing/tempctrl_client.py
@@ -130,11 +130,39 @@ class TempCtrlClient:
         return self._proxy.is_available
 
     def get_status(self):
-        """Latest tempctrl metadata snapshot, or ``None`` if absent."""
+        """Latest tempctrl metadata snapshot, or ``None`` if absent.
+
+        The picohost producer publishes two streams — ``tempctrl_lna``
+        and ``tempctrl_load``, each with flat per-channel fields plus a
+        duplicated copy of the device-wide watchdog state. This method
+        merges them back into the flat ``LNA_*`` / ``LOAD_*`` shape
+        used internally by ``_tempctrl_health_check`` so callers don't
+        have to know about the split.
+        """
         try:
-            return self._reader.get("tempctrl")
+            lna = self._reader.get("tempctrl_lna")
         except KeyError:
+            lna = None
+        try:
+            load = self._reader.get("tempctrl_load")
+        except KeyError:
+            load = None
+        if not lna and not load:
             return None
+        merged = {}
+        for prefix, src in (("LNA_", lna), ("LOAD_", load)):
+            if not src:
+                continue
+            for k, v in src.items():
+                if k in ("sensor_name", "app_id"):
+                    continue
+                if k in ("watchdog_tripped", "watchdog_timeout_ms"):
+                    # Device-wide; same firmware tick produced both
+                    # entries, so first-write-wins.
+                    merged.setdefault(k, v)
+                else:
+                    merged[f"{prefix}{k}"] = v
+        return merged or None
 
     def set_watchdog_timeout(self, timeout_ms):
         self._proxy.send_command(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from eigsep_observing._test_fixtures import (  # noqa: F401 (re-exported)
     NTIMES,
     S11_HEADER,
     VNA_METADATA,
+    tempctrl_post_handler_reading,
 )
 from eigsep_observing.testing import DummyPandaClient
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -61,7 +61,11 @@ def test_sensor_metadata_in_redis(client, transport):
     metadata = MetadataSnapshotReader(transport).get()
 
     expected_sensors = {
-        "tempctrl",
+        # tempctrl publishes two streams (one per Peltier channel); the
+        # picohost producer fans the firmware's combined tick into
+        # tempctrl_lna and tempctrl_load.
+        "tempctrl_lna",
+        "tempctrl_load",
         "potmon",
         "imu_el",
         "imu_az",
@@ -81,11 +85,16 @@ def test_metadata_has_expected_fields(client, transport):
 
     metadata = MetadataSnapshotReader(transport).get()
 
-    # Check tempctrl LNA/LOAD channels
-    tempctrl = metadata.get("tempctrl", {})
-    assert "LNA_T_now" in tempctrl
-    assert "LOAD_T_now" in tempctrl
-    assert tempctrl.get("sensor_name") == "tempctrl"
+    # Each Peltier channel has its own stream with flat per-channel
+    # fields, a top-level status, and the device-wide watchdog fields
+    # duplicated in by the picohost handler.
+    for stream in ("tempctrl_lna", "tempctrl_load"):
+        entry = metadata.get(stream, {})
+        assert entry.get("sensor_name") == stream
+        assert "status" in entry
+        assert "T_now" in entry
+        assert "drive_level" in entry
+        assert "watchdog_timeout_ms" in entry
 
     # Check IMU (BNO085 RVC mode)
     imu = metadata.get("imu_el", {})

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -765,69 +765,88 @@ def test_avg_metadata():
     sw_data[1] = dict(sw_data[0], status="error")
     assert io.avg_metadata(sw_data) == "UNKNOWN"
 
-    # tempctrl: LNA/LOAD channels (channel-split path)
-    tc_data = [
+    # tempctrl_lna and tempctrl_load are independent streams that each
+    # flow through the generic _avg_sensor_values path; no special-case
+    # dispatch. Per-channel "status" collapses to "error" on any errored
+    # sample, just like every other sensor.
+    lna_data = [
         {
-            "sensor_name": "tempctrl",
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
             "app_id": 1,
             "watchdog_tripped": False,
             "watchdog_timeout_ms": 5000,
-            "LNA_status": "update",
-            "LNA_T_now": 30.0,
-            "LNA_timestamp": 1.0,
-            "LNA_T_target": 25.0,
-            "LNA_drive_level": 0.5,
-            "LNA_enabled": True,
-            "LNA_active": True,
-            "LNA_int_disabled": False,
-            "LNA_hysteresis": 0.1,
-            "LNA_clamp": 1.0,
-            "LOAD_status": "update",
-            "LOAD_T_now": 25.0,
-            "LOAD_timestamp": 2.0,
-            "LOAD_T_target": 25.0,
-            "LOAD_drive_level": 0.5,
-            "LOAD_enabled": True,
-            "LOAD_active": True,
-            "LOAD_int_disabled": False,
-            "LOAD_hysteresis": 0.1,
-            "LOAD_clamp": 1.0,
+            "T_now": 30.0,
+            "timestamp": 1.0,
+            "T_target": 25.0,
+            "drive_level": 0.5,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.1,
+            "clamp": 1.0,
         },
         {
-            "sensor_name": "tempctrl",
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
             "app_id": 1,
             "watchdog_tripped": False,
             "watchdog_timeout_ms": 5000,
-            "LNA_status": "update",
-            "LNA_T_now": 32.0,
-            "LNA_timestamp": 3.0,
-            "LNA_T_target": 25.0,
-            "LNA_drive_level": 0.5,
-            "LNA_enabled": True,
-            "LNA_active": True,
-            "LNA_int_disabled": False,
-            "LNA_hysteresis": 0.1,
-            "LNA_clamp": 1.0,
-            "LOAD_status": "error",
-            "LOAD_T_now": 0.0,
-            "LOAD_timestamp": 4.0,
-            "LOAD_T_target": 25.0,
-            "LOAD_drive_level": 0.5,
-            "LOAD_enabled": True,
-            "LOAD_active": True,
-            "LOAD_int_disabled": False,
-            "LOAD_hysteresis": 0.1,
-            "LOAD_clamp": 1.0,
+            "T_now": 32.0,
+            "timestamp": 3.0,
+            "T_target": 25.0,
+            "drive_level": 0.5,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.1,
+            "clamp": 1.0,
         },
     ]
-    result = io.avg_metadata(tc_data)
-    assert result["sensor_name"] == "tempctrl"
-    assert result["LNA"]["T_now"] == 31.0  # average of 30 and 32
-    # LOAD has one error entry, so only non-error value used
-    assert result["LOAD"]["T_now"] == 25.0
-    # status averages: LNA has no errors → "update"; LOAD has one → "error"
-    assert result["LNA"]["status"] == "update"
-    assert result["LOAD"]["status"] == "error"
+    result = io.avg_metadata(lna_data)
+    assert result["sensor_name"] == "tempctrl_lna"
+    assert result["T_now"] == pytest.approx(31.0)  # average of 30 and 32
+    assert result["status"] == "update"
+
+    load_data = [
+        {
+            "sensor_name": "tempctrl_load",
+            "status": "update",
+            "app_id": 1,
+            "watchdog_tripped": False,
+            "watchdog_timeout_ms": 5000,
+            "T_now": 25.0,
+            "timestamp": 2.0,
+            "T_target": 25.0,
+            "drive_level": 0.5,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.1,
+            "clamp": 1.0,
+        },
+        {
+            "sensor_name": "tempctrl_load",
+            "status": "error",
+            "app_id": 1,
+            "watchdog_tripped": False,
+            "watchdog_timeout_ms": 5000,
+            "T_now": 0.0,
+            "timestamp": 4.0,
+            "T_target": 25.0,
+            "drive_level": 0.5,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.1,
+            "clamp": 1.0,
+        },
+    ]
+    result = io.avg_metadata(load_data)
+    # one error sample → float reduction filters it; only 25.0 survives.
+    assert result["T_now"] == pytest.approx(25.0)
+    # status collapses to "error" if any sample errored.
+    assert result["status"] == "error"
 
     # generic sensor (IMU) — full schema-conformant data
     imu_data = [
@@ -843,80 +862,49 @@ def test_avg_metadata():
     assert isinstance(result["app_id"], int)
 
 
-def test_avg_metadata_tempctrl_forwards_top_level_fields():
-    """tempctrl has top-level (non A_/B_-prefixed) fields like
-    watchdog_tripped (bool) and watchdog_timeout_ms (int) that earlier
-    versions of _avg_temp_metadata silently dropped because the helper
-    only enumerated A_/B_ keys. Lock in the fix: top-level fields must
-    survive into the averaged output, with types preserved per schema.
+def test_avg_metadata_tempctrl_watchdog_fields_survive_split():
+    """Each split tempctrl stream carries the device-wide watchdog
+    fields (``watchdog_tripped``, ``watchdog_timeout_ms``) duplicated
+    in by the picohost producer. Lock in that the generic
+    ``_avg_sensor_values`` path preserves them with types intact —
+    before the LNA/LOAD split, an earlier ``_avg_temp_metadata``
+    silently dropped these because the helper only enumerated channel
+    keys.
     """
-    tc_data = [
-        {
-            "sensor_name": "tempctrl",
+
+    def _make(stream, t_now):
+        return {
+            "sensor_name": stream,
+            "status": "update",
             "app_id": 1,
             "watchdog_tripped": False,
             "watchdog_timeout_ms": 5000,
-            "LNA_status": "update",
-            "LNA_T_now": 30.0,
-            "LNA_timestamp": 1.0,
-            "LNA_T_target": 25.0,
-            "LNA_drive_level": 0.5,
-            "LNA_enabled": True,
-            "LNA_active": True,
-            "LNA_int_disabled": False,
-            "LNA_hysteresis": 0.1,
-            "LNA_clamp": 1.0,
-            "LOAD_status": "update",
-            "LOAD_T_now": 32.0,
-            "LOAD_timestamp": 2.0,
-            "LOAD_T_target": 25.0,
-            "LOAD_drive_level": 0.6,
-            "LOAD_enabled": True,
-            "LOAD_active": True,
-            "LOAD_int_disabled": False,
-            "LOAD_hysteresis": 0.1,
-            "LOAD_clamp": 1.0,
-        },
-        {
-            "sensor_name": "tempctrl",
-            "app_id": 1,
-            "watchdog_tripped": False,
-            "watchdog_timeout_ms": 5000,
-            "LNA_status": "update",
-            "LNA_T_now": 32.0,  # average with 30.0 → 31.0
-            "LNA_timestamp": 3.0,
-            "LNA_T_target": 25.0,
-            "LNA_drive_level": 0.5,
-            "LNA_enabled": True,
-            "LNA_active": True,
-            "LNA_int_disabled": False,
-            "LNA_hysteresis": 0.1,
-            "LNA_clamp": 1.0,
-            "LOAD_status": "update",
-            "LOAD_T_now": 32.0,
-            "LOAD_timestamp": 4.0,
-            "LOAD_T_target": 25.0,
-            "LOAD_drive_level": 0.6,
-            "LOAD_enabled": True,
-            "LOAD_active": True,
-            "LOAD_int_disabled": False,
-            "LOAD_hysteresis": 0.1,
-            "LOAD_clamp": 1.0,
-        },
-    ]
-    result = io.avg_metadata(tc_data)
+            "T_now": t_now,
+            "timestamp": 1.0,
+            "T_target": 25.0,
+            "drive_level": 0.5,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.1,
+            "clamp": 1.0,
+        }
 
-    # Top-level fields are forwarded with types preserved.
-    assert result["sensor_name"] == "tempctrl"
-    assert result["app_id"] == 1
-    assert isinstance(result["app_id"], int)
-    assert result["watchdog_tripped"] is False
-    assert result["watchdog_timeout_ms"] == 5000
-    assert isinstance(result["watchdog_timeout_ms"], int)
+    lna = io.avg_metadata(
+        [_make("tempctrl_lna", 30.0), _make("tempctrl_lna", 32.0)]
+    )
+    assert lna["sensor_name"] == "tempctrl_lna"
+    assert lna["app_id"] == 1
+    assert isinstance(lna["app_id"], int)
+    assert lna["watchdog_tripped"] is False
+    assert lna["watchdog_timeout_ms"] == 5000
+    assert isinstance(lna["watchdog_timeout_ms"], int)
+    assert lna["T_now"] == pytest.approx(31.0)
 
-    # LNA/LOAD sub-dicts still produced and floats still averaged.
-    assert result["LNA"]["T_now"] == pytest.approx(31.0)
-    assert result["LOAD"]["T_now"] == pytest.approx(32.0)
+    load = io.avg_metadata([_make("tempctrl_load", 32.0)])
+    assert load["sensor_name"] == "tempctrl_load"
+    assert load["watchdog_timeout_ms"] == 5000
+    assert load["T_now"] == pytest.approx(32.0)
 
 
 # ----------------------------------------------------------------------
@@ -968,29 +956,19 @@ def test_avg_metadata_bool_any_on_disagreement():
     integration whose watchdog tripped at any point in the integration
     must record watchdog_tripped=True."""
     base = {
-        "sensor_name": "tempctrl",
+        "sensor_name": "tempctrl_lna",
+        "status": "update",
         "app_id": 1,
         "watchdog_timeout_ms": 5000,
-        "LNA_status": "update",
-        "LNA_T_now": 30.0,
-        "LNA_timestamp": 1.0,
-        "LNA_T_target": 25.0,
-        "LNA_drive_level": 0.5,
-        "LNA_enabled": True,
-        "LNA_active": True,
-        "LNA_int_disabled": False,
-        "LNA_hysteresis": 0.1,
-        "LNA_clamp": 1.0,
-        "LOAD_status": "update",
-        "LOAD_T_now": 30.0,
-        "LOAD_timestamp": 1.0,
-        "LOAD_T_target": 25.0,
-        "LOAD_drive_level": 0.5,
-        "LOAD_enabled": True,
-        "LOAD_active": True,
-        "LOAD_int_disabled": False,
-        "LOAD_hysteresis": 0.1,
-        "LOAD_clamp": 1.0,
+        "T_now": 30.0,
+        "timestamp": 1.0,
+        "T_target": 25.0,
+        "drive_level": 0.5,
+        "enabled": True,
+        "active": True,
+        "int_disabled": False,
+        "hysteresis": 0.1,
+        "clamp": 1.0,
     }
     data = [
         {**base, "watchdog_tripped": False},
@@ -1225,8 +1203,11 @@ def test_stream_metadata_averaging():
         f.close()
 
 
-def test_temp_metadata_split():
-    """Verify tempctrl LNA/LOAD channels split into separate entries."""
+def test_temp_metadata_streams_land_in_file():
+    """tempctrl_lna and tempctrl_load are independent streams; each
+    lands as a flat per-channel entry in the file. (Producer-side
+    fan-out lives in picohost's PicoPeltier._peltier_redis_handler.)
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         save_dir = Path(tmpdir)
         pairs = ["0"]
@@ -1237,44 +1218,39 @@ def test_temp_metadata_split():
         spec_len = io.data_shape(1, HEADER["acc_bins"], HEADER["nchan"])[1]
         d = {"0": np.ones(spec_len, dtype=dtype)}
 
+        def _entry(stream, t_now, timestamp):
+            return {
+                "sensor_name": stream,
+                "status": "update",
+                "app_id": 1,
+                "watchdog_tripped": False,
+                "watchdog_timeout_ms": 5000,
+                "T_now": t_now,
+                "timestamp": timestamp,
+                "T_target": 25.0,
+                "drive_level": 0.5,
+                "enabled": True,
+                "active": True,
+                "int_disabled": False,
+                "hysteresis": 0.1,
+                "clamp": 1.0,
+            }
+
         md = {
-            "stream:tempctrl": [
-                {
-                    "sensor_name": "tempctrl",
-                    "app_id": 1,
-                    "watchdog_tripped": False,
-                    "watchdog_timeout_ms": 5000,
-                    "LNA_status": "update",
-                    "LNA_T_now": 30.0,
-                    "LNA_timestamp": 1.0,
-                    "LNA_T_target": 25.0,
-                    "LNA_drive_level": 0.5,
-                    "LNA_enabled": True,
-                    "LNA_active": True,
-                    "LNA_int_disabled": False,
-                    "LNA_hysteresis": 0.1,
-                    "LNA_clamp": 1.0,
-                    "LOAD_status": "update",
-                    "LOAD_T_now": 25.0,
-                    "LOAD_timestamp": 2.0,
-                    "LOAD_T_target": 25.0,
-                    "LOAD_drive_level": 0.5,
-                    "LOAD_enabled": True,
-                    "LOAD_active": True,
-                    "LOAD_int_disabled": False,
-                    "LOAD_hysteresis": 0.1,
-                    "LOAD_clamp": 1.0,
-                },
-            ],
+            "stream:tempctrl_lna": [_entry("tempctrl_lna", 30.0, 1.0)],
+            "stream:tempctrl_load": [_entry("tempctrl_load", 25.0, 2.0)],
         }
         f.add_data(1, 0.0, d, metadata=md)
 
-        # LNA and LOAD should be separate flat entries, not nested
         assert "tempctrl" not in f.metadata
         assert "tempctrl_lna" in f.metadata
         assert "tempctrl_load" in f.metadata
         assert f.metadata["tempctrl_lna"][0]["T_now"] == 30.0
         assert f.metadata["tempctrl_load"][0]["T_now"] == 25.0
+        # Device-wide watchdog fields survive into the file (the old
+        # _avg_temp_metadata split dropped them).
+        assert f.metadata["tempctrl_lna"][0]["watchdog_timeout_ms"] == 5000
+        assert f.metadata["tempctrl_load"][0]["watchdog_timeout_ms"] == 5000
 
         f.close()
 
@@ -1339,32 +1315,40 @@ def test_metadata_end_to_end_round_trip():
                     "pot_az_angle": 200.0 * 1.5 - 100.0,
                 },
             ],
-            "stream:tempctrl": [
+            "stream:tempctrl_lna": [
                 {
-                    "sensor_name": "tempctrl",
+                    "sensor_name": "tempctrl_lna",
+                    "status": "update",
                     "app_id": 1,
                     "watchdog_tripped": False,
                     "watchdog_timeout_ms": 5000,
-                    "LNA_status": "update",
-                    "LNA_T_now": 30.0 + 0.01 * i,
-                    "LNA_timestamp": 1.0 + i,
-                    "LNA_T_target": 25.0,
-                    "LNA_drive_level": 0.0,
-                    "LNA_enabled": True,
-                    "LNA_active": True,
-                    "LNA_int_disabled": False,
-                    "LNA_hysteresis": 0.5,
-                    "LNA_clamp": 100.0,
-                    "LOAD_status": "update",
-                    "LOAD_T_now": 25.0 + 0.01 * i,
-                    "LOAD_timestamp": 1.0 + i,
-                    "LOAD_T_target": 25.0,
-                    "LOAD_drive_level": 0.0,
-                    "LOAD_enabled": True,
-                    "LOAD_active": True,
-                    "LOAD_int_disabled": False,
-                    "LOAD_hysteresis": 0.5,
-                    "LOAD_clamp": 100.0,
+                    "T_now": 30.0 + 0.01 * i,
+                    "timestamp": 1.0 + i,
+                    "T_target": 25.0,
+                    "drive_level": 0.0,
+                    "enabled": True,
+                    "active": True,
+                    "int_disabled": False,
+                    "hysteresis": 0.5,
+                    "clamp": 100.0,
+                },
+            ],
+            "stream:tempctrl_load": [
+                {
+                    "sensor_name": "tempctrl_load",
+                    "status": "update",
+                    "app_id": 1,
+                    "watchdog_tripped": False,
+                    "watchdog_timeout_ms": 5000,
+                    "T_now": 25.0 + 0.01 * i,
+                    "timestamp": 1.0 + i,
+                    "T_target": 25.0,
+                    "drive_level": 0.0,
+                    "enabled": True,
+                    "active": True,
+                    "int_disabled": False,
+                    "hysteresis": 0.5,
+                    "clamp": 100.0,
                 },
             ],
         }
@@ -1709,17 +1693,6 @@ def test_avg_rfswitch_metadata_raises_on_non_dict_entry():
     ]
     with pytest.raises(AttributeError):
         io._avg_rfswitch_metadata(value)
-
-
-def test_avg_temp_metadata_raises_on_non_dict_first_entry():
-    """A non-dict first entry trips value[0].get('app_id') →
-    AttributeError. Must propagate."""
-    with pytest.raises(AttributeError):
-        io._avg_temp_metadata(
-            ["not a dict"],
-            "tempctrl",
-            io.SENSOR_SCHEMAS["tempctrl"],
-        )
 
 
 def test_validate_metadata():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,6 +22,7 @@ from conftest import (
     NTIMES,
     S11_HEADER,
     VNA_METADATA,
+    tempctrl_post_handler_reading,
 )
 from eigsep_observing import io
 from eigsep_observing.testing.utils import (
@@ -768,80 +769,31 @@ def test_avg_metadata():
     # tempctrl_lna and tempctrl_load are independent streams that each
     # flow through the generic _avg_sensor_values path; no special-case
     # dispatch. Per-channel "status" collapses to "error" on any errored
-    # sample, just like every other sensor.
-    lna_data = [
-        {
-            "sensor_name": "tempctrl_lna",
-            "status": "update",
-            "app_id": 1,
-            "watchdog_tripped": False,
-            "watchdog_timeout_ms": 5000,
-            "T_now": 30.0,
-            "timestamp": 1.0,
-            "T_target": 25.0,
-            "drive_level": 0.5,
-            "enabled": True,
-            "active": True,
-            "int_disabled": False,
-            "hysteresis": 0.1,
-            "clamp": 1.0,
-        },
-        {
-            "sensor_name": "tempctrl_lna",
-            "status": "update",
-            "app_id": 1,
-            "watchdog_tripped": False,
-            "watchdog_timeout_ms": 5000,
-            "T_now": 32.0,
-            "timestamp": 3.0,
-            "T_target": 25.0,
-            "drive_level": 0.5,
-            "enabled": True,
-            "active": True,
-            "int_disabled": False,
-            "hysteresis": 0.1,
-            "clamp": 1.0,
-        },
-    ]
+    # sample, just like every other sensor. Per-sample dicts are anchored
+    # to the real TempCtrlEmulator + PicoPeltier._peltier_redis_handler
+    # output via tempctrl_post_handler_reading; only T_now/timestamp/status
+    # vary per sample.
+    def _lna(t_now, timestamp, status="update"):
+        e = tempctrl_post_handler_reading("tempctrl_lna")
+        e["T_now"] = t_now
+        e["timestamp"] = timestamp
+        e["status"] = status
+        return e
+
+    def _load(t_now, timestamp, status="update"):
+        e = tempctrl_post_handler_reading("tempctrl_load")
+        e["T_now"] = t_now
+        e["timestamp"] = timestamp
+        e["status"] = status
+        return e
+
+    lna_data = [_lna(30.0, 1.0), _lna(32.0, 3.0)]
     result = io.avg_metadata(lna_data)
     assert result["sensor_name"] == "tempctrl_lna"
     assert result["T_now"] == pytest.approx(31.0)  # average of 30 and 32
     assert result["status"] == "update"
 
-    load_data = [
-        {
-            "sensor_name": "tempctrl_load",
-            "status": "update",
-            "app_id": 1,
-            "watchdog_tripped": False,
-            "watchdog_timeout_ms": 5000,
-            "T_now": 25.0,
-            "timestamp": 2.0,
-            "T_target": 25.0,
-            "drive_level": 0.5,
-            "enabled": True,
-            "active": True,
-            "int_disabled": False,
-            "hysteresis": 0.1,
-            "clamp": 1.0,
-        },
-        {
-            "sensor_name": "tempctrl_load",
-            "status": "error",
-            "app_id": 1,
-            "watchdog_tripped": False,
-            "watchdog_timeout_ms": 5000,
-            "T_now": 0.0,
-            "timestamp": 4.0,
-            "T_target": 25.0,
-            "drive_level": 0.5,
-            "enabled": True,
-            "active": True,
-            "int_disabled": False,
-            "hysteresis": 0.1,
-            "clamp": 1.0,
-        },
-    ]
+    load_data = [_load(25.0, 2.0), _load(0.0, 4.0, status="error")]
     result = io.avg_metadata(load_data)
     # one error sample → float reduction filters it; only 25.0 survives.
     assert result["T_now"] == pytest.approx(25.0)
@@ -871,24 +823,15 @@ def test_avg_metadata_tempctrl_watchdog_fields_survive_split():
     silently dropped these because the helper only enumerated channel
     keys.
     """
+    expected_watchdog_ms = tempctrl_post_handler_reading("tempctrl_lna")[
+        "watchdog_timeout_ms"
+    ]
 
     def _make(stream, t_now):
-        return {
-            "sensor_name": stream,
-            "status": "update",
-            "app_id": 1,
-            "watchdog_tripped": False,
-            "watchdog_timeout_ms": 5000,
-            "T_now": t_now,
-            "timestamp": 1.0,
-            "T_target": 25.0,
-            "drive_level": 0.5,
-            "enabled": True,
-            "active": True,
-            "int_disabled": False,
-            "hysteresis": 0.1,
-            "clamp": 1.0,
-        }
+        e = tempctrl_post_handler_reading(stream)
+        e["T_now"] = t_now
+        e["timestamp"] = 1.0
+        return e
 
     lna = io.avg_metadata(
         [_make("tempctrl_lna", 30.0), _make("tempctrl_lna", 32.0)]
@@ -897,13 +840,13 @@ def test_avg_metadata_tempctrl_watchdog_fields_survive_split():
     assert lna["app_id"] == 1
     assert isinstance(lna["app_id"], int)
     assert lna["watchdog_tripped"] is False
-    assert lna["watchdog_timeout_ms"] == 5000
+    assert lna["watchdog_timeout_ms"] == expected_watchdog_ms
     assert isinstance(lna["watchdog_timeout_ms"], int)
     assert lna["T_now"] == pytest.approx(31.0)
 
     load = io.avg_metadata([_make("tempctrl_load", 32.0)])
     assert load["sensor_name"] == "tempctrl_load"
-    assert load["watchdog_timeout_ms"] == 5000
+    assert load["watchdog_timeout_ms"] == expected_watchdog_ms
     assert load["T_now"] == pytest.approx(32.0)
 
 
@@ -955,21 +898,9 @@ def test_avg_metadata_bool_any_on_disagreement():
     """bool fields take any() — fault-flag worst-case. A tempctrl
     integration whose watchdog tripped at any point in the integration
     must record watchdog_tripped=True."""
-    base = {
-        "sensor_name": "tempctrl_lna",
-        "status": "update",
-        "app_id": 1,
-        "watchdog_timeout_ms": 5000,
-        "T_now": 30.0,
-        "timestamp": 1.0,
-        "T_target": 25.0,
-        "drive_level": 0.5,
-        "enabled": True,
-        "active": True,
-        "int_disabled": False,
-        "hysteresis": 0.1,
-        "clamp": 1.0,
-    }
+    base = tempctrl_post_handler_reading("tempctrl_lna")
+    base["T_now"] = 30.0
+    base["timestamp"] = 1.0
     data = [
         {**base, "watchdog_tripped": False},
         {**base, "watchdog_tripped": True},  # tripped mid-integration
@@ -1219,22 +1150,14 @@ def test_temp_metadata_streams_land_in_file():
         d = {"0": np.ones(spec_len, dtype=dtype)}
 
         def _entry(stream, t_now, timestamp):
-            return {
-                "sensor_name": stream,
-                "status": "update",
-                "app_id": 1,
-                "watchdog_tripped": False,
-                "watchdog_timeout_ms": 5000,
-                "T_now": t_now,
-                "timestamp": timestamp,
-                "T_target": 25.0,
-                "drive_level": 0.5,
-                "enabled": True,
-                "active": True,
-                "int_disabled": False,
-                "hysteresis": 0.1,
-                "clamp": 1.0,
-            }
+            e = tempctrl_post_handler_reading(stream)
+            e["T_now"] = t_now
+            e["timestamp"] = timestamp
+            return e
+
+        expected_watchdog_ms = tempctrl_post_handler_reading("tempctrl_lna")[
+            "watchdog_timeout_ms"
+        ]
 
         md = {
             "stream:tempctrl_lna": [_entry("tempctrl_lna", 30.0, 1.0)],
@@ -1249,8 +1172,14 @@ def test_temp_metadata_streams_land_in_file():
         assert f.metadata["tempctrl_load"][0]["T_now"] == 25.0
         # Device-wide watchdog fields survive into the file (the old
         # _avg_temp_metadata split dropped them).
-        assert f.metadata["tempctrl_lna"][0]["watchdog_timeout_ms"] == 5000
-        assert f.metadata["tempctrl_load"][0]["watchdog_timeout_ms"] == 5000
+        assert (
+            f.metadata["tempctrl_lna"][0]["watchdog_timeout_ms"]
+            == expected_watchdog_ms
+        )
+        assert (
+            f.metadata["tempctrl_load"][0]["watchdog_timeout_ms"]
+            == expected_watchdog_ms
+        )
 
         f.close()
 
@@ -1317,38 +1246,16 @@ def test_metadata_end_to_end_round_trip():
             ],
             "stream:tempctrl_lna": [
                 {
-                    "sensor_name": "tempctrl_lna",
-                    "status": "update",
-                    "app_id": 1,
-                    "watchdog_tripped": False,
-                    "watchdog_timeout_ms": 5000,
+                    **tempctrl_post_handler_reading("tempctrl_lna"),
                     "T_now": 30.0 + 0.01 * i,
                     "timestamp": 1.0 + i,
-                    "T_target": 25.0,
-                    "drive_level": 0.0,
-                    "enabled": True,
-                    "active": True,
-                    "int_disabled": False,
-                    "hysteresis": 0.5,
-                    "clamp": 100.0,
                 },
             ],
             "stream:tempctrl_load": [
                 {
-                    "sensor_name": "tempctrl_load",
-                    "status": "update",
-                    "app_id": 1,
-                    "watchdog_tripped": False,
-                    "watchdog_timeout_ms": 5000,
+                    **tempctrl_post_handler_reading("tempctrl_load"),
                     "T_now": 25.0 + 0.01 * i,
                     "timestamp": 1.0 + i,
-                    "T_target": 25.0,
-                    "drive_level": 0.0,
-                    "enabled": True,
-                    "active": True,
-                    "int_disabled": False,
-                    "hysteresis": 0.5,
-                    "clamp": 100.0,
                 },
             ],
         }

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -558,44 +558,54 @@ def test_snap_tick_swallows_reader_exception(agg, monkeypatch, caplog):
 
 
 def test_thresholds_classify_uses_live_tempctrl_band(agg, seeded):
-    """End-to-end: a panda tick that publishes tempctrl metadata
-    flows into the aggregator state, and the thresholds classifier
+    """End-to-end: panda ticks that publish each tempctrl channel's
+    stream flow into the aggregator state, and the thresholds classifier
     correctly reports 'ok' for the in-band value."""
     _, panda = seeded
     writer = MetadataWriter(panda)
-    # tempctrl schema (abbreviated) — only the fields the classifier
+    now = time.time()
+    # Per-channel schema (abbreviated) — only the fields the classifier
     # will read. Schema is not enforced by MetadataWriter; the
     # producer-contract suite handles that separately.
     writer.add(
-        "tempctrl",
+        "tempctrl_lna",
         {
-            "sensor_name": "tempctrl",
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
             "app_id": 4,
             "watchdog_tripped": False,
             "watchdog_timeout_ms": 30000,
-            "LNA_status": "update",
-            "LNA_T_now": 25.2,
-            "LNA_timestamp": time.time(),
-            "LNA_T_target": 25.0,
-            "LNA_drive_level": 0.3,
-            "LNA_enabled": True,
-            "LNA_active": True,
-            "LNA_int_disabled": False,
-            "LNA_hysteresis": 0.5,
-            "LNA_clamp": 0.6,
-            "LOAD_status": "update",
-            "LOAD_T_now": 25.0,
-            "LOAD_timestamp": time.time(),
-            "LOAD_T_target": 25.0,
-            "LOAD_drive_level": 0.3,
-            "LOAD_enabled": True,
-            "LOAD_active": True,
-            "LOAD_int_disabled": False,
-            "LOAD_hysteresis": 0.5,
-            "LOAD_clamp": 0.6,
+            "T_now": 25.2,
+            "timestamp": now,
+            "T_target": 25.0,
+            "drive_level": 0.3,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.5,
+            "clamp": 0.6,
         },
     )
-    _rewind_streams(panda, ["stream:tempctrl"])
+    writer.add(
+        "tempctrl_load",
+        {
+            "sensor_name": "tempctrl_load",
+            "status": "update",
+            "app_id": 4,
+            "watchdog_tripped": False,
+            "watchdog_timeout_ms": 30000,
+            "T_now": 25.0,
+            "timestamp": now,
+            "T_target": 25.0,
+            "drive_level": 0.3,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.5,
+            "clamp": 0.6,
+        },
+    )
+    _rewind_streams(panda, ["stream:tempctrl_lna", "stream:tempctrl_load"])
     agg._panda_tick()
 
     # Simulate the SNAP side having surfaced the header so derived
@@ -603,13 +613,12 @@ def test_thresholds_classify_uses_live_tempctrl_band(agg, seeded):
     agg._snap_tick()
 
     state = agg.snapshot()
-    latest = state.metadata_latest["tempctrl"]
+    latest = state.metadata_latest["tempctrl_lna"]
     assert (
-        agg.thresholds.classify("tempctrl.LNA_T_now", latest["LNA_T_now"])
-        == "ok"
+        agg.thresholds.classify("tempctrl_lna.T_now", latest["T_now"]) == "ok"
     )
     # 40 C would be outside the derived danger band (25 +/- 10).
-    assert agg.thresholds.classify("tempctrl.LNA_T_now", 40.0) == "danger"
+    assert agg.thresholds.classify("tempctrl_lna.T_now", 40.0) == "danger"
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -165,33 +165,43 @@ def agg_primed():
             "sw_state_name": "RFNOFF",
         },
     )
+    now = time.time()
     panda_md.add(
-        "tempctrl",
+        "tempctrl_lna",
         {
-            "sensor_name": "tempctrl",
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
             "app_id": 4,
             "watchdog_tripped": False,
             "watchdog_timeout_ms": 30000,
-            "LNA_status": "update",
-            "LNA_T_now": 25.1,
-            "LNA_timestamp": time.time(),
-            "LNA_T_target": 25.0,
-            "LNA_drive_level": 0.25,
-            "LNA_enabled": True,
-            "LNA_active": True,
-            "LNA_int_disabled": False,
-            "LNA_hysteresis": 0.5,
-            "LNA_clamp": 0.6,
-            "LOAD_status": "update",
-            "LOAD_T_now": 25.0,
-            "LOAD_timestamp": time.time(),
-            "LOAD_T_target": 25.0,
-            "LOAD_drive_level": 0.3,
-            "LOAD_enabled": True,
-            "LOAD_active": True,
-            "LOAD_int_disabled": False,
-            "LOAD_hysteresis": 0.5,
-            "LOAD_clamp": 0.6,
+            "T_now": 25.1,
+            "timestamp": now,
+            "T_target": 25.0,
+            "drive_level": 0.25,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.5,
+            "clamp": 0.6,
+        },
+    )
+    panda_md.add(
+        "tempctrl_load",
+        {
+            "sensor_name": "tempctrl_load",
+            "status": "update",
+            "app_id": 4,
+            "watchdog_tripped": False,
+            "watchdog_timeout_ms": 30000,
+            "T_now": 25.0,
+            "timestamp": now,
+            "T_target": 25.0,
+            "drive_level": 0.3,
+            "enabled": True,
+            "active": True,
+            "int_disabled": False,
+            "hysteresis": 0.5,
+            "clamp": 0.6,
         },
     )
 
@@ -211,7 +221,8 @@ def agg_primed():
         [
             "stream:lidar",
             "stream:rfswitch",
-            "stream:tempctrl",
+            "stream:tempctrl_lna",
+            "stream:tempctrl_load",
             "stream:status",
         ],
     )
@@ -410,10 +421,11 @@ def test_metadata_route_includes_classify(client):
     body = client.get("/api/metadata").get_json()
     data = body["data"]
     assert "lidar" in data
-    assert "tempctrl" in data
-    tc = data["tempctrl"]
-    # tempctrl.LNA_T_now = 25.1 is inside healthy (24.0, 26.0).
-    assert tc["classify"]["tempctrl.LNA_T_now"] == "ok"
+    assert "tempctrl_lna" in data
+    assert "tempctrl_load" in data
+    lna = data["tempctrl_lna"]
+    # tempctrl_lna.T_now = 25.1 is inside healthy (24.0, 26.0).
+    assert lna["classify"]["tempctrl_lna.T_now"] == "ok"
 
 
 def test_adc_route_lists_per_input_with_clip_frac(client):
@@ -732,8 +744,8 @@ def test_config_route_exposes_thresholds_with_provenance(client):
     thresh = data["thresholds"]
     # adc.rms is YAML-override per bundled live_status_thresholds.yaml.
     assert thresh["adc.rms"]["source"] == "yaml_override"
-    # tempctrl.LNA_T_now is derived from obs_config.
-    assert thresh["tempctrl.LNA_T_now"]["source"] == "derived"
+    # tempctrl_lna.T_now is derived from obs_config.
+    assert thresh["tempctrl_lna.T_now"]["source"] == "derived"
 
 
 def test_envelope_shape(client):
@@ -808,7 +820,7 @@ def test_corr_route_calibrated_returns_t_load_for_p_ant_equals_p_off(
 
     body = client_.get("/api/corr?calibrated=1").get_json()
     data = body["data"]
-    # tempctrl LOAD_T_now is 25.0 C → 298.15 K. P_ant=P_off=100 in the
+    # tempctrl_load T_now is 25.0 C → 298.15 K. P_ant=P_off=100 in the
     # fixture; T_in collapses to T_LOAD in Kelvin.
     expected_k = 25.0 + 273.15
     assert data["pairs"]["0"]["mag"][0] == pytest.approx(expected_k, rel=1e-6)
@@ -872,13 +884,13 @@ def test_corr_route_calibrated_with_aged_cache_still_calibrates_and_exposes_age(
 def test_corr_route_calibrated_without_t_load_returns_raw_and_stale_true(
     agg_primed,
 ):
-    """If LOAD_T_now is missing from the snapshot (sensor offline,
-    pico booted but tempctrl never reported), the cal can't proceed.
+    """If T_now is missing from the snapshot (sensor offline, pico
+    booted but tempctrl_load never reported), the cal can't proceed.
     Fall back to raw and keep the dashboard painting."""
     _seed_onoff_cache(agg_primed)
-    # Drop tempctrl from the snapshot to simulate a missing producer.
+    # Drop tempctrl_load from the snapshot to simulate a missing producer.
     with agg_primed._lock:
-        agg_primed.state.metadata_snapshot.pop("tempctrl", None)
+        agg_primed.state.metadata_snapshot.pop("tempctrl_load", None)
 
     app = create_app(agg_primed)
     app.config.update(TESTING=True)
@@ -993,20 +1005,19 @@ def test_solve_calibration_logs_error_on_non_finite_enr_db(agg_primed, caplog):
 def test_solve_calibration_logs_error_on_non_numeric_load_t_now(
     agg_primed, caplog
 ):
-    """A non-numeric tempctrl.LOAD_T_now is a producer/schema contract
+    """A non-numeric tempctrl_load.T_now is a producer/schema contract
     violation; CLAUDE.md requires ERROR-level logging on top of the
     dashboard-level reason."""
     _seed_onoff_cache(agg_primed)
     with agg_primed._lock:
-        agg_primed.state.metadata_snapshot["tempctrl"] = {
-            "LOAD_T_now": "warm-ish",
+        agg_primed.state.metadata_snapshot["tempctrl_load"] = {
+            "T_now": "warm-ish",
         }
     obs_cfg = {"calibration": {"noise_diode_enr_db": 6.5}}
     with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
         _solve_calibration(agg_primed.state, obs_cfg, now=time.time())
     assert any(
-        "LOAD_T_now" in r.message and r.levelname == "ERROR"
-        for r in caplog.records
+        "T_now" in r.message and r.levelname == "ERROR" for r in caplog.records
     )
 
 

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -56,16 +56,16 @@ def test_default_thresholds_tempctrl_bands_from_config():
     the upper bound of the drive-level healthy band."""
     out = default_thresholds(OBS_CFG_TEMPCTRL_ON, CORR_HEADER)
 
-    assert out["tempctrl.LNA_T_now"]["healthy"] == [24.0, 26.0]
-    assert out["tempctrl.LOAD_T_now"]["healthy"] == [24.0, 26.0]
+    assert out["tempctrl_lna.T_now"]["healthy"] == [24.0, 26.0]
+    assert out["tempctrl_load.T_now"]["healthy"] == [24.0, 26.0]
     # danger is deferred to Thresholds where the YAML tuning knob is
     # resolved. default_thresholds leaves it None and carries
     # _target_C so the merger can fill it in.
-    assert out["tempctrl.LNA_T_now"]["danger"] is None
-    assert out["tempctrl.LNA_T_now"]["_target_C"] == 25.0
+    assert out["tempctrl_lna.T_now"]["danger"] is None
+    assert out["tempctrl_lna.T_now"]["_target_C"] == 25.0
 
-    assert out["tempctrl.LNA_drive_level"]["healthy"] == [0.0, 0.6]
-    assert out["tempctrl.LOAD_drive_level"]["healthy"] == [0.0, 0.6]
+    assert out["tempctrl_lna.drive_level"]["healthy"] == [0.0, 0.6]
+    assert out["tempctrl_load.drive_level"]["healthy"] == [0.0, 0.6]
 
 
 def test_default_thresholds_corr_cadence_from_integration_time():
@@ -89,10 +89,10 @@ def test_default_thresholds_file_heartbeat_from_ntimes():
 def test_default_thresholds_dropped_when_tempctrl_disabled():
     out = default_thresholds(OBS_CFG_TEMPCTRL_OFF, CORR_HEADER)
     for key in (
-        "tempctrl.LNA_T_now",
-        "tempctrl.LOAD_T_now",
-        "tempctrl.LNA_drive_level",
-        "tempctrl.LOAD_drive_level",
+        "tempctrl_lna.T_now",
+        "tempctrl_load.T_now",
+        "tempctrl_lna.drive_level",
+        "tempctrl_load.drive_level",
     ):
         assert key not in out
 
@@ -110,7 +110,7 @@ def test_default_thresholds_omits_cadence_without_header():
 
 def test_enabled_signals_drops_disabled_subsystems():
     enabled = enabled_signals(OBS_CFG_TEMPCTRL_OFF)
-    assert "tempctrl.LNA_T_now" not in enabled
+    assert "tempctrl_lna.T_now" not in enabled
     # Signals with enabled_by=None stay regardless.
     assert "adc.rms" in enabled
     assert "corr.acc_cadence_s" in enabled
@@ -118,8 +118,8 @@ def test_enabled_signals_drops_disabled_subsystems():
 
 def test_enabled_signals_includes_tempctrl_when_on():
     enabled = enabled_signals(OBS_CFG_TEMPCTRL_ON)
-    assert "tempctrl.LNA_T_now" in enabled
-    assert "tempctrl.LNA_drive_level" in enabled
+    assert "tempctrl_lna.T_now" in enabled
+    assert "tempctrl_lna.drive_level" in enabled
 
 
 # ---------------------------------------------------------------------
@@ -140,7 +140,7 @@ def test_thresholds_merges_derived_and_yaml():
     assert adc["healthy"] == [10.0, 20.0]
     assert adc["source"] == "yaml_override"
 
-    lna = th.bands["tempctrl.LNA_T_now"]
+    lna = th.bands["tempctrl_lna.T_now"]
     assert lna["healthy"] == [24.0, 26.0]
     # danger filled in from target_C +/- tempctrl.danger_k_C
     assert lna["danger"] == [15.0, 35.0]
@@ -150,7 +150,7 @@ def test_thresholds_merges_derived_and_yaml():
 def test_thresholds_yaml_wins_over_derived():
     """An explicit YAML entry for a derived signal should override."""
     yaml_overrides = {
-        "tempctrl.LNA_T_now": {
+        "tempctrl_lna.T_now": {
             "healthy": [22.0, 28.0],
             "danger": [18.0, 32.0],
         },
@@ -158,7 +158,7 @@ def test_thresholds_yaml_wins_over_derived():
     th = Thresholds(
         OBS_CFG_TEMPCTRL_ON, CORR_HEADER, yaml_overrides=yaml_overrides
     )
-    lna = th.bands["tempctrl.LNA_T_now"]
+    lna = th.bands["tempctrl_lna.T_now"]
     assert lna["healthy"] == [22.0, 28.0]
     assert lna["danger"] == [18.0, 32.0]
     assert lna["source"] == "yaml_override"
@@ -172,7 +172,7 @@ def test_thresholds_unregistered_signal_classifies_unknown():
 def test_thresholds_disabled_signal_classifies_unknown():
     """Signals filtered out by enabled_by should be unreachable."""
     th = Thresholds(OBS_CFG_TEMPCTRL_OFF, CORR_HEADER)
-    assert th.classify("tempctrl.LNA_T_now", 25.0) == "unknown"
+    assert th.classify("tempctrl_lna.T_now", 25.0) == "unknown"
 
 
 def test_thresholds_null_healthy_classifies_unknown():
@@ -203,7 +203,7 @@ def test_thresholds_classify_value_paths():
 
 def test_thresholds_classify_stale_wins_over_value():
     yaml_overrides = {
-        "tempctrl.LNA_T_now": {
+        "tempctrl_lna.T_now": {
             "healthy": [24.0, 26.0],
             "danger": [15.0, 35.0],
         },
@@ -212,7 +212,7 @@ def test_thresholds_classify_stale_wins_over_value():
         OBS_CFG_TEMPCTRL_ON, CORR_HEADER, yaml_overrides=yaml_overrides
     )
     # In healthy range on value alone, but too old.
-    assert th.classify("tempctrl.LNA_T_now", 25.0, age_s=120.0) == "stale"
+    assert th.classify("tempctrl_lna.T_now", 25.0, age_s=120.0) == "stale"
     # max_age_s=None disables the check.
     assert th.classify("adc.rms", 15.0, age_s=9999.0) in {
         "ok",
@@ -224,11 +224,11 @@ def test_thresholds_classify_stale_wins_over_value():
 
 
 def test_thresholds_classify_warn_without_danger_band():
-    """Derived tempctrl.LNA_drive_level has healthy=[0, clamp] but no
+    """Derived tempctrl_lna.drive_level has healthy=[0, clamp] but no
     danger band. Outside-healthy should warn, not raise."""
     th = Thresholds(OBS_CFG_TEMPCTRL_ON, CORR_HEADER)
-    assert th.classify("tempctrl.LNA_drive_level", 0.5) == "ok"
-    assert th.classify("tempctrl.LNA_drive_level", 0.9) == "warn"
+    assert th.classify("tempctrl_lna.drive_level", 0.5) == "ok"
+    assert th.classify("tempctrl_lna.drive_level", 0.9) == "warn"
 
 
 # ---------------------------------------------------------------------
@@ -257,7 +257,7 @@ def test_thresholds_with_header_preserves_yaml_override():
     th2 = th.with_header({"integration_time": 0.5, "sync_time": 1.0})
     assert th2.bands["adc.rms"]["healthy"] == [10.0, 20.0]
     # Preserved non-default tempctrl_k (target 25 ± 7)
-    assert th2.bands["tempctrl.LNA_T_now"]["danger"] == [18.0, 32.0]
+    assert th2.bands["tempctrl_lna.T_now"]["danger"] == [18.0, 32.0]
 
 
 # ---------------------------------------------------------------------
@@ -276,7 +276,7 @@ def test_thresholds_as_dict_includes_provenance_and_metadata():
 
     assert d["adc.rms"]["source"] == "yaml_override"
     assert d["adc.rms"]["unit"] == "counts"
-    assert d["tempctrl.LNA_T_now"]["source"] == "derived"
+    assert d["tempctrl_lna.T_now"]["source"] == "derived"
     # Signals with no band from either tier:
     assert d["corr.auto_mag_median"]["source"] == "default_null"
     assert d["corr.auto_mag_median"]["healthy"] is None
@@ -293,7 +293,7 @@ def test_thresholds_from_yaml_loads_bundled_defaults():
     assert th.bands["adc.rms"]["healthy"] == [10.0, 20.0]
     assert th.bands["adc.rms"]["source"] == "yaml_override"
     # Derived defaults still apply.
-    assert th.bands["tempctrl.LNA_T_now"]["source"] == "derived"
+    assert th.bands["tempctrl_lna.T_now"]["source"] == "derived"
 
 
 def test_thresholds_from_yaml_with_explicit_path(tmp_path):

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -161,16 +161,20 @@ def test_set_watchdog_timeout(client):
 
 
 def test_get_status_returns_snapshot_or_none(client):
-    """get_status returns a dict with the full schema, or None before
-    the pico has published. Fire a command first to ensure at least
-    one publish has happened."""
+    """get_status merges the two split Redis streams back into the flat
+    LNA_*/LOAD_* shape callers (notably _tempctrl_health_check) depend
+    on. Returns None before either pico stream has published."""
     tc = TempCtrlClient(client.transport, settings=SETTINGS)
     tc.apply_settings()
     assert _wait_until(lambda: tc.get_status() is not None)
     status = tc.get_status()
-    assert status["sensor_name"] == "tempctrl"
+    # The merge preserves the legacy flat shape: device-wide watchdog
+    # fields at the top, per-channel fields under LNA_*/LOAD_* prefix.
     assert "LNA_T_target" in status
     assert "LOAD_T_target" in status
+    assert "LNA_status" in status
+    assert "LOAD_status" in status
+    assert "watchdog_timeout_ms" in status
 
 
 def test_is_available_reflects_registration(client):

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ requires-dist = [
     { name = "ipython", marker = "extra == 'interactive'" },
     { name = "matplotlib", marker = "extra == 'interactive'" },
     { name = "numpy" },
-    { name = "picohost", specifier = ">=3.1" },
+    { name = "picohost", specifier = ">=3.3.0" },
     { name = "plotly" },
     { name = "pyserial-mock", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1591,7 +1591,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.1.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eigsep-redis" },
@@ -1599,9 +1599,9 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyserial" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/f7/77f9f01919ee873eea84215717b6884befaa9889f55ea7ffb6885813c60a/picohost-3.1.0.tar.gz", hash = "sha256:9c363170edac2c8663985cdc510fc8515b8e49ba654a9ad99b995dbfce7bcfbd", size = 74058, upload-time = "2026-04-30T20:59:12.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/87/291c9241ccecc8728fddaa95d15975a175d6a37480319f4f68305d4f5187/picohost-3.3.0.tar.gz", hash = "sha256:c03fcbce86a65f2823ad458126f8324c3c846197a44e19eade2007369e764038", size = 78715, upload-time = "2026-05-16T00:13:59.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/4c/983d092a582b16cff49c4f58b7ab9233b0b1264cd282389e373aa38a1b48/picohost-3.1.0-py3-none-any.whl", hash = "sha256:3b71b68e4a5b6f9f6a1f203e84093324a6b9a9b575a37ef218fe3a3ed6e48eef", size = 46157, upload-time = "2026-04-30T20:59:10.811Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/cf/127da2e6a104e916fea15e0995ffe915569b1372323f57ee6edf90e93b17/picohost-3.3.0-py3-none-any.whl", hash = "sha256:144e380c577d9145c08a8d85ae654ddc1e5e47abf94858503993ee8f7bddf94b", size = 48866, upload-time = "2026-05-16T00:13:57.612Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> ⚠️ **Draft — gated on EIGSEP/pico-firmware#78.** This PR consumes the per-channel Redis streams that the picohost PR produces. Land that first, bump the picohost version, then mark this ready.

## Summary

picohost's `PicoPeltier` now fans tempctrl status into two Redis streams (`tempctrl_lna`, `tempctrl_load`). This PR updates eigsep_observing to consume them as ordinary one-stream-per-sensor entries:

- **`io.py`** — `SENSOR_SCHEMAS` replaces the nested `tempctrl` entry with two flat `_PELTIER_SCHEMA` references. Removed the `_avg_temp_metadata` special case (~70 lines) and its `avg_metadata` dispatch, plus the `File._write_sample` LNA/LOAD split branch. Both new streams flow through the generic `_avg_sensor_values` reduction.
- **`live_status/signals.py` + `thresholds.py`** — renamed 4 signal keys: `tempctrl.LNA_T_now` → `tempctrl_lna.T_now`, etc. YAML config shape (`use_tempctrl`, `tempctrl_settings: {LNA, LOAD}`, `tempctrl.danger_k_C` tuning knob) is preserved.
- **`live_status/app.py`** — VNA cal reads `tempctrl_load.T_now`.
- **`live_status/static/js/dashboard.js`** — renders two per-channel tiles. Each tile gets its own top-level `status` badge — the original `?` symptom is gone because each new stream has the standard top-level `status`.
- **`tempctrl_client.py`** — `get_status()` reads both new streams and merges back to the legacy flat `LNA_*` / `LOAD_*` shape, so `_tempctrl_health_check` and its tests need no changes. `PicoProxy("tempctrl")` command path is untouched.
- **`contract_tests`** — new `_peltier_post_handler_reading` runs the picohost producer end-to-end and validates each stream against its schema.
- **Test fixtures + every tempctrl test** rewritten for the two-stream world.

## File-format compatibility

The on-disk HDF5 format already used `tempctrl_lna` / `tempctrl_load` top-level groups (the old `File.add_data` split path produced them). New files additionally carry `watchdog_tripped` / `watchdog_timeout_ms` per channel — these were silently dropped at write time before this change. Additive, no migration needed.

## Why minor bump and not major

The picohost ↔ eigsep_observing edge is internal; the current v3/v2 majors haven't shipped anywhere. Marking this as `feat:` instead of `feat!:` avoids version-number churn for refactors that will never be seen by an external consumer. The breaking nature is documented in the commit body and in the picohost companion PR.

## Test plan

- [x] `pytest tests/ src/eigsep_observing/contract_tests/` — 547 + 18 passed
- [x] Live-status, integration, tempctrl_client, io subsets independently green
- [x] After picohost PR lands and version bumps: pin `picohost>=<new>` in `pyproject.toml`
- [ ] Emulator-backed dashboard sanity check (two tempctrl tiles; force one channel error to confirm independent color)
- [ ] HDF5 round-trip sanity: confirm `tempctrl_lna/watchdog_timeout_ms` is now present in a file written by a short corr run

🤖 Generated with [Claude Code](https://claude.com/claude-code)