### PR TITLE
fix(scripts): stop standalone scripts crashing without fakeredis on prod

### DIFF
--- a/scripts/motor_control.py
+++ b/scripts/motor_control.py
@@ -12,28 +12,15 @@ import logging
 import time
 
 import numpy as np
-from eigsep_redis import StatusWriter, Transport
+from eigsep_redis import StatusWriter
 
 from eigsep_observing import MotorClient
-from eigsep_observing.testing import DummyPandaClient  # noqa: F401 (for --dummy)
+from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
 configure_eig_logger(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def _build_transport(dummy):
-    if dummy:
-        logger.warning("Running in DUMMY mode, no hardware will be used.")
-        transport = Transport(host="localhost", port=6380)
-        transport.reset()
-        # Spin up an embedded PicoManager on the fake redis so
-        # PicoProxy finds the motor. Keep the client alive via the
-        # `_dummy_client` attribute so it isn't garbage-collected.
-        transport._dummy_client = DummyPandaClient(transport=transport)
-        return transport
-    return Transport(host="localhost", port=6379)
 
 
 def main(transport, args):
@@ -102,5 +89,5 @@ def _parse_args():
 
 if __name__ == "__main__":
     args = _parse_args()
-    transport = _build_transport(args.dummy)
+    transport = build_transport(args.dummy)
     main(transport, args)

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -17,25 +17,13 @@ from argparse import ArgumentParser
 import curses
 import logging
 
-from eigsep_redis import Transport
-
 from eigsep_observing import MotorZeroer
-from eigsep_observing.testing import DummyPandaClient  # noqa: F401
+from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
 configure_eig_logger(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def _build_transport(dummy):
-    if dummy:
-        logger.warning("Running in DUMMY mode, no hardware will be used.")
-        transport = Transport(host="localhost", port=6380)
-        transport.reset()
-        transport._dummy_client = DummyPandaClient(transport=transport)
-        return transport
-    return Transport(host="localhost", port=6379)
 
 
 def _render(screen, zeroer, deg):
@@ -104,5 +92,5 @@ def _parse_args():
 
 if __name__ == "__main__":
     args = _parse_args()
-    transport = _build_transport(args.dummy)
+    transport = build_transport(args.dummy)
     curses.wrapper(_curses_main, transport, args)

--- a/scripts/no_switch_observation.py
+++ b/scripts/no_switch_observation.py
@@ -28,7 +28,6 @@ from eigsep_redis import ConfigStore, StatusWriter, Transport
 from eigsep_observing import PandaClient
 from eigsep_observing.run_tag import clear as clear_run_tag
 from eigsep_observing.run_tag import publish as publish_run_tag
-from eigsep_observing.testing import DummyPandaClient
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 
 
@@ -54,6 +53,8 @@ def _build_client(transport, cfg, dummy):
     cfg["serialize_motion_and_switching"] = True
     ConfigStore(transport).upload(cfg)
     if dummy:
+        from eigsep_observing.testing import DummyPandaClient
+
         return DummyPandaClient(transport=transport, default_cfg=cfg)
     return PandaClient(transport)
 

--- a/scripts/vna_position_sweep.py
+++ b/scripts/vna_position_sweep.py
@@ -33,7 +33,6 @@ from eigsep_redis import ConfigStore, StatusWriter, Transport
 from eigsep_observing import PandaClient
 from eigsep_observing.run_tag import clear as clear_run_tag
 from eigsep_observing.run_tag import publish as publish_run_tag
-from eigsep_observing.testing import DummyPandaClient
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 
 
@@ -67,6 +66,8 @@ def _build_client(transport, cfg, dummy):
     cfg["serialize_motion_and_switching"] = True
     ConfigStore(transport).upload(cfg)
     if dummy:
+        from eigsep_observing.testing import DummyPandaClient
+
         return DummyPandaClient(transport=transport, default_cfg=cfg)
     return PandaClient(transport)
 


### PR DESCRIPTION
## Summary

Four standalone scripts under `scripts/` imported `eigsep_observing.testing` at module top, which transitively pulls in `fakeredis` via `eigsep_redis.testing.DummyTransport`. Production deploys don't install the `[dev]` extra, so all four crashed at import time before they could even check `--dummy` — gating motor zeroing, motor scans, and the two VNA characterization scripts.

- **motor_manual.py / motor_control.py**: switched to `eigsep_observing._scripts_util.build_transport`, the same lazy-import helper every other manual bring-up script (`imu_manual`, `lidar_manual`, `potmon_manual`, `rfswitch_manual`, `tempctrl_manual`) already uses. The motor pair had been left behind in that earlier migration.
- **no_switch_observation.py / vna_position_sweep.py**: couldn't reuse `build_transport` because they construct `DummyPandaClient` themselves in `_build_client` with a script-specific config (`use_motor=True`, `use_vna=True`, `serialize_motion_and_switching=True`). Using the shared helper would attach an extra default-configured `DummyPandaClient` on the same transport, putting two embedded `PicoManager`s on one redis. Moved just the `DummyPandaClient` import into the `dummy` branch of `_build_client` instead.

Net: in production (no `[dev]` extra), all four scripts now load and run in real mode; `--dummy` mode is unchanged.

## Test plan

- [x] `ruff check` + `ruff format --check` on all four files — clean
- [x] Simulated prod via `MetaPathFinder` blocking `fakeredis`: all four scripts import without pulling in `fakeredis` or `eigsep_observing.testing`
- [x] `pytest tests/test_motor_scripts.py` — 10 tests pass (covers all four scripts via `_load`)
- [ ] Smoke test on the panda in real mode (operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)