### PR TITLE
feat(scripts): manual bring-up tools for rfswitch, lidar, imu, potmon, tempctrl

### DIFF
--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -48,10 +48,7 @@ BAR_WIDTH = 41  # odd so the zero-tick lines up
 
 
 def _read_imu(snapshot, name):
-    try:
-        snap = snapshot.get(name)
-    except KeyError:
-        return None
+    snap = snapshot.get().get(name)
     return snap or None
 
 

--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -1,0 +1,149 @@
+"""Live IMU readout for bring-up (imu_el and/or imu_az).
+
+The two IMU picos share firmware (BNO085 in UART RVC mode under
+picohost 1.0.0) and publish only ``yaw``/``pitch``/``roll`` (deg) and
+``accel_x``/``accel_y``/``accel_z`` (m/s²). Tilt the rig by hand and
+watch the numbers move; pitch and roll get an ASCII level bar centered
+at zero so a visual sweep is immediately obvious.
+
+Read-only — IMUs accept no commands. The script asserts at import that
+the schema hasn't drifted (e.g. picohost re-adding a quaternion field
+would change reduction semantics in ``io.py`` and warrant updating
+this display).
+"""
+
+from argparse import ArgumentParser
+import logging
+import sys
+import time
+
+from eigsep_redis import MetadataSnapshotReader
+
+from eigsep_observing._scripts_util import build_transport
+from eigsep_observing.io import _IMU_SCHEMA
+from eigsep_observing.utils import configure_eig_logger
+
+
+configure_eig_logger(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Field names this script renders. Asserting against the schema keeps
+# the display honest: if the IMU schema grows or loses a field, this
+# import-time check fires so the script can't silently mis-render.
+_EXPECTED = {
+    "yaw",
+    "pitch",
+    "roll",
+    "accel_x",
+    "accel_y",
+    "accel_z",
+}
+_missing = _EXPECTED - set(_IMU_SCHEMA)
+assert not _missing, (
+    f"imu_manual expects fields {_EXPECTED} from _IMU_SCHEMA; missing "
+    f"{_missing}. Has the IMU schema changed in io.py?"
+)
+
+BAR_WIDTH = 41  # odd so the zero-tick lines up
+
+
+def _read_imu(snapshot, name):
+    try:
+        snap = snapshot.get(name)
+    except KeyError:
+        return None
+    return snap or None
+
+
+def _angle_bar(value, *, full_scale=90.0):
+    """Center-zero bar for [-full_scale, +full_scale] degrees."""
+    if value is None:
+        return " " * BAR_WIDTH
+    clamped = max(-full_scale, min(full_scale, float(value)))
+    frac = (clamped + full_scale) / (2 * full_scale)
+    pos = int(round(frac * (BAR_WIDTH - 1)))
+    cells = [" "] * BAR_WIDTH
+    cells[BAR_WIDTH // 2] = "|"  # zero tick
+    cells[pos] = "#"
+    return "".join(cells)
+
+
+def _fmt_field(reading, key, fmt):
+    if reading is None:
+        return "   --"
+    v = reading.get(key)
+    if not isinstance(v, (int, float)):
+        return "   --"
+    return format(v, fmt)
+
+
+def _render(snapshot, names):
+    readings = {name: _read_imu(snapshot, name) for name in names}
+    sys.stdout.write("\x1b[2J\x1b[H")
+    print(f"imu_manual @ {time.strftime('%H:%M:%S')}")
+    for name in names:
+        r = readings[name]
+        print()
+        print(f"=== {name} ===")
+        if r is None:
+            print("  (no reading; is the pico flashed and the manager up?)")
+            continue
+        yaw = _fmt_field(r, "yaw", "7.2f")
+        pitch = _fmt_field(r, "pitch", "7.2f")
+        roll = _fmt_field(r, "roll", "7.2f")
+        ax = _fmt_field(r, "accel_x", "6.2f")
+        ay = _fmt_field(r, "accel_y", "6.2f")
+        az = _fmt_field(r, "accel_z", "6.2f")
+        print(f"  yaw   {yaw} deg")
+        print(f"  pitch {pitch} deg  [{_angle_bar(r.get('pitch'))}]")
+        print(f"  roll  {roll} deg  [{_angle_bar(r.get('roll'))}]")
+        print(f"  accel ({ax}, {ay}, {az}) m/s²  status={r.get('status')!r}")
+    print()
+    print("Ctrl-C to exit.")
+    sys.stdout.flush()
+
+
+def _render_loop(snapshot, names, interval_s):
+    while True:
+        _render(snapshot, names)
+        time.sleep(interval_s)
+
+
+def _parse_args():
+    parser = ArgumentParser(description="Live IMU readout for imu_el/imu_az.")
+    parser.add_argument(
+        "--dummy",
+        action="store_true",
+        help="Run against a fakeredis-backed DummyPandaClient",
+    )
+    parser.add_argument(
+        "--which",
+        choices=("el", "az", "both"),
+        default="both",
+        help="Which IMU(s) to display (default: both).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.2,
+        help="Refresh interval in seconds (default: 0.2).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    transport = build_transport(args.dummy)
+    snapshot = MetadataSnapshotReader(transport)
+    if args.which == "both":
+        names = ["imu_el", "imu_az"]
+    else:
+        names = [f"imu_{args.which}"]
+    try:
+        _render_loop(snapshot, names, args.interval)
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lidar_manual.py
+++ b/scripts/lidar_manual.py
@@ -1,0 +1,115 @@
+"""Live lidar readout for bring-up.
+
+Prints ``distance_m`` from the lidar pico's metadata snapshot at ~5 Hz
+with a horizontal bar so an operator can wave a hand in front of the
+sensor and visually confirm the value tracks. Read-only; the lidar
+firmware has no commands.
+
+The bar saturates at ``--max-range`` so the visualization stays useful
+for short-range bench testing without rebuilding firmware.
+"""
+
+from argparse import ArgumentParser
+import logging
+import sys
+import time
+
+from eigsep_redis import MetadataSnapshotReader
+
+from eigsep_observing._scripts_util import build_transport
+from eigsep_observing.utils import configure_eig_logger
+
+
+configure_eig_logger(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+BAR_WIDTH = 60
+
+
+def _read_lidar(snapshot):
+    try:
+        snap = snapshot.get("lidar")
+    except KeyError:
+        return None, None
+    if not snap:
+        return None, None
+    return snap.get("distance_m"), snap.get("status")
+
+
+def _format_bar(distance, max_range):
+    if distance is None:
+        return "[" + " " * BAR_WIDTH + "]"
+    frac = max(0.0, min(1.0, distance / max_range))
+    filled = int(round(frac * BAR_WIDTH))
+    return "[" + "#" * filled + " " * (BAR_WIDTH - filled) + "]"
+
+
+def _format_age(ts, now):
+    if ts is None:
+        return " --"
+    age = max(0.0, now - ts)
+    if age < 60:
+        return f"{age:5.1f}s"
+    return f"{age / 60:5.1f}m"
+
+
+def _render_loop(snapshot, interval_s, max_range):
+    while True:
+        distance, status = _read_lidar(snapshot)
+        # Read the panda-stamped _ts so we can flag a stale sensor
+        # (e.g. lidar pico crashed and no longer publishes).
+        meta = snapshot.get()
+        ts = meta.get("lidar_ts") if isinstance(meta, dict) else None
+        age = _format_age(ts, time.time())
+        bar = _format_bar(distance, max_range)
+        if distance is None:
+            value = "  --"
+        else:
+            value = f"{distance:5.2f} m"
+        # ANSI clear + home so the operator sees one stable line that
+        # updates in place, like ``pico_preflight --watch``.
+        sys.stdout.write("\x1b[2J\x1b[H")
+        print(f"lidar manual (max range {max_range:.1f} m)")
+        print()
+        print(f"  distance: {value}   status: {status!r}   age: {age}")
+        print(f"  {bar}")
+        print()
+        print("Ctrl-C to exit.")
+        sys.stdout.flush()
+        time.sleep(interval_s)
+
+
+def _parse_args():
+    parser = ArgumentParser(description="Live lidar distance readout.")
+    parser.add_argument(
+        "--dummy",
+        action="store_true",
+        help="Run against a fakeredis-backed DummyPandaClient",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.2,
+        help="Refresh interval in seconds (default: 0.2).",
+    )
+    parser.add_argument(
+        "--max-range",
+        type=float,
+        default=5.0,
+        help="Bar saturates at this distance in meters (default: 5.0).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    transport = build_transport(args.dummy)
+    snapshot = MetadataSnapshotReader(transport)
+    try:
+        _render_loop(snapshot, args.interval, args.max_range)
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lidar_manual.py
+++ b/scripts/lidar_manual.py
@@ -27,10 +27,7 @@ BAR_WIDTH = 60
 
 
 def _read_lidar(snapshot):
-    try:
-        snap = snapshot.get("lidar")
-    except KeyError:
-        return None, None
+    snap = snapshot.get().get("lidar")
     if not snap:
         return None, None
     return snap.get("distance_m"), snap.get("status")

--- a/scripts/potmon_manual.py
+++ b/scripts/potmon_manual.py
@@ -1,0 +1,114 @@
+"""Live potentiometer monitor readout for bring-up.
+
+Displays raw voltages and (calibration-derived) angles for both axes
+from the ``potmon`` metadata snapshot. Rotate the elevation / azimuth
+pots by hand and verify the values move smoothly through their range.
+
+Read-only — calibration is a separate concern. Run the picohost
+``calibrate_pot.py`` script first if the angle columns show ``--``
+(uncalibrated streams publish ``None`` for the cal/angle fields, which
+this script renders as ``--`` per the SENSOR_SCHEMAS contract).
+"""
+
+from argparse import ArgumentParser
+import logging
+import sys
+import time
+
+from eigsep_redis import MetadataSnapshotReader
+
+from eigsep_observing._scripts_util import build_transport
+from eigsep_observing.utils import configure_eig_logger
+
+
+configure_eig_logger(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def _read_potmon(snapshot):
+    try:
+        snap = snapshot.get("potmon")
+    except KeyError:
+        return None
+    return snap or None
+
+
+def _fmt(value, fmt):
+    if not isinstance(value, (int, float)):
+        return "    --"
+    return format(value, fmt)
+
+
+def _render(snapshot):
+    snap = _read_potmon(snapshot)
+    sys.stdout.write("\x1b[2J\x1b[H")
+    print(f"potmon_manual @ {time.strftime('%H:%M:%S')}")
+    print()
+    if snap is None:
+        print("  (no potmon reading; is the pico flashed and the manager up?)")
+        print()
+        print("Ctrl-C to exit.")
+        sys.stdout.flush()
+        return
+    el_v = _fmt(snap.get("pot_el_voltage"), "6.3f")
+    el_a = _fmt(snap.get("pot_el_angle"), "7.2f")
+    az_v = _fmt(snap.get("pot_az_voltage"), "6.3f")
+    az_a = _fmt(snap.get("pot_az_angle"), "7.2f")
+    print("  axis     voltage      angle")
+    print("  ----    --------    --------")
+    print(f"  el      {el_v} V   {el_a} deg")
+    print(f"  az      {az_v} V   {az_a} deg")
+    print()
+    print(f"  status: {snap.get('status')!r}")
+    cal_el = snap.get("pot_el_cal_slope")
+    cal_az = snap.get("pot_az_cal_slope")
+    if cal_el is None or cal_az is None:
+        # Uncalibrated streams emit None for all cal/angle fields. Tell
+        # the operator how to fix it instead of leaving them to wonder
+        # why the angle column is blank.
+        print()
+        print(
+            "  one or both axes uncalibrated — run picohost's "
+            "calibrate_pot.py first."
+        )
+    print()
+    print("Ctrl-C to exit.")
+    sys.stdout.flush()
+
+
+def _render_loop(snapshot, interval_s):
+    while True:
+        _render(snapshot)
+        time.sleep(interval_s)
+
+
+def _parse_args():
+    parser = ArgumentParser(
+        description="Live potentiometer voltage and angle readout."
+    )
+    parser.add_argument(
+        "--dummy",
+        action="store_true",
+        help="Run against a fakeredis-backed DummyPandaClient",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.2,
+        help="Refresh interval in seconds (default: 0.2).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    transport = build_transport(args.dummy)
+    snapshot = MetadataSnapshotReader(transport)
+    try:
+        _render_loop(snapshot, args.interval)
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/potmon_manual.py
+++ b/scripts/potmon_manual.py
@@ -26,10 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def _read_potmon(snapshot):
-    try:
-        snap = snapshot.get("potmon")
-    except KeyError:
-        return None
+    snap = snapshot.get().get("potmon")
     return snap or None
 
 

--- a/scripts/rfswitch_manual.py
+++ b/scripts/rfswitch_manual.py
@@ -1,0 +1,151 @@
+"""Interactive RF switch bring-up tool.
+
+Pick a switch state from a numbered menu (or ``c`` to cycle through
+them all with a pause between each). Every command goes through
+PicoManager via :class:`picohost.proxy.PicoProxy`, the same path the
+observing loops use — so a switch that works here will work in
+production. After each switch, the script reads ``sw_state_name`` back
+from the metadata snapshot and prints it; cross-check against the
+live-status dashboard tile.
+
+Run alongside ``scripts/live_status.py`` so you can see the rfswitch
+tile flip in the browser as you exercise each state.
+"""
+
+from argparse import ArgumentParser
+import logging
+import time
+
+from eigsep_redis import MetadataSnapshotReader
+from picohost.base import PicoRFSwitch
+from picohost.proxy import PicoProxy
+
+from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing.utils import configure_eig_logger
+
+
+configure_eig_logger(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Canonical state list — sourced from the firmware-side class so a
+# new state added in firmware shows up here without a code change.
+STATES = list(PicoRFSwitch.path_str)
+
+
+def _print_menu():
+    print()
+    print("=== RF switch states ===")
+    for i, state in enumerate(STATES):
+        print(f"  [{i:>2}] {state}")
+    print("  [ c] cycle through all states (2 s dwell)")
+    print("  [ q] quit")
+
+
+def _read_current_state(snapshot):
+    try:
+        snap = snapshot.get("rfswitch")
+    except KeyError:
+        return None
+    return snap.get("sw_state_name") if snap else None
+
+
+def _switch(proxy, state):
+    """Issue the switch command and return True on success.
+
+    ``send_command`` returns ``None`` when the pico's heartbeat is
+    missing, raises ``TimeoutError`` if PicoManager doesn't respond
+    within the proxy timeout, and ``RuntimeError`` if the firmware
+    reports a failure. All three cases are operator-actionable here —
+    print a one-line summary and let the caller decide whether to keep
+    going.
+    """
+    try:
+        result = proxy.send_command("switch", state=state)
+    except (TimeoutError, RuntimeError) as exc:
+        print(f"  !! switch to {state} failed: {type(exc).__name__}: {exc}")
+        return False
+    if result is None:
+        print(f"  !! switch to {state} failed: rfswitch unavailable")
+        return False
+    return True
+
+
+def _do_switch(proxy, snapshot, state, *, settle_s=0.4):
+    print(f"-> switching to {state}")
+    if not _switch(proxy, state):
+        return
+    # Give PicoManager a tick to publish the new sw_state_name.
+    time.sleep(settle_s)
+    seen = _read_current_state(snapshot)
+    if seen == state:
+        print(f"   metadata confirms sw_state_name={seen}")
+    else:
+        print(f"   metadata shows sw_state_name={seen!r} (expected {state})")
+
+
+def _cycle(proxy, snapshot, dwell_s):
+    for state in STATES:
+        _do_switch(proxy, snapshot, state)
+        time.sleep(dwell_s)
+
+
+def _repl(proxy, snapshot, cycle_dwell_s):
+    while True:
+        _print_menu()
+        current = _read_current_state(snapshot)
+        print(f"Current sw_state_name: {current!r}")
+        try:
+            choice = input("Select> ").strip().lower()
+        except EOFError:
+            print()
+            return
+        if not choice:
+            continue
+        if choice == "q":
+            return
+        if choice == "c":
+            _cycle(proxy, snapshot, cycle_dwell_s)
+            continue
+        try:
+            idx = int(choice)
+        except ValueError:
+            print(f"  ?? unrecognized input: {choice!r}")
+            continue
+        if not 0 <= idx < len(STATES):
+            print(f"  ?? index {idx} out of range")
+            continue
+        _do_switch(proxy, snapshot, STATES[idx])
+
+
+def _parse_args():
+    parser = ArgumentParser(
+        description="Interactive RF switch bring-up: drive each state by hand."
+    )
+    parser.add_argument(
+        "--dummy",
+        action="store_true",
+        help="Run against a fakeredis-backed DummyPandaClient",
+    )
+    parser.add_argument(
+        "--cycle-dwell",
+        type=float,
+        default=2.0,
+        help="Seconds to dwell at each state in cycle (c) mode.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    transport = build_transport(args.dummy)
+    proxy = PicoProxy("rfswitch", transport, source="rfswitch_manual")
+    require_pico(proxy)
+    snapshot = MetadataSnapshotReader(transport)
+    try:
+        _repl(proxy, snapshot, args.cycle_dwell)
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rfswitch_manual.py
+++ b/scripts/rfswitch_manual.py
@@ -42,10 +42,7 @@ def _print_menu():
 
 
 def _read_current_state(snapshot):
-    try:
-        snap = snapshot.get("rfswitch")
-    except KeyError:
-        return None
+    snap = snapshot.get().get("rfswitch")
     return snap.get("sw_state_name") if snap else None
 
 

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -77,8 +77,11 @@ def _seed_state(snapshot):
     lna = _snap(snapshot, "tempctrl_lna") or {}
     load = _snap(snapshot, "tempctrl_load") or {}
     return _State(
-        lna_setpoint=float(lna.get("T_target") or 20.0),
-        load_setpoint=float(load.get("T_target") or 20.0),
+        lna_t = lna.get("T_target")
+        load_t = load.get("T_target")
+        return _State(
+            lna_setpoint=float(lna_t) if lna_t is not None else 20.0,
+            load_setpoint=float(load_t) if load_t is not None else 20.0,
         lna_enabled=bool(lna.get("enabled") or False),
         load_enabled=bool(load.get("enabled") or False),
     )

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -76,12 +76,11 @@ def _seed_state(snapshot):
     """
     lna = _snap(snapshot, "tempctrl_lna") or {}
     load = _snap(snapshot, "tempctrl_load") or {}
+    lna_t = lna.get("T_target")
+    load_t = load.get("T_target")
     return _State(
-        lna_t = lna.get("T_target")
-        load_t = load.get("T_target")
-        return _State(
-            lna_setpoint=float(lna_t) if lna_t is not None else 20.0,
-            load_setpoint=float(load_t) if load_t is not None else 20.0,
+        lna_setpoint=float(lna_t) if lna_t is not None else 20.0,
+        load_setpoint=float(load_t) if load_t is not None else 20.0,
         lna_enabled=bool(lna.get("enabled") or False),
         load_enabled=bool(load.get("enabled") or False),
     )

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -64,10 +64,7 @@ class _State:
 
 
 def _snap(snapshot, name):
-    try:
-        return snapshot.get(name)
-    except KeyError:
-        return None
+    return snapshot.get().get(name)
 
 
 def _seed_state(snapshot):

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -1,0 +1,268 @@
+"""Interactive tempctrl (peltier) bring-up tool.
+
+Curses UI showing live per-channel readouts for the two tempctrl
+streams (``tempctrl_lna`` and ``tempctrl_load``) and single-key
+commands that exercise every panda-side setter on
+:class:`picohost.base.PicoPeltier`. Operator confirms that the cold
+side temperature actually moves when the setpoint changes, that the
+firmware watchdog trips when the panda goes silent, and that the
+clamp limits drive saturation as expected.
+
+Controls:
+  l / L    enable LNA on / off
+  o / O    enable LOAD on / off
+  + / -    LNA setpoint +/- 0.5 deg C
+  ] / [    LOAD setpoint +/- 0.5 deg C
+  c        cycle clamp through (0.1, 0.3, 0.5, 1.0) on both channels
+  w        push a 5 s watchdog (should trip if not refreshed)
+  r        re-enable both channels at their last setpoint
+  q        quit
+
+Every command goes through :class:`picohost.proxy.PicoProxy` so
+behavior mirrors the production tempctrl_loop path. Setpoints and
+clamp values are tracked client-side so the +/- keys can bump them
+without round-tripping the firmware to read back the current value.
+"""
+
+from argparse import ArgumentParser
+import curses
+import logging
+
+from eigsep_redis import MetadataSnapshotReader
+from picohost.proxy import PicoProxy
+
+from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing.utils import configure_eig_logger
+
+
+configure_eig_logger(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+CLAMPS = (0.1, 0.3, 0.5, 1.0)
+SETPOINT_STEP_C = 0.5
+WATCHDOG_PROBE_MS = 5000
+
+
+class _State:
+    """Operator-facing state the script tracks locally.
+
+    Firmware is the source of truth for ``T_now`` / ``drive_level`` /
+    ``watchdog_tripped`` (read from snapshot). The local copies of
+    setpoints, enable flags, and the clamp index are only used so the
+    +/- keys can bump them — they're seeded from the snapshot on
+    startup if available, and re-pushed on every change so a missed
+    command can't leave the firmware and the UI disagreeing.
+    """
+
+    def __init__(self, lna_setpoint, load_setpoint, lna_enabled, load_enabled):
+        self.lna_setpoint = lna_setpoint
+        self.load_setpoint = load_setpoint
+        self.lna_enabled = lna_enabled
+        self.load_enabled = load_enabled
+        self.clamp_idx = 2  # default 0.5
+        self.last_message = ""
+
+
+def _snap(snapshot, name):
+    try:
+        return snapshot.get(name)
+    except KeyError:
+        return None
+
+
+def _seed_state(snapshot):
+    """Build a starting :class:`_State` from whatever the firmware reports.
+
+    Defaults if a field is missing or the channel hasn't published yet
+    are deliberately conservative: 20 deg C setpoint, channels off, so
+    the operator has to opt into actually driving the peltier.
+    """
+    lna = _snap(snapshot, "tempctrl_lna") or {}
+    load = _snap(snapshot, "tempctrl_load") or {}
+    return _State(
+        lna_setpoint=float(lna.get("T_target") or 20.0),
+        load_setpoint=float(load.get("T_target") or 20.0),
+        lna_enabled=bool(lna.get("enabled") or False),
+        load_enabled=bool(load.get("enabled") or False),
+    )
+
+
+def _send(proxy, action, **kwargs):
+    """Invoke a tempctrl command and return a short status string.
+
+    Returns "ok", a "skipped: ..." reason, or an error summary. Used as
+    the curses footer message so the operator sees per-keypress
+    feedback without having to scrape the log.
+    """
+    try:
+        result = proxy.send_command(action, **kwargs)
+    except (TimeoutError, RuntimeError) as exc:
+        return f"err {action}: {type(exc).__name__}: {exc}"
+    if result is None:
+        return f"skipped {action}: tempctrl unavailable"
+    return f"ok {action} {kwargs}"
+
+
+def _push_enables(proxy, state):
+    state.last_message = _send(
+        proxy,
+        "set_enable",
+        LNA=state.lna_enabled,
+        LOAD=state.load_enabled,
+    )
+
+
+def _push_temperatures(proxy, state):
+    state.last_message = _send(
+        proxy,
+        "set_temperature",
+        T_LNA=state.lna_setpoint,
+        T_LOAD=state.load_setpoint,
+    )
+
+
+def _push_clamp(proxy, state):
+    value = CLAMPS[state.clamp_idx]
+    state.last_message = _send(proxy, "set_clamp", LNA=value, LOAD=value)
+
+
+def _fmt(value, fmt):
+    if not isinstance(value, (int, float)):
+        return "    --"
+    return format(value, fmt)
+
+
+def _render(screen, snapshot, state):
+    lna = _snap(snapshot, "tempctrl_lna") or {}
+    load = _snap(snapshot, "tempctrl_load") or {}
+    screen.clear()
+    screen.addstr(0, 0, "=== tempctrl manual ===")
+    screen.addstr(
+        1, 0, "channel  T_now    T_target  drive   clamp   enabled  status"
+    )
+    screen.addstr(
+        2,
+        0,
+        "LNA      "
+        f"{_fmt(lna.get('T_now'), '6.2f')}  "
+        f"{_fmt(lna.get('T_target'), '6.2f')}    "
+        f"{_fmt(lna.get('drive_level'), '6.2f')}  "
+        f"{_fmt(lna.get('clamp'), '6.2f')}  "
+        f"{str(lna.get('enabled')):>7}  {lna.get('status')!r}",
+    )
+    screen.addstr(
+        3,
+        0,
+        "LOAD     "
+        f"{_fmt(load.get('T_now'), '6.2f')}  "
+        f"{_fmt(load.get('T_target'), '6.2f')}    "
+        f"{_fmt(load.get('drive_level'), '6.2f')}  "
+        f"{_fmt(load.get('clamp'), '6.2f')}  "
+        f"{str(load.get('enabled')):>7}  {load.get('status')!r}",
+    )
+    # watchdog_tripped is duplicated across both streams (see
+    # _PELTIER_SCHEMA) — read from either; LNA is fine.
+    screen.addstr(
+        5, 0, f"watchdog_tripped: {bool(lna.get('watchdog_tripped'))}"
+    )
+    screen.addstr(
+        6,
+        0,
+        f"client setpoints: LNA={state.lna_setpoint:.2f} "
+        f"LOAD={state.load_setpoint:.2f}  "
+        f"clamp={CLAMPS[state.clamp_idx]:.2f}",
+    )
+    screen.addstr(8, 0, "l/L enable LNA on/off       o/O enable LOAD on/off")
+    screen.addstr(9, 0, "+/- LNA setpoint  ][ LOAD setpoint  c cycle clamp")
+    screen.addstr(10, 0, "w push 5s watchdog   r re-enable both   q quit")
+    if state.last_message:
+        screen.addstr(12, 0, f"> {state.last_message}"[: curses.COLS - 1])
+    screen.refresh()
+
+
+def _handle_key(ch, proxy, state):
+    if ch in (ord("q"), 27):  # q or ESC
+        return False
+    if ch == ord("l"):
+        state.lna_enabled = True
+        _push_enables(proxy, state)
+    elif ch == ord("L"):
+        state.lna_enabled = False
+        _push_enables(proxy, state)
+    elif ch == ord("o"):
+        state.load_enabled = True
+        _push_enables(proxy, state)
+    elif ch == ord("O"):
+        state.load_enabled = False
+        _push_enables(proxy, state)
+    elif ch in (ord("+"), ord("=")):
+        state.lna_setpoint += SETPOINT_STEP_C
+        _push_temperatures(proxy, state)
+    elif ch == ord("-"):
+        state.lna_setpoint -= SETPOINT_STEP_C
+        _push_temperatures(proxy, state)
+    elif ch == ord("]"):
+        state.load_setpoint += SETPOINT_STEP_C
+        _push_temperatures(proxy, state)
+    elif ch == ord("["):
+        state.load_setpoint -= SETPOINT_STEP_C
+        _push_temperatures(proxy, state)
+    elif ch == ord("c"):
+        state.clamp_idx = (state.clamp_idx + 1) % len(CLAMPS)
+        _push_clamp(proxy, state)
+    elif ch == ord("w"):
+        state.last_message = _send(
+            proxy, "set_watchdog_timeout", timeout_ms=WATCHDOG_PROBE_MS
+        )
+    elif ch == ord("r"):
+        state.lna_enabled = True
+        state.load_enabled = True
+        _push_enables(proxy, state)
+        _push_temperatures(proxy, state)
+    return True
+
+
+def _curses_main(screen, transport, args):
+    curses.noecho()
+    screen.timeout(int(args.interval * 1000))
+    proxy = PicoProxy("tempctrl", transport, source="tempctrl_manual")
+    require_pico(proxy)
+    snapshot = MetadataSnapshotReader(transport)
+    state = _seed_state(snapshot)
+    while True:
+        _render(screen, snapshot, state)
+        ch = screen.getch()
+        if ch == -1:
+            # timeout — re-render so the readout stays live
+            continue
+        if not _handle_key(ch, proxy, state):
+            return
+
+
+def _parse_args():
+    parser = ArgumentParser(
+        description="Interactive tempctrl bring-up: drive setpoints and "
+        "exercise the firmware watchdog."
+    )
+    parser.add_argument(
+        "--dummy",
+        action="store_true",
+        help="Run against a fakeredis-backed DummyPandaClient",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.5,
+        help="Refresh interval in seconds (default: 0.5).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    transport = build_transport(args.dummy)
+    curses.wrapper(_curses_main, transport, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eigsep_observing/_scripts_util.py
+++ b/src/eigsep_observing/_scripts_util.py
@@ -1,0 +1,74 @@
+"""Shared helpers for the standalone manual test scripts under ``scripts/``.
+
+Two responsibilities, both deliberately small:
+
+- :func:`build_transport` mirrors the ``--dummy`` bootstrap used by
+  ``motor_manual.py`` / ``motor_control.py`` so every per-app manual
+  script can share one well-tested transport path.
+- :func:`require_pico` is a structural availability check the manual
+  scripts run before issuing any command, so an operator who forgot to
+  start ``pico-manager.service`` (or who flashed the wrong pico) gets a
+  one-line actionable error instead of a silent ``send_command`` no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from eigsep_redis import Transport
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_transport(
+    dummy: bool,
+    *,
+    host: str = "localhost",
+    real_port: int = 6379,
+    dummy_port: int = 6380,
+) -> Transport:
+    """Return a :class:`Transport` matching the manual-script convention.
+
+    Real mode just constructs a ``Transport(host, real_port)``.
+
+    Dummy mode constructs a transport against a separate fakeredis port
+    (``dummy_port``, conventionally 6380), resets the fakeredis state,
+    and attaches a fully-emulated ``DummyPandaClient`` to the transport
+    so every dummy pico (motor, rfswitch, tempctrl, potmon, imu_el,
+    imu_az, lidar) is registered and emitting status before the caller
+    starts issuing proxy commands. The client is stashed on
+    ``transport._dummy_client`` to keep it alive — without that
+    reference Python would garbage-collect the embedded PicoManager
+    threads and the proxy would see ``is_available=False``.
+    """
+    if dummy:
+        logger.warning("Running in DUMMY mode, no hardware will be used.")
+        from .testing import DummyPandaClient
+
+        transport = Transport(host=host, port=dummy_port)
+        transport.reset()
+        transport._dummy_client = DummyPandaClient(transport=transport)
+        return transport
+    return Transport(host=host, port=real_port)
+
+
+def require_pico(proxy, *, hint_script: str = "pico_preflight.py") -> None:
+    """Exit with a clear message if ``proxy``'s heartbeat is missing.
+
+    Manual scripts go through :class:`picohost.proxy.PicoProxy`, which
+    silently returns ``None`` from :meth:`send_command` when the
+    targeted pico's heartbeat is absent. That's the right behavior for
+    long-running observing loops, but a manual operator running a
+    bring-up script needs to know immediately that the pico-manager
+    service isn't reachable.
+    """
+    if proxy.is_available:
+        return
+    sys.stderr.write(
+        f"ERROR: pico {proxy.name!r} is not registered with PicoManager.\n"
+        f"  - Is pico-manager.service running on the panda?\n"
+        f"  - Was the pico flashed? Run scripts/{hint_script} to verify.\n"
+    )
+    raise SystemExit(2)

--- a/tests/test_scripts_util.py
+++ b/tests/test_scripts_util.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from eigsep_redis.testing import DummyTransport
 
 from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing.testing import DummyPandaClient
 
 
 class _FakeProxy:
@@ -65,43 +67,69 @@ def test_require_pico_custom_hint_script(capsys):
 def test_build_transport_real_uses_real_port():
     """Real mode should construct a plain Transport — no dummy plumbing.
 
-    Patch the constructor at the module level (where the helper looks
-    it up) so we can assert the args without needing a real Redis
-    server on the test box.
+    Substitute ``DummyTransport`` (a real working subclass of
+    ``Transport`` backed by fakeredis) for ``Transport`` at the import
+    site so the test exercises the real construction path without
+    needing a Redis server. The host/port end up on the returned
+    instance as ordinary attributes, which is what we verify.
     """
-
-    # Use a plain instance (not a Mock) as the return value. Mock
-    # auto-creates attributes on access, which makes hasattr(mock, X)
-    # always True and defeats the absence assertion below.
-    class _BareTransport:
-        pass
-
-    fake = _BareTransport()
     with patch(
-        "eigsep_observing._scripts_util.Transport", return_value=fake
-    ) as MockTransport:
+        "eigsep_observing._scripts_util.Transport", DummyTransport
+    ):
         result = build_transport(False, host="example.org", real_port=4321)
-    MockTransport.assert_called_once_with(host="example.org", port=4321)
-    assert result is fake
-    # Real mode must not attach a dummy client — that would mask a
-    # misconfigured production deployment.
-    assert not hasattr(result, "_dummy_client")
+    try:
+        assert isinstance(result, DummyTransport)
+        assert result.host == "example.org"
+        assert result.port == 4321
+        # Real mode must not attach a dummy client — that would mask a
+        # misconfigured production deployment.
+        assert not hasattr(result, "_dummy_client")
+    finally:
+        result.close()
 
 
 def test_build_transport_dummy_attaches_client_and_resets():
-    """Dummy mode must reset fakeredis and attach DummyPandaClient.
+    """Dummy mode must reset fakeredis and attach a real DummyPandaClient.
 
     The ``_dummy_client`` attribute is load-bearing — without it the
     embedded PicoManager threads would be garbage-collected and every
-    proxy on the transport would report ``is_available=False``.
+    proxy on the transport would report ``is_available=False``. Run
+    the real ``DummyPandaClient`` (not a Mock) so that contract is
+    actually exercised: the test fails loudly if the embedded manager
+    ever stops registering picos on construction.
+
+    ``Transport`` is substituted with a ``DummyTransport`` subclass
+    that records ``reset()`` calls — we can't observe reset from the
+    fakeredis end-state because ``DummyPandaClient`` immediately
+    repopulates the DB.
     """
-    with patch("eigsep_observing._scripts_util.Transport") as MockTransport:
-        transport = MockTransport.return_value
-        # Patch DummyPandaClient at its real import path; the helper
-        # imports it lazily so the patch target is the canonical name.
-        with patch("eigsep_observing.testing.DummyPandaClient") as MockClient:
-            result = build_transport(True, host="localhost", dummy_port=6380)
-    MockTransport.assert_called_once_with(host="localhost", port=6380)
-    transport.reset.assert_called_once()
-    MockClient.assert_called_once_with(transport=transport)
-    assert result._dummy_client is MockClient.return_value
+    reset_calls: list[tuple[str, int]] = []
+
+    class _SpyDummyTransport(DummyTransport):
+        def reset(self):
+            reset_calls.append((self.host, self.port))
+            super().reset()
+
+    with patch(
+        "eigsep_observing._scripts_util.Transport", _SpyDummyTransport
+    ):
+        result = build_transport(True, host="localhost", dummy_port=6380)
+    try:
+        assert isinstance(result, _SpyDummyTransport)
+        assert result.host == "localhost"
+        assert result.port == 6380
+        assert reset_calls == [("localhost", 6380)]
+        assert isinstance(result._dummy_client, DummyPandaClient)
+        # The embedded PicoManager must have registered its picos
+        # before build_transport returned — that's the whole reason
+        # the dummy client gets stashed on the transport. If this
+        # ever regresses, manual scripts would silently see
+        # ``is_available=False`` on every proxy.
+        registered = {
+            n.decode() if isinstance(n, bytes) else n
+            for n in result.r.smembers("picos")
+        }
+        assert "rfswitch" in registered
+    finally:
+        result._dummy_client.stop()
+        result.close()

--- a/tests/test_scripts_util.py
+++ b/tests/test_scripts_util.py
@@ -69,17 +69,23 @@ def test_build_transport_real_uses_real_port():
     it up) so we can assert the args without needing a real Redis
     server on the test box.
     """
-    with patch("eigsep_observing._scripts_util.Transport") as MockTransport:
-        instance = MockTransport.return_value
+
+    # Use a plain instance (not a Mock) as the return value. Mock
+    # auto-creates attributes on access, which makes hasattr(mock, X)
+    # always True and defeats the absence assertion below.
+    class _BareTransport:
+        pass
+
+    fake = _BareTransport()
+    with patch(
+        "eigsep_observing._scripts_util.Transport", return_value=fake
+    ) as MockTransport:
         result = build_transport(False, host="example.org", real_port=4321)
     MockTransport.assert_called_once_with(host="example.org", port=4321)
-    assert result is instance
+    assert result is fake
     # Real mode must not attach a dummy client — that would mask a
     # misconfigured production deployment.
-    assert (
-        not hasattr(instance, "_dummy_client")
-        or instance._dummy_client is MockTransport.return_value._dummy_client
-    )  # noqa: E501
+    assert not hasattr(result, "_dummy_client")
 
 
 def test_build_transport_dummy_attaches_client_and_resets():

--- a/tests/test_scripts_util.py
+++ b/tests/test_scripts_util.py
@@ -73,9 +73,7 @@ def test_build_transport_real_uses_real_port():
     needing a Redis server. The host/port end up on the returned
     instance as ordinary attributes, which is what we verify.
     """
-    with patch(
-        "eigsep_observing._scripts_util.Transport", DummyTransport
-    ):
+    with patch("eigsep_observing._scripts_util.Transport", DummyTransport):
         result = build_transport(False, host="example.org", real_port=4321)
     try:
         assert isinstance(result, DummyTransport)
@@ -110,9 +108,7 @@ def test_build_transport_dummy_attaches_client_and_resets():
             reset_calls.append((self.host, self.port))
             super().reset()
 
-    with patch(
-        "eigsep_observing._scripts_util.Transport", _SpyDummyTransport
-    ):
+    with patch("eigsep_observing._scripts_util.Transport", _SpyDummyTransport):
         result = build_transport(True, host="localhost", dummy_port=6380)
     try:
         assert isinstance(result, _SpyDummyTransport)

--- a/tests/test_scripts_util.py
+++ b/tests/test_scripts_util.py
@@ -1,0 +1,101 @@
+"""Tests for the shared manual-script helpers.
+
+The helpers are tiny but every manual test script under ``scripts/``
+imports them, so the tests guard the two contract surfaces that an
+operator running a manual script depends on:
+
+- ``build_transport`` constructs the right Transport for the mode and,
+  in dummy mode, leaves a fully-emulated ``DummyPandaClient`` attached
+  so proxies are immediately available.
+- ``require_pico`` exits with code 2 (not 1, not 0) on a missing pico
+  so a wrapper script can distinguish "pico unavailable" from other
+  exit conditions, and writes an actionable message to stderr.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from eigsep_observing._scripts_util import build_transport, require_pico
+
+
+class _FakeProxy:
+    """Minimal stand-in for picohost.proxy.PicoProxy.
+
+    Only ``name`` and ``is_available`` are read by ``require_pico``, so
+    the test fake exposes just those — using a real PicoProxy would
+    require a transport and a Redis stream, both of which are
+    orthogonal to what's being tested here.
+    """
+
+    def __init__(self, name, available):
+        self.name = name
+        self.is_available = available
+
+
+def test_require_pico_passes_when_available():
+    proxy = _FakeProxy("rfswitch", available=True)
+    assert require_pico(proxy) is None
+
+
+def test_require_pico_exits_when_unavailable(capsys):
+    proxy = _FakeProxy("rfswitch", available=False)
+    with pytest.raises(SystemExit) as excinfo:
+        require_pico(proxy)
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "rfswitch" in err
+    assert "pico-manager.service" in err
+    # The hint script defaults to pico_preflight so operators have one
+    # well-known command to run before re-trying.
+    assert "pico_preflight.py" in err
+
+
+def test_require_pico_custom_hint_script(capsys):
+    proxy = _FakeProxy("motor", available=False)
+    with pytest.raises(SystemExit):
+        require_pico(proxy, hint_script="some_other.py")
+    err = capsys.readouterr().err
+    assert "some_other.py" in err
+    assert "pico_preflight.py" not in err
+
+
+def test_build_transport_real_uses_real_port():
+    """Real mode should construct a plain Transport — no dummy plumbing.
+
+    Patch the constructor at the module level (where the helper looks
+    it up) so we can assert the args without needing a real Redis
+    server on the test box.
+    """
+    with patch("eigsep_observing._scripts_util.Transport") as MockTransport:
+        instance = MockTransport.return_value
+        result = build_transport(False, host="example.org", real_port=4321)
+    MockTransport.assert_called_once_with(host="example.org", port=4321)
+    assert result is instance
+    # Real mode must not attach a dummy client — that would mask a
+    # misconfigured production deployment.
+    assert (
+        not hasattr(instance, "_dummy_client")
+        or instance._dummy_client is MockTransport.return_value._dummy_client
+    )  # noqa: E501
+
+
+def test_build_transport_dummy_attaches_client_and_resets():
+    """Dummy mode must reset fakeredis and attach DummyPandaClient.
+
+    The ``_dummy_client`` attribute is load-bearing — without it the
+    embedded PicoManager threads would be garbage-collected and every
+    proxy on the transport would report ``is_available=False``.
+    """
+    with patch("eigsep_observing._scripts_util.Transport") as MockTransport:
+        transport = MockTransport.return_value
+        # Patch DummyPandaClient at its real import path; the helper
+        # imports it lazily so the patch target is the canonical name.
+        with patch("eigsep_observing.testing.DummyPandaClient") as MockClient:
+            result = build_transport(True, host="localhost", dummy_port=6380)
+    MockTransport.assert_called_once_with(host="localhost", port=6380)
+    transport.reset.assert_called_once()
+    MockClient.assert_called_once_with(transport=transport)
+    assert result._dummy_client is MockClient.return_value

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "eigsep-observing"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## Summary

Five standalone scripts modeled on `motor_manual.py` for verifying each pico-firmware app by hand once a fresh panda is wired up. All five share a new private `_scripts_util` helper that mirrors the established `--dummy` / `Transport` bootstrap convention.

- `scripts/rfswitch_manual.py` — REPL menu of `PicoRFSwitch.path_str` states, plus a cycle mode. Reads `sw_state_name` back from the snapshot after each switch so the operator can cross-check against the live-status tile.
- `scripts/lidar_manual.py` — pure display of `distance_m` with a horizontal bar and freshness age.
- `scripts/imu_manual.py` — pure display of `yaw`/`pitch`/`roll`/`accel` for `imu_el` and `imu_az` with a center-zero ASCII level bar. Import-time guard against `_IMU_SCHEMA` drift.
- `scripts/potmon_manual.py` — pure display of voltage + angle per axis. Calls out the picohost `calibrate_pot.py` workflow when angles are `None`.
- `scripts/tempctrl_manual.py` — curses UI exercising every `PicoPeltier` setter (enable, setpoint, clamp, watchdog) with live per-channel readouts.

Every command path routes through `picohost.proxy.PicoProxy` so behavior matches the production observing loops. New helper exports:
- `build_transport(dummy, ...)` — same `--dummy` bootstrap pattern as `motor_manual.py`.
- `require_pico(proxy, hint_script=...)` — exits with code 2 and an actionable stderr message when the targeted pico has no heartbeat.

## Test plan

- [x] `pytest tests/test_scripts_util.py` — 5 dedicated tests on the helper.
- [x] `ruff check` + `ruff format --check` clean on all new files.
- [x] `--help` invocation succeeds on each of the 5 scripts (imports + argparse).
- [x] Smoke-tested `rfswitch_manual`, `lidar_manual`, `imu_manual`, `potmon_manual` end-to-end in `--dummy` mode against a real `redis-server` on port 6380 — `DummyPandaClient`'s embedded emulators publish, the snapshot reads back, and (for `rfswitch`) the round-trip switch confirms metadata propagation.
- [ ] `tempctrl_manual.py` requires a real TTY for curses; verify by running locally with a fakeredis-server on 6380 and pressing each key.
- [ ] On-hardware bring-up: run each script against the actual panda + flashed picos to confirm the operator workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)