### PR TITLE
Live-status: 4-tile honest health row + SNAP FPGA probe

### DIFF
--- a/scripts/live_status.py
+++ b/scripts/live_status.py
@@ -83,6 +83,18 @@ def main(argv=None):
     )
     parser.add_argument("--panda-port", type=int, default=6379)
     parser.add_argument(
+        "--snap-fpga-host",
+        default=None,
+        help=(
+            "Override for the SNAP FPGA IP used by the reachability "
+            "probe. Default: read ``snap_ip`` from the corr config "
+            "in Redis once available (10.10.10.12 in the bundled "
+            "corr_config.yaml). Pass this only when corr config has "
+            "not yet been published and you want the SNAP FPGA tile "
+            "to still light up."
+        ),
+    )
+    parser.add_argument(
         "--obs-config",
         default=None,
         help=(
@@ -130,6 +142,7 @@ def main(argv=None):
         transport_panda=transport_panda,
         obs_cfg=obs_cfg,
         thresholds=thresholds,
+        snap_fpga_host_override=args.snap_fpga_host,
     )
 
     app = create_app(aggregator)

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -198,6 +198,33 @@ class StateSnapshot:
     panda_error: Optional[str] = None
 
 
+def corr_observing_timeout_s(state: StateSnapshot) -> float:
+    """Infer a reasonable observing-idle timeout from corr cadence.
+
+    The corr loop advances ``corr_last_unix`` once per integration, so
+    a fixed 2 s threshold misreports "not observing" whenever
+    ``integration_time`` is configured above ~1 s. Prefer the measured
+    cadence, fall back to the header's ``integration_time``, and
+    finally to a 2 s floor. Scale by 2.5× so one slipped integration
+    doesn't flip the indicator.
+    """
+    cadence = None
+    if state.corr_cadence_s is not None and state.corr_cadence_s > 0:
+        cadence = float(state.corr_cadence_s)
+    elif state.corr_header is not None:
+        int_time = state.corr_header.get("integration_time")
+        if int_time is not None:
+            try:
+                int_time_f = float(int_time)
+            except (TypeError, ValueError):
+                int_time_f = None
+            if int_time_f and int_time_f > 0:
+                cadence = int_time_f
+    if cadence is None:
+        return 2.0
+    return max(2.0, cadence * 2.5)
+
+
 class LiveStatusAggregator:
     """Background poller + shared state for the live-status Flask app.
 

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -60,6 +60,7 @@ from ..snap_reinit import read as read_snap_reinit
 from ..utils import calc_freqs_dfreq
 from ..vna import VnaReader
 from .signals import SIGNAL_REGISTRY
+from .snap_probe import probe_snap_fpga
 from .thresholds import Thresholds
 from .vna_calibration import VnaCache
 
@@ -197,6 +198,12 @@ class StateSnapshot:
     snap_error: Optional[str] = None
     panda_error: Optional[str] = None
 
+    # SNAP FPGA reachability (independent of corr stream). Probed via
+    # TCP to the katcp port only when corr is stale — corr flow is a
+    # stronger signal and makes the probe redundant.
+    snap_fpga_reachable: Optional[bool] = None
+    snap_fpga_last_probe_unix: Optional[float] = None
+
 
 def corr_observing_timeout_s(state: StateSnapshot) -> float:
     """Infer a reasonable observing-idle timeout from corr cadence.
@@ -265,6 +272,8 @@ class LiveStatusAggregator:
         snap_tick_s: float = 0.5,
         panda_tick_s: float = 0.5,
         read_timeout_s: float = 0.2,
+        snap_fpga_probe_interval_s: float = 5.0,
+        snap_fpga_host: Optional[str] = None,
         stop_event: Optional[threading.Event] = None,
     ):
         if read_timeout_s <= 0:
@@ -278,6 +287,8 @@ class LiveStatusAggregator:
         self._snap_tick_s = snap_tick_s
         self._panda_tick_s = panda_tick_s
         self._read_timeout_s = read_timeout_s
+        self._snap_fpga_probe_interval_s = snap_fpga_probe_interval_s
+        self._snap_fpga_host_override = snap_fpga_host
         self._stop_event = stop_event or threading.Event()
 
         # SNAP-side surfaces.
@@ -402,6 +413,8 @@ class LiveStatusAggregator:
                     if s.last_rfnon_pairs is not None
                     else None
                 ),
+                snap_fpga_reachable=s.snap_fpga_reachable,
+                snap_fpga_last_probe_unix=s.snap_fpga_last_probe_unix,
             )
 
     # -- SNAP drain loop -------------------------------------------
@@ -420,6 +433,12 @@ class LiveStatusAggregator:
         now = time.time()
         errors: list[str] = []
         any_ok = False
+        # Snapshot the fields the probe needs before the main lock
+        # block may overwrite them from Redis.  This lets tests pre-set
+        # state fields and have the probe see them deterministically.
+        with self._lock:
+            _pre_corr_last_unix = self.state.corr_last_unix
+            _pre_corr_cfg = self.state.corr_config
 
         # Corr config + header (pointer-free gets). ``ValueError`` from
         # the store means "header/config not in Redis yet" — that's a
@@ -547,6 +566,59 @@ class LiveStatusAggregator:
 
             if reinit_h is not None:
                 s.snap_reinit = reinit_h
+
+        self._maybe_probe_snap_fpga(now, _pre_corr_last_unix, _pre_corr_cfg)
+
+    def _maybe_probe_snap_fpga(
+        self,
+        now: float,
+        corr_unix: Optional[float],
+        corr_cfg: Optional[dict],
+    ) -> None:
+        """Probe the SNAP FPGA if corr is stale + interval elapsed.
+
+        Parameters are snapshotted by ``_snap_tick`` *before* the main
+        lock block so test pre-sets survive the Redis read. In
+        production the values are from the previous tick, which is
+        fine — the probe is rate-limited to once per
+        ``snap_fpga_probe_interval_s`` anyway.
+
+        Skips the probe entirely when ``corr_unix`` is fresh —
+        the corr stream itself is a stronger liveness signal. Also
+        skips when no ``snap_ip`` is configured anywhere (corr config
+        not yet read AND no CLI override), leaving
+        ``snap_fpga_reachable`` at ``None`` so the tile shows
+        "unknown" rather than a false negative.
+        """
+        with self._lock:
+            last_probe = self.state.snap_fpga_last_probe_unix
+            timeout_s = corr_observing_timeout_s(self.state)
+
+        # Don't probe — corr stream is proving liveness.
+        if corr_unix is not None:
+            if (now - corr_unix) < timeout_s:
+                return
+
+        # Rate-limit the probe.
+        if (
+            last_probe is not None
+            and (now - last_probe) < self._snap_fpga_probe_interval_s
+        ):
+            return
+
+        # Pick the host: corr_config first, CLI override second.
+        snap_ip = None
+        if corr_cfg is not None:
+            snap_ip = corr_cfg.get("snap_ip")
+        if not snap_ip:
+            snap_ip = self._snap_fpga_host_override
+        if not snap_ip:
+            return  # state.snap_fpga_reachable stays None → "unknown"
+
+        result = probe_snap_fpga(snap_ip)
+        with self._lock:
+            self.state.snap_fpga_reachable = result
+            self.state.snap_fpga_last_probe_unix = now
 
     def _read_corr(self) -> tuple[Optional[tuple], bool]:
         """Drain the corr stream to the latest entry; reshape the tail.

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -273,7 +273,7 @@ class LiveStatusAggregator:
         panda_tick_s: float = 0.5,
         read_timeout_s: float = 0.2,
         snap_fpga_probe_interval_s: float = 5.0,
-        snap_fpga_host: Optional[str] = None,
+        snap_fpga_host_override: Optional[str] = None,
         stop_event: Optional[threading.Event] = None,
     ):
         if read_timeout_s <= 0:
@@ -288,7 +288,7 @@ class LiveStatusAggregator:
         self._panda_tick_s = panda_tick_s
         self._read_timeout_s = read_timeout_s
         self._snap_fpga_probe_interval_s = snap_fpga_probe_interval_s
-        self._snap_fpga_host_override = snap_fpga_host
+        self._snap_fpga_host_override = snap_fpga_host_override
         self._stop_event = stop_event or threading.Event()
 
         # SNAP-side surfaces.
@@ -433,12 +433,9 @@ class LiveStatusAggregator:
         now = time.time()
         errors: list[str] = []
         any_ok = False
-        # Snapshot the fields the probe needs before the main lock
-        # block may overwrite them from Redis.  This lets tests pre-set
-        # state fields and have the probe see them deterministically.
         with self._lock:
-            _pre_corr_last_unix = self.state.corr_last_unix
-            _pre_corr_cfg = self.state.corr_config
+            corr_unix_pre_tick = self.state.corr_last_unix
+            corr_cfg_pre_tick = self.state.corr_config
 
         # Corr config + header (pointer-free gets). ``ValueError`` from
         # the store means "header/config not in Redis yet" — that's a
@@ -567,13 +564,13 @@ class LiveStatusAggregator:
             if reinit_h is not None:
                 s.snap_reinit = reinit_h
 
-        self._maybe_probe_snap_fpga(now, _pre_corr_last_unix, _pre_corr_cfg)
+        self._maybe_probe_snap_fpga(now, corr_unix_pre_tick, corr_cfg_pre_tick)
 
     def _maybe_probe_snap_fpga(
         self,
         now: float,
-        corr_unix: Optional[float],
-        corr_cfg: Optional[dict],
+        corr_unix_pre_tick: Optional[float],
+        corr_cfg_pre_tick: Optional[dict],
     ) -> None:
         """Probe the SNAP FPGA if corr is stale + interval elapsed.
 
@@ -583,7 +580,7 @@ class LiveStatusAggregator:
         fine — the probe is rate-limited to once per
         ``snap_fpga_probe_interval_s`` anyway.
 
-        Skips the probe entirely when ``corr_unix`` is fresh —
+        Skips the probe entirely when ``corr_unix_pre_tick`` is fresh —
         the corr stream itself is a stronger liveness signal. Also
         skips when no ``snap_ip`` is configured anywhere (corr config
         not yet read AND no CLI override), leaving
@@ -595,8 +592,8 @@ class LiveStatusAggregator:
             timeout_s = corr_observing_timeout_s(self.state)
 
         # Don't probe — corr stream is proving liveness.
-        if corr_unix is not None:
-            if (now - corr_unix) < timeout_s:
+        if corr_unix_pre_tick is not None:
+            if (now - corr_unix_pre_tick) < timeout_s:
                 return
 
         # Rate-limit the probe.
@@ -608,8 +605,8 @@ class LiveStatusAggregator:
 
         # Pick the host: corr_config first, CLI override second.
         snap_ip = None
-        if corr_cfg is not None:
-            snap_ip = corr_cfg.get("snap_ip")
+        if corr_cfg_pre_tick is not None:
+            snap_ip = corr_cfg_pre_tick.get("snap_ip")
         if not snap_ip:
             snap_ip = self._snap_fpga_host_override
         if not snap_ip:

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -21,7 +21,11 @@ import numpy as np
 from flask import Flask, Response, jsonify, render_template, request
 from plotly.offline import get_plotlyjs
 
-from .aggregator import LiveStatusAggregator, StateSnapshot
+from .aggregator import (
+    LiveStatusAggregator,
+    StateSnapshot,
+    corr_observing_timeout_s,
+)
 from .calibration import (
     apply_calibration_auto,
     apply_calibration_cross_mag,
@@ -511,40 +515,13 @@ def _vna_payload(state: StateSnapshot, mode: str, now: float) -> dict:
     }
 
 
-def _corr_observing_timeout_s(state: StateSnapshot) -> float:
-    """Infer a reasonable observing-idle timeout from corr cadence.
-
-    The corr loop advances ``corr_last_unix`` once per integration, so
-    a fixed 2 s threshold misreports "not observing" whenever
-    ``integration_time`` is configured above ~1 s. Prefer the measured
-    cadence, fall back to the header's ``integration_time``, and
-    finally to a 2 s floor. Scale by 2.5× so one slipped integration
-    doesn't flip the indicator.
-    """
-    cadence: Optional[float] = None
-    if state.corr_cadence_s is not None and state.corr_cadence_s > 0:
-        cadence = float(state.corr_cadence_s)
-    elif state.corr_header is not None:
-        int_time = state.corr_header.get("integration_time")
-        if int_time is not None:
-            try:
-                int_time_f = float(int_time)
-            except (TypeError, ValueError):
-                int_time_f = None
-            if int_time_f and int_time_f > 0:
-                cadence = int_time_f
-    if cadence is None:
-        return 2.0
-    return max(2.0, cadence * 2.5)
-
-
 def _health_payload(state: StateSnapshot, now: float) -> dict:
     panda_hb_age = None
     if state.panda_heartbeat_last_check_unix is not None:
         panda_hb_age = max(0.0, now - state.panda_heartbeat_last_check_unix)
     observing_inferred = False
     if state.corr_last_unix is not None:
-        timeout_s = _corr_observing_timeout_s(state)
+        timeout_s = corr_observing_timeout_s(state)
         observing_inferred = (now - state.corr_last_unix) < timeout_s
     reinit = dict(state.snap_reinit or {})
     # Recompute the age against ``now`` so the dashboard's "Reinits"

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -536,6 +536,19 @@ def _health_payload(state: StateSnapshot, now: float) -> dict:
     run_age_s = None
     if state.run_started_at_unix is not None:
         run_age_s = max(0.0, now - state.run_started_at_unix)
+    # Tier the SNAP FPGA tile: corr stream beats probe, probe beats
+    # silence. ``observing_inferred`` and the probe both flag SNAP
+    # liveness; this layer picks the strongest available evidence so
+    # the operator sees "live" during normal observing and only sees
+    # the active-probe result when the observe loop isn't running.
+    if observing_inferred:
+        snap_fpga_state = "live"
+    elif state.snap_fpga_reachable is True:
+        snap_fpga_state = "reachable"
+    elif state.snap_fpga_reachable is False:
+        snap_fpga_state = "unreachable"
+    else:
+        snap_fpga_state = "unknown"
     return {
         "snap_connected": state.snap_connected,
         "panda_connected": state.panda_connected,
@@ -547,6 +560,8 @@ def _health_payload(state: StateSnapshot, now: float) -> dict:
         "snap_error": state.snap_error,
         "panda_error": state.panda_error,
         "snap_reinit": reinit,
+        "snap_fpga_state": snap_fpga_state,
+        "snap_fpga_last_probe_unix": state.snap_fpga_last_probe_unix,
         "run_tag": state.run_tag,
         "run_started_at_unix": state.run_started_at_unix,
         "run_age_s": run_age_s,

--- a/src/eigsep_observing/live_status/snap_probe.py
+++ b/src/eigsep_observing/live_status/snap_probe.py
@@ -1,0 +1,61 @@
+"""SNAP FPGA TCP reachability probe.
+
+Tests whether a CASPER service (katcp on port 7147 by default) is
+accepting TCP connections at ``snap_ip``. The probe does not speak
+katcp; a successful handshake is sufficient to prove the SNAP
+firmware is up at the network layer.
+
+Decoupled from the rest of the live-status stack — pure function,
+no Redis dependency, no shared state. Called from
+``LiveStatusAggregator._snap_tick`` only when ``corr_last_unix``
+is stale (the corr stream is already a stronger liveness signal
+when it's flowing).
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+KATCP_PORT = 7147
+
+
+def probe_snap_fpga(
+    snap_ip: Optional[str],
+    *,
+    port: int = KATCP_PORT,
+    timeout: float = 1.0,
+) -> bool:
+    """Return True iff a TCP connection to ``snap_ip:port`` opens.
+
+    Parameters
+    ----------
+    snap_ip
+        Target host (typically ``cfg['snap_ip']``). ``None`` or an
+        empty string returns ``False`` without attempting a connect —
+        callers may pass an unresolved value.
+    port
+        TCP port to probe. Defaults to the CASPER katcp port (7147).
+    timeout
+        Per-connect timeout in seconds. ~1 s is a reasonable upper
+        bound on a loopback or directly-connected SNAP and keeps
+        the aggregator's drain tick responsive.
+
+    Returns
+    -------
+    bool
+        ``True`` if the connect succeeded, ``False`` otherwise
+        (refused, timeout, DNS failure, OS error).
+    """
+    if not snap_ip:
+        return False
+    try:
+        with socket.create_connection((snap_ip, port), timeout=timeout):
+            return True
+    except OSError as exc:
+        logger.debug("snap probe to %s:%d failed: %s", snap_ip, port, exc)
+        return False

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -337,21 +337,47 @@ function updateVna(vna) {
 // ---- health --------------------------------------------------------
 
 function updateHealth(h, fileData) {
-  const snapTile = document.getElementById("tile-snap");
-  snapTile.className = `tile ${h.snap_connected ? "ok" : "danger"}`;
-  snapTile.textContent = `SNAP: ${h.snap_connected ? "connected" : "offline"}`;
+  // SNAP FPGA tile — tiered state from /api/health.
+  const fpgaTile = document.getElementById("tile-snap-fpga");
+  const fpgaClassMap = {
+    live: "ok",
+    reachable: "ok",
+    unreachable: "danger",
+    unknown: "unknown",
+  };
+  const fpgaLabelMap = {
+    live: "live (corr streaming)",
+    reachable: "reachable (no corr)",
+    unreachable: "unreachable",
+    unknown: "unknown",
+  };
+  const fpgaState = h.snap_fpga_state || "unknown";
+  fpgaTile.className = `tile ${fpgaClassMap[fpgaState] || "unknown"}`;
+  fpgaTile.textContent = `SNAP FPGA: ${fpgaLabelMap[fpgaState] || "unknown"}`;
 
-  const pandaTile = document.getElementById("tile-panda");
+  // Backend Redis tile — old "SNAP" tile, honestly named.
+  const redisTile = document.getElementById("tile-backend-redis");
+  redisTile.className = `tile ${h.snap_connected ? "ok" : "danger"}`;
+  redisTile.textContent = `Backend Redis: ${h.snap_connected ? "up" : "down"}`;
+
+  // Panda observe tile — same 3-state logic, clearer labels.
+  const pandaTile = document.getElementById("tile-panda-observe");
   let pandaClass = "danger";
-  if (h.panda_heartbeat) pandaClass = "ok";
-  else if (h.panda_connected) pandaClass = "warn";
+  let pandaLabel = "panda offline";
+  if (h.panda_heartbeat) {
+    pandaClass = "ok";
+    pandaLabel = "running";
+  } else if (h.panda_connected) {
+    pandaClass = "warn";
+    pandaLabel = "script idle";
+  }
   pandaTile.className = `tile ${pandaClass}`;
-  pandaTile.textContent =
-    `Panda: ${h.panda_heartbeat ? "alive" : h.panda_connected ? "stale HB" : "offline"}`;
+  pandaTile.textContent = `Panda observe: ${pandaLabel}`;
 
-  const obsTile = document.getElementById("tile-observing");
-  obsTile.className = `tile ${h.observing_inferred ? "ok" : "warn"}`;
-  obsTile.textContent = `Observing: ${h.observing_inferred ? "yes" : "no"}`;
+  // Corr loop tile — old "Observing" tile, honestly named.
+  const corrTile = document.getElementById("tile-corr-loop");
+  corrTile.className = `tile ${h.observing_inferred ? "ok" : "warn"}`;
+  corrTile.textContent = `Corr loop: ${h.observing_inferred ? "recording" : "idle"}`;
 
   const fileTile = document.getElementById("tile-file");
   if (fileData) {

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -10,9 +10,10 @@
 <header>
   <h1>EIGSEP live status</h1>
   <div id="health-summary" class="health">
-    <span class="tile" id="tile-snap">SNAP: ?</span>
-    <span class="tile" id="tile-panda">Panda: ?</span>
-    <span class="tile" id="tile-observing">Observing: ?</span>
+    <span class="tile" id="tile-snap-fpga" title="SNAP FPGA reachability. 'live' = corr stream is flowing (proves SNAP responds at the casperfpga level). 'reachable' = corr is idle but a TCP connect to the katcp port (7147) succeeds. 'unreachable' = probe failed. 'unknown' = no snap_ip configured yet.">SNAP FPGA: ?</span>
+    <span class="tile" id="tile-backend-redis" title="Backend Redis (rpi_ip) liveness. Any successful read on the SNAP-side Redis flips this green.">Backend Redis: ?</span>
+    <span class="tile" id="tile-panda-observe" title="Panda observe script. 'running' = fresh heartbeat from panda_observe (or sibling script). 'script idle' = panda Redis is up but no script is publishing the heartbeat. 'panda offline' = panda Redis itself is unreachable.">Panda observe: ?</span>
+    <span class="tile" id="tile-corr-loop" title="Corr loop. 'recording' = a new corr integration arrived within 2.5x the integration cadence — eigsep-fpga-init is publishing data. 'idle' = no new integration in that window.">Corr loop: ?</span>
     <span class="tile" id="tile-file">Last file: ?</span>
     <span class="tile" id="tile-reinit" title="SNAP --reinit count since the last Redis flush. Bumps on every supervised crash-recovery.">Reinits: ?</span>
     <span class="tile" id="tile-run" title="Active panda script (panda_observe / no_switch_observation / vna_position_sweep). 'idle' means no script is currently driving the run.">Run: ?</span>

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -835,3 +835,102 @@ def test_thresholds_from_constructor_override():
         assert agg.thresholds.bands["adc.rms"]["healthy"] == [1.0, 2.0]
     finally:
         agg.stop()
+
+
+# ---------------------------------------------------------------------
+# SNAP FPGA probe
+# ---------------------------------------------------------------------
+
+
+def test_snap_fpga_probe_skipped_when_corr_fresh(agg, seeded, monkeypatch):
+    """When the corr stream is fresh, the probe is a no-op — the corr
+    flow itself proves SNAP liveness, so we don't open extra sockets."""
+    snap, _panda = seeded
+    # Seed a fresh corr_last_unix in state by directly stamping it.
+    agg.state.corr_last_unix = time.time()
+    agg.state.corr_header = {"integration_time": 0.27}
+
+    calls = []
+
+    def fake_probe(*args, **kwargs):
+        calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(
+        "eigsep_observing.live_status.aggregator.probe_snap_fpga",
+        fake_probe,
+    )
+    agg._snap_tick()
+    assert calls == []  # probe must NOT have run
+    # snap_fpga_reachable stays None (probe never ran on this tick).
+    assert agg.state.snap_fpga_reachable is None
+
+
+def test_snap_fpga_probe_runs_when_corr_stale(agg, monkeypatch):
+    """No corr data ever seen → probe should run and update state."""
+    agg.state.corr_config = {"snap_ip": "10.10.10.12"}
+    monkeypatch.setattr(
+        "eigsep_observing.live_status.aggregator.probe_snap_fpga",
+        lambda host, **kw: host == "10.10.10.12",
+    )
+    agg._snap_tick()
+    assert agg.state.snap_fpga_reachable is True
+    assert agg.state.snap_fpga_last_probe_unix is not None
+
+
+def test_snap_fpga_probe_records_unreachable(agg, monkeypatch):
+    agg.state.corr_config = {"snap_ip": "10.10.10.12"}
+    monkeypatch.setattr(
+        "eigsep_observing.live_status.aggregator.probe_snap_fpga",
+        lambda host, **kw: False,
+    )
+    agg._snap_tick()
+    assert agg.state.snap_fpga_reachable is False
+
+
+def test_snap_fpga_probe_gated_by_interval(agg, monkeypatch):
+    """Two ticks within the probe interval must only run the probe
+    once — the inner tick cadence is 0.01 s, the probe interval is
+    5 s by default."""
+    agg.state.corr_config = {"snap_ip": "10.10.10.12"}
+    calls = []
+    monkeypatch.setattr(
+        "eigsep_observing.live_status.aggregator.probe_snap_fpga",
+        lambda host, **kw: calls.append(host) or True,
+    )
+    agg._snap_tick()
+    agg._snap_tick()
+    assert calls == ["10.10.10.12"]
+
+
+def test_snap_fpga_probe_uses_explicit_host_when_no_config(agg, monkeypatch):
+    """If the corr config hasn't been read yet but a snap_fpga_host
+    was passed to __init__, use it."""
+    agg._snap_fpga_host_override = "10.10.10.12"
+    agg.state.corr_config = None
+    monkeypatch.setattr(
+        "eigsep_observing.live_status.aggregator.probe_snap_fpga",
+        lambda host, **kw: host == "10.10.10.12",
+    )
+    agg._snap_tick()
+    assert agg.state.snap_fpga_reachable is True
+
+
+def test_snap_fpga_probe_unknown_when_no_host(agg, monkeypatch):
+    """No snap_ip anywhere → probe skipped, state stays None."""
+    agg.state.corr_config = None
+    agg._snap_fpga_host_override = None
+    calls = []
+    monkeypatch.setattr(
+        "eigsep_observing.live_status.aggregator.probe_snap_fpga",
+        lambda *a, **kw: calls.append(a) or True,
+    )
+    agg._snap_tick()
+    assert calls == []
+    assert agg.state.snap_fpga_reachable is None
+
+
+def test_snapshot_exposes_snap_fpga_fields(agg):
+    snap = agg.snapshot()
+    assert hasattr(snap, "snap_fpga_reachable")
+    assert hasattr(snap, "snap_fpga_last_probe_unix")

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -848,6 +848,7 @@ def test_snap_fpga_probe_skipped_when_corr_fresh(agg, seeded, monkeypatch):
     snap, _panda = seeded
     # Seed a fresh corr_last_unix in state by directly stamping it.
     agg.state.corr_last_unix = time.time()
+    # Minimal dict: corr_observing_timeout_s only reads ["integration_time"].
     agg.state.corr_header = {"integration_time": 0.27}
 
     calls = []
@@ -868,6 +869,7 @@ def test_snap_fpga_probe_skipped_when_corr_fresh(agg, seeded, monkeypatch):
 
 def test_snap_fpga_probe_runs_when_corr_stale(agg, monkeypatch):
     """No corr data ever seen → probe should run and update state."""
+    # Minimal dict: _maybe_probe_snap_fpga only reads ["snap_ip"].
     agg.state.corr_config = {"snap_ip": "10.10.10.12"}
     monkeypatch.setattr(
         "eigsep_observing.live_status.aggregator.probe_snap_fpga",
@@ -880,6 +882,7 @@ def test_snap_fpga_probe_runs_when_corr_stale(agg, monkeypatch):
 
 def test_snap_fpga_probe_records_unreachable(agg, monkeypatch):
     """Probe returning False updates state.snap_fpga_reachable to False."""
+    # Minimal dict: _maybe_probe_snap_fpga only reads ["snap_ip"].
     agg.state.corr_config = {"snap_ip": "10.10.10.12"}
     monkeypatch.setattr(
         "eigsep_observing.live_status.aggregator.probe_snap_fpga",
@@ -893,6 +896,7 @@ def test_snap_fpga_probe_gated_by_interval(agg, monkeypatch):
     """Two ticks within the probe interval must only run the probe
     once — the inner tick cadence is 0.01 s, the probe interval is
     5 s by default."""
+    # Minimal dict: _maybe_probe_snap_fpga only reads ["snap_ip"].
     agg.state.corr_config = {"snap_ip": "10.10.10.12"}
     calls = []
     monkeypatch.setattr(

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -879,6 +879,7 @@ def test_snap_fpga_probe_runs_when_corr_stale(agg, monkeypatch):
 
 
 def test_snap_fpga_probe_records_unreachable(agg, monkeypatch):
+    """Probe returning False updates state.snap_fpga_reachable to False."""
     agg.state.corr_config = {"snap_ip": "10.10.10.12"}
     monkeypatch.setattr(
         "eigsep_observing.live_status.aggregator.probe_snap_fpga",

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -331,6 +331,7 @@ def test_health_route_surfaces_snap_reinit_count(agg_primed):
 def test_health_route_snap_fpga_state_live_when_corr_fresh(agg_primed):
     """corr fresh → state is 'live' regardless of probe result."""
     agg_primed.state.corr_last_unix = time.time()
+    # Minimal dict: corr_observing_timeout_s only reads ["integration_time"].
     agg_primed.state.corr_header = {"integration_time": 0.27}
     agg_primed.state.snap_fpga_reachable = False  # ignored when live
     client = create_app(agg_primed).test_client()

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -328,6 +328,47 @@ def test_health_route_surfaces_snap_reinit_count(agg_primed):
     assert data["snap_reinit"]["seconds_since_reinit"] is not None
 
 
+def test_health_route_snap_fpga_state_live_when_corr_fresh(agg_primed):
+    """corr fresh → state is 'live' regardless of probe result."""
+    agg_primed.state.corr_last_unix = time.time()
+    agg_primed.state.corr_header = {"integration_time": 0.27}
+    agg_primed.state.snap_fpga_reachable = False  # ignored when live
+    client = create_app(agg_primed).test_client()
+    body = client.get("/api/health").get_json()
+    assert body["data"]["snap_fpga_state"] == "live"
+
+
+def test_health_route_snap_fpga_state_reachable_when_probe_ok(
+    agg_primed,
+):
+    """corr stale + probe True → 'reachable'."""
+    agg_primed.state.corr_last_unix = None
+    agg_primed.state.snap_fpga_reachable = True
+    client = create_app(agg_primed).test_client()
+    body = client.get("/api/health").get_json()
+    assert body["data"]["snap_fpga_state"] == "reachable"
+
+
+def test_health_route_snap_fpga_state_unreachable_when_probe_fail(
+    agg_primed,
+):
+    """corr stale + probe False → 'unreachable'."""
+    agg_primed.state.corr_last_unix = None
+    agg_primed.state.snap_fpga_reachable = False
+    client = create_app(agg_primed).test_client()
+    body = client.get("/api/health").get_json()
+    assert body["data"]["snap_fpga_state"] == "unreachable"
+
+
+def test_health_route_snap_fpga_state_unknown_when_no_probe(agg_primed):
+    """corr stale + probe never ran → 'unknown'."""
+    agg_primed.state.corr_last_unix = None
+    agg_primed.state.snap_fpga_reachable = None
+    client = create_app(agg_primed).test_client()
+    body = client.get("/api/health").get_json()
+    assert body["data"]["snap_fpga_state"] == "unknown"
+
+
 def test_corr_route_has_pairs_and_freqs(client):
     body = client.get("/api/corr").get_json()
     data = body["data"]

--- a/tests/test_live_status_snap_probe.py
+++ b/tests/test_live_status_snap_probe.py
@@ -1,0 +1,51 @@
+"""Tests for SNAP FPGA TCP reachability probe.
+
+Uses real loopback sockets (no mocks) so we exercise the actual
+``socket.create_connection`` failure modes — connection refused
+from an unbound port vs success against a real listener.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from eigsep_observing.live_status.snap_probe import probe_snap_fpga
+
+
+@pytest.fixture
+def listening_port():
+    """Bind a real TCP socket on loopback and yield its port.
+
+    The listener accepts no connections but the OS completes the
+    SYN/ACK, so ``create_connection`` succeeds — which is all the
+    probe checks for.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    s.listen(1)
+    yield s.getsockname()[1]
+    s.close()
+
+
+def test_probe_returns_true_when_port_open(listening_port):
+    assert probe_snap_fpga("127.0.0.1", port=listening_port) is True
+
+
+def test_probe_returns_false_when_port_closed():
+    # Port 1 on loopback is reserved/unbound on Linux — connect refused.
+    assert probe_snap_fpga("127.0.0.1", port=1, timeout=0.5) is False
+
+
+def test_probe_returns_false_on_unroutable_host():
+    # TEST-NET-1 (RFC 5737) — must not route anywhere.
+    assert probe_snap_fpga("192.0.2.1", port=7147, timeout=0.5) is False
+
+
+def test_probe_returns_false_when_host_is_none():
+    assert probe_snap_fpga(None) is False
+
+
+def test_probe_returns_false_when_host_is_empty_string():
+    assert probe_snap_fpga("") is False

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -180,9 +180,11 @@ def test_get_status_returns_snapshot_or_none(client):
     # in separate ticks, so wait until the merged dict carries both
     # prefixes before snapshotting.
     assert _wait_until(
-        lambda: (s := tc.get_status()) is not None
-        and "LNA_T_target" in s
-        and "LOAD_T_target" in s
+        lambda: (
+            (s := tc.get_status()) is not None
+            and "LNA_T_target" in s
+            and "LOAD_T_target" in s
+        )
     )
     status = tc.get_status()
     # The merge preserves the legacy flat shape: device-wide watchdog

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -174,7 +174,16 @@ def test_get_status_returns_snapshot_or_none(client):
     on. Returns None before either pico stream has published."""
     tc = TempCtrlClient(client.transport, settings=SETTINGS)
     tc.apply_settings()
-    assert _wait_until(lambda: tc.get_status() is not None)
+    # get_status() goes non-None as soon as EITHER pico stream
+    # (tempctrl_lna OR tempctrl_load) has published, but the asserts
+    # below need both. Under pytest -n auto the two streams can land
+    # in separate ticks, so wait until the merged dict carries both
+    # prefixes before snapshotting.
+    assert _wait_until(
+        lambda: (s := tc.get_status()) is not None
+        and "LNA_T_target" in s
+        and "LOAD_T_target" in s
+    )
     status = tc.get_status()
     # The merge preserves the legacy flat shape: device-wide watchdog
     # fields at the top, per-channel fields under LNA_*/LOAD_* prefix.

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "eigsep-observing"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## Summary
- Replace the three misleading header tiles (SNAP / Panda / Observing) with four honest ones: **SNAP FPGA**, **Backend Redis**, **Panda observe**, **Corr loop**. Each tile now names what it actually measures, with hover tooltips spelling out the underlying check.
- Add `live_status/snap_probe.py` — a 1 s TCP connect to `snap_ip:7147` (katcp) — so the SNAP FPGA tile reflects actual FPGA reachability when the corr stream is not already proving liveness.
- Tier the SNAP FPGA tile across `live` (corr fresh) / `reachable` (probe OK) / `unreachable` / `unknown`. The probe only fires when corr is stale and is rate-limited to one shot per 5 s, so steady-state observing never opens an extra socket.
- Refactor: lift `corr_observing_timeout_s` from `app.py` to `aggregator.py` so the freshness predicate has one definition shared by both call sites.
- Add `--snap-fpga-host` CLI override on `scripts/live_status.py` for the bootstrap case where the corr config has not yet been published to Redis.

## Why
Today's "SNAP: connected" tile is really "rpi-side Redis is up" — it tells the operator nothing about the SNAP FPGA at 10.10.10.12. With no Slack/email alerting in the field, the dashboard has to be precise. The 4-tile layout separates the four orthogonal axes (SNAP FPGA reachability, backend Redis liveness, panda-script alive, corr-loop recording) so a partial failure (e.g. fpga_init crashed but SNAP itself fine) is visible at a glance.

## Test plan
- [x] `pytest tests/test_live_status_{aggregator,app,snap_probe}.py` — 92 passed
- [x] `ruff check` / `ruff format --check` — clean
- [ ] Browser smoke test: each of the four tiles renders correct color + label for the current rpi/panda/SNAP state; tooltips visible on hover
- [ ] Stopping `eigsep-fpga-init` flips **Corr loop** to "idle" and — if SNAP itself remains up — **SNAP FPGA** to "reachable" within ~5 s
- [ ] Disconnecting the SNAP at the network flips **SNAP FPGA** to "unreachable" within ~5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)