### PR TITLE
test: replace fixed sleeps with condition polling in emulator integration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,6 +38,47 @@ def client(transport, dummy_cfg):
     c.stop()
 
 
+# All emulator-fed streams we expect after the embedded PicoManager starts
+# (one entry per registered DummyPico*). Used both as the fixture-readiness
+# wait condition and as the assertion target in test_sensor_metadata_in_redis.
+_EXPECTED_SENSORS = (
+    # tempctrl publishes two streams (one per Peltier channel); the
+    # picohost producer fans the firmware's combined tick into
+    # tempctrl_lna and tempctrl_load.
+    "tempctrl_lna",
+    "tempctrl_load",
+    "potmon",
+    "imu_el",
+    "imu_az",
+    "lidar",
+    "rfswitch",
+)
+
+
+def _wait_for_sensors(transport, sensors=_EXPECTED_SENSORS, timeout=5.0):
+    """Poll the metadata snapshot until every name in ``sensors`` has
+    published at least once. Returns the final snapshot. Raises
+    ``AssertionError`` (with the keys actually present) on timeout.
+
+    Replaces ``time.sleep(0.5)`` — under ``pytest -n auto`` on CI the
+    200 ms emulator cadence + reader-thread + Redis write chain can take
+    longer than a half-second wall clock. Condition-polling decouples
+    the test from how heavily the runner is loaded.
+    """
+    deadline = time.monotonic() + timeout
+    reader = MetadataSnapshotReader(transport)
+    while True:
+        metadata = reader.get()
+        if all(s in metadata for s in sensors):
+            return metadata
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"timed out after {timeout}s waiting for sensors "
+                f"{list(sensors)}; got keys: {list(metadata.keys())}"
+            )
+        time.sleep(0.02)
+
+
 def test_picos_registered(client):
     """PicoManager should register all dummy devices in Redis."""
     available = client.transport.r.smembers("picos")
@@ -56,23 +97,8 @@ def test_picos_registered(client):
 
 def test_sensor_metadata_in_redis(client, transport):
     """Emulators generate status that flows through redis_handler to Redis."""
-    time.sleep(0.5)
-
-    metadata = MetadataSnapshotReader(transport).get()
-
-    expected_sensors = {
-        # tempctrl publishes two streams (one per Peltier channel); the
-        # picohost producer fans the firmware's combined tick into
-        # tempctrl_lna and tempctrl_load.
-        "tempctrl_lna",
-        "tempctrl_load",
-        "potmon",
-        "imu_el",
-        "imu_az",
-        "lidar",
-        "rfswitch",
-    }
-    for sensor in expected_sensors:
+    metadata = _wait_for_sensors(transport)
+    for sensor in _EXPECTED_SENSORS:
         assert sensor in metadata, (
             f"Expected sensor '{sensor}' in metadata, "
             f"got keys: {list(metadata.keys())}"
@@ -81,9 +107,7 @@ def test_sensor_metadata_in_redis(client, transport):
 
 def test_metadata_has_expected_fields(client, transport):
     """Verify that metadata values contain the expected sensor fields."""
-    time.sleep(0.5)
-
-    metadata = MetadataSnapshotReader(transport).get()
+    metadata = _wait_for_sensors(transport)
 
     # Each Peltier channel has its own stream with flat per-channel
     # fields, a top-level status, and the device-wide watchdog fields
@@ -124,7 +148,7 @@ def test_metadata_has_expected_fields(client, transport):
 
 def test_metadata_snapshot_single_key(client, transport):
     """metadata_snapshot.get(key) returns just that sensor's data."""
-    time.sleep(0.5)
+    _wait_for_sensors(transport, sensors=("lidar",))
     lidar = MetadataSnapshotReader(transport).get("lidar")
     assert isinstance(lidar, dict)
     assert "distance_m" in lidar

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -34,8 +34,16 @@ def _emulator(client):
     return client._manager.picos["tempctrl"]._emulator
 
 
-def _wait_until(predicate, timeout=2.0, interval=0.02):
-    """Poll ``predicate`` until it returns truthy or ``timeout`` elapses."""
+def _wait_until(predicate, timeout=5.0, interval=0.02):
+    """Poll ``predicate`` until it returns truthy or ``timeout`` elapses.
+
+    Default timeout is 5 s — the original 2 s was tight enough that under
+    ``pytest -n auto`` on a busy CI runner, ``test_get_status_returns_
+    snapshot_or_none`` would intermittently miss the first tempctrl
+    publish (200 ms emulator cadence × per-channel × scheduler jitter).
+    Healthy local runs complete in well under a second, so the bump only
+    extends the worst case.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():


### PR DESCRIPTION
## Summary
- Under `pytest -n auto` on CI, the 200 ms emulator publish cadence + 4-way parallel scheduler contention exceeds the existing `time.sleep(0.5)` waits in `test_integration.py` and the 2 s default `_wait_until` timeout in `test_tempctrl_client.py`. All three of these tests flaked together on a recent PR #113 run while passing reliably locally.
- Replace `time.sleep(0.5)` in three `test_integration.py` tests with a new `_wait_for_sensors(transport, sensors, timeout=5.0)` helper that polls the metadata snapshot until every expected stream has published, with a generous CI-safe deadline.
- Bump `_wait_until` default timeout in `test_tempctrl_client.py` from 2 s to 5 s with a comment explaining why; healthy runs still complete in well under a second.
- Test-only diff. No production code touched.

## Test plan
- [x] `pytest tests/test_integration.py tests/test_tempctrl_client.py -n auto` — 22 passed
- [x] Stress: 5 consecutive parallel runs — 22/22 every time (~12-14 s each)
- [x] `ruff check` / `ruff format --check` — clean
- [x] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)