### PR TITLE
feat(observe): decouple writer from panda ConfigStore

### DIFF
--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -113,7 +113,6 @@ class EigObserver:
             self.status_reader = StatusReader(transport_panda)
             self.heartbeat_reader = HeartbeatReader(transport_panda)
             self.vna_reader = VnaReader(transport_panda)
-            self.cfg = self.config.get()
             self._status_log_handler = StatusStreamHandler(transport_panda)
             logging.getLogger("eigsep_observing").addHandler(
                 self._status_log_handler

--- a/src/eigsep_observing/scripts/observe.py
+++ b/src/eigsep_observing/scripts/observe.py
@@ -1,10 +1,16 @@
 """Observing-side file writer.
 
-Reads configuration from Redis (uploaded by PandaClient) and writes
-correlation and VNA data to disk. Either start order works: the script
-blocks on a 1 s retry loop until the Panda's ``ConfigStore`` is
-populated, and the systemd unit's ``Restart=on-failure`` covers the
-case where the Panda host is entirely unreachable.
+Writes correlation and VNA data to disk. Corr writing starts as soon as
+the SNAP is producing — independent of any panda-side state — and the
+``obs_config`` / ``run_tag`` overlays stamped into each corr file header
+are read opportunistically per file boundary (see
+:meth:`EigObserver._with_header_overlays`). This decouples the writer
+from ``panda_observe`` so any panda-side script (or none at all) can run
+alongside it.
+
+The VNA thread is spawned unconditionally whenever ``--panda`` is on;
+it polls ``panda_connected`` internally and sits idle if no VNA data
+appears on the stream.
 
 Installed as the ``eigsep-observe`` console script and run by the
 ``eigsep-observe-writer.service`` systemd unit (see ``deploy/systemd/``).
@@ -14,9 +20,8 @@ import argparse
 import logging
 import sys
 import threading
-import time
 
-from eigsep_redis import ConfigStore, Transport
+from eigsep_redis import Transport
 
 from eigsep_observing import EigObserver
 
@@ -51,6 +56,12 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="corr_save_dir",
         default="/media/eigsep/T7/data",
         help="Directory for correlator HDF5 files.",
+    )
+    parser.add_argument(
+        "--vna-save-dir",
+        dest="vna_save_dir",
+        default="/media/eigsep/T7/data/s11_data",
+        help="Directory for VNA S11 HDF5 files.",
     )
     parser.add_argument(
         "--corr-ntimes",
@@ -122,17 +133,6 @@ def main() -> int:
         logger.warning("Not connecting to LattePanda")
         transport_panda = None
 
-    if args.use_panda:
-        logger.info("Waiting for Panda config in Redis.")
-        panda_config = ConfigStore(transport_panda)
-        while True:
-            try:
-                panda_config.get()
-                break
-            except ValueError:
-                logger.info("Panda config not yet available, retrying...")
-                time.sleep(1.0)
-
     if args.dummy:
         observer = DummyEigObserver(
             transport_snap=transport_snap,
@@ -171,12 +171,13 @@ def main() -> int:
         logger.info("Starting correlation file writing thread.")
         corr_thd.start()
 
-    # set up VNA file writing — use panda config from Redis
-    if args.use_panda and observer.cfg.get("use_vna", False):
-        logger.info(f"panda connected: {observer.panda_connected}")
+    # VNA file writing: spawn unconditionally when --panda is on. The
+    # thread polls ``panda_connected`` internally and idles on an empty
+    # VNA stream, so it's harmless when no panda script is publishing.
+    if args.use_panda:
         vna_thd = threading.Thread(
             target=observer.record_vna_data,
-            args=(observer.cfg["vna_save_dir"],),
+            args=(args.vna_save_dir,),
         )
         thds["vna"] = vna_thd
         logger.info("Starting VNA file writing thread.")

--- a/src/eigsep_observing/testing/observer.py
+++ b/src/eigsep_observing/testing/observer.py
@@ -15,9 +15,10 @@ CFG_PATH = utils.get_config_path("dummy_config.yaml")
 class DummyEigObserver(EigObserver):
     def __init__(self, transport_snap=None, transport_panda=None):
         """
-        Override constructor to pre-seed the dummy configs on each
-        transport so the parent constructor's ``.get()`` calls find
-        them.
+        Pre-seed the dummy configs on each transport so the SNAP-side
+        ``CorrConfigStore.get()`` succeeds during parent construction
+        and ``_with_header_overlays`` finds a populated panda
+        ``ConfigStore`` when tests exercise the overlay path.
         """
         if transport_snap is not None:
             CorrConfigStore(transport_snap).upload(

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -95,7 +95,7 @@ def test_observer_init_panda_only(observer_panda_only, transport_panda):
     """Test EigObserver initialization with only LattePanda connection."""
     assert observer_panda_only.transport_snap is None
     assert observer_panda_only.transport_panda is transport_panda
-    assert observer_panda_only.cfg is not None
+    assert observer_panda_only.config is not None
 
 
 def test_observer_init_both(observer_both, transport_snap, transport_panda):
@@ -103,7 +103,7 @@ def test_observer_init_both(observer_both, transport_snap, transport_panda):
     assert observer_both.transport_snap is transport_snap
     assert observer_both.transport_panda is transport_panda
     assert observer_both.corr_cfg is not None
-    assert observer_both.cfg is not None
+    assert observer_both.config is not None
 
 
 def test_observer_init_none():
@@ -112,6 +112,28 @@ def test_observer_init_none():
     assert observer.transport_snap is None
     assert observer.transport_panda is None
     observer.close()
+
+
+def test_observer_init_panda_empty_config_does_not_raise():
+    """Construction against an unseeded panda ConfigStore must not raise.
+
+    The writer must start as soon as the backend boots, without waiting
+    for ``panda_observe`` to upload an ``obs_config``. ``_with_header_overlays``
+    is the only consumer of the panda config; its read is defensive and
+    falls back to sentinels.
+    """
+    transport_panda = DummyTransport()
+    HeartbeatWriter(transport_panda).set(alive=True)
+    observer = EigObserver(transport_panda=transport_panda)
+    try:
+        assert observer.config is not None
+        overlaid = observer._with_header_overlays({"foo": 1})
+        assert overlaid["foo"] == 1
+        assert overlaid["obs_config"] == {}
+        assert overlaid["run_tag"] == "UNKNOWN"
+        assert overlaid["run_started_at_unix"] == 0.0
+    finally:
+        observer.close()
 
 
 def test_status_handler_does_not_block_caller_on_slow_xadd(


### PR DESCRIPTION
## Summary

- The writer used to block at startup until `panda_observe` had uploaded the panda `ConfigStore`, so no corr files were written on a fresh boot until the operator manually launched the panda script — even though the SNAP was already programmed and producing data.
- This PR removes that gate. `obs_config` and `run_tag` are now stamped into corr file headers opportunistically per file boundary via the already-defensive `_with_header_overlays`; corr files written before any panda script runs carry `obs_config={}` and `run_tag="UNKNOWN"` as sentinels (same shape the overlay already produces on a transient read failure).
- The VNA save dir moves to a `--vna-save-dir` CLI arg (mirrors `--corr-save-dir`), and the VNA thread is spawned unconditionally when `--panda` is on. Any panda-side script — including a future standalone VNA-sweep script — can now substitute for `panda_observe` without fake-uploading an `obs_config`.

### What changed

- `observer.py`: deleted `self.cfg = self.config.get()` in `EigObserver.__init__`. `self.config` (the `ConfigStore` handle) stays; `_with_header_overlays` reads it fresh per file boundary.
- `scripts/observe.py`: removed the wait loop; added `--vna-save-dir` arg; dropped the `use_vna` config gate; rewrote the module docstring; dropped now-unused `ConfigStore`/`time` imports.
- `testing/observer.py`: tightened the `DummyEigObserver` docstring (parent no longer eagerly reads panda config).
- `tests/test_observer.py`: updated two existing tests that asserted `observer.cfg is not None` to assert `observer.config is not None`; added `test_observer_init_panda_empty_config_does_not_raise` to lock in the new contract.

### Out of scope (follow-ups noted in the design)

- `vna_save_dir` stays in `obs_config.yaml` for now — `PandaClient.init_VNA` still passes it to `cmt_vna.VNA` for the driver's fallback `write_data()` path. Stripping it requires a separate panda-side patch.
- VNA S11 file headers do not currently get `obs_config` stamped (`record_vna_data` bypasses `_with_header_overlays`). Separate consistency gap.

## Test plan

- [x] `pytest tests/test_observer.py` — 39 passed (38 original + 1 new).
- [x] `pytest` (full suite) — 568 passed / 3 failed. All 3 failures (`test_get_status_returns_snapshot_or_none`, `test_sensor_metadata_in_redis`, `test_metadata_has_expected_fields`) reproduce on `main` and are about `tempctrl` sensor-key naming, unrelated to this change.
- [x] Dummy-mode smoke: `eigsep-observe --dummy --no-snap` runs through to `observer.stop_event.wait()` without printing `"Waiting for Panda config in Redis."` — wait loop verifiably gone.
- [ ] Field validation (post-merge, on backend Pi rc image): reboot with panda powered off; verify corr HDF5s appear under `--corr-save-dir` within `corr_ntimes * t_int` seconds with `obs_config={}` / `run_tag="UNKNOWN"` in headers. Power on panda + launch `eigsep-panda`; verify next file picks up populated overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)