### PR TITLE
feat/live status pane redesign

### DIFF
--- a/src/eigsep_observing/live_status/static/css/dashboard.css
+++ b/src/eigsep_observing/live_status/static/css/dashboard.css
@@ -196,14 +196,15 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
   margin-top: 10px;
 }
 
-/* IMU card spans full width and lays its two streams side-by-side. */
-.imu-grid {
+/* Two-column sub-grid for wide cards that fan a single subsystem into
+   two halves (IMU el/az, Tempctrl LNA/LOAD, Motor az/el). */
+.two-col-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
 }
 
-.imu-col h3 {
+.col-block h3 {
   margin: 0 0 4px;
   font-size: 12px;
   color: var(--muted);

--- a/src/eigsep_observing/live_status/static/css/dashboard.css
+++ b/src/eigsep_observing/live_status/static/css/dashboard.css
@@ -165,3 +165,83 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
 
 .vna-status.stale { color: var(--warn); }
 .vna-status.error { color: var(--danger); }
+
+/* Per-sensor pane header: display name | status tile | age. Sits at
+   the top of every per-pico card (and inside each sub-block of cards
+   that fan out multiple streams, like IMU and Tempctrl). */
+.pane-status {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 0 6px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 6px;
+}
+
+.pane-status .name {
+  font-size: 13px;
+  color: var(--fg);
+  font-weight: 500;
+}
+
+.pane-status .age {
+  font-family: "JetBrains Mono", Consolas, monospace;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* Multi-stream cards (Tempctrl LNA/LOAD) stack sub-blocks vertically. */
+.stream-block + .stream-block {
+  margin-top: 10px;
+}
+
+/* IMU card spans full width and lays its two streams side-by-side. */
+.imu-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.imu-col h3 {
+  margin: 0 0 4px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+/* ADC sub-section inside the Correlation spectra card. Two-column
+   grid, 6 rows, sitting below plot-phase. */
+.adc-section {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.adc-section h3 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.adc-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 16px;
+  row-gap: 2px;
+}
+
+.adc-cell {
+  display: grid;
+  grid-template-columns: minmax(0, max-content) 1fr auto;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.adc-cell:last-child,
+.adc-cell:nth-last-child(2) {
+  border-bottom: none;
+}

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -106,6 +106,33 @@ function makeSpan(className, text, style) {
   return s;
 }
 
+// Per-sensor pane header row: display name | status tile | age.
+// Used at the top of every per-pico card (and per-stream sub-block).
+// Tile color is binary by status: an explicit "error" goes danger, any
+// other non-empty status goes ok, missing status renders unknown.
+// Per-field classify tags are reserved for the data tiles themselves
+// (today only tempctrl wires those; imu/motor/potmon/lidar have no
+// classify thresholds configured).
+function makePaneStatusHeader(displayName, entry) {
+  const row = document.createElement("div");
+  row.className = "pane-status";
+  const status = entry && entry.status;
+  let cls;
+  if (status === "error") cls = "danger";
+  else if (status) cls = "ok";
+  else cls = "unknown";
+  const ageStr =
+    entry && entry.age_s !== null && entry.age_s !== undefined
+      ? `${fmt(entry.age_s, 1)}s`
+      : "—";
+  row.append(
+    makeSpan("name", displayName),
+    makeSpan(tileClass(cls), status || "?"),
+    makeSpan("age", ageStr),
+  );
+  return row;
+}
+
 async function fetchJson(path) {
   const r = await fetch(path);
   if (!r.ok) throw new Error(`${path} -> ${r.status}`);
@@ -424,86 +451,202 @@ function updateHealth(h, fileData) {
 
 // ---- metadata + adc + tempctrl + rfswitch --------------------------
 
-function renderMetadataTiles(meta) {
-  const container = document.getElementById("metadata-tiles");
-  container.replaceChildren();
-  for (const sensor of Object.keys(meta).sort()) {
-    const entry = meta[sensor];
-    const row = document.createElement("div");
-    row.className = "metadata-row";
-    const classifyTag = Object.values(entry.classify || {})[0] || "unknown";
-    const tileCls = tileClass(
-      entry.status === "error" ? "danger" : classifyTag
-    );
-    const ageStr =
-      entry.age_s !== null && entry.age_s !== undefined
-        ? `${fmt(entry.age_s, 1)}s`
-        : "—";
-    row.append(
-      makeSpan("label", sensor),
-      makeSpan(tileCls, entry.status || "?"),
-      makeSpan("value", ageStr)
-    );
-    container.appendChild(row);
-  }
-}
-
+// Render the two tempctrl streams as separate sub-blocks (LNA, LOAD),
+// each with its own pane-status header and two data rows (now, drive).
 function renderTempctrlTiles(meta, classifiers) {
-  const container = document.getElementById("tempctrl-tiles");
-  container.replaceChildren();
   const channels = [
-    { label: "LNA", stream: "tempctrl_lna" },
-    { label: "LOAD", stream: "tempctrl_load" },
+    { label: "LNA", stream: "tempctrl_lna", containerId: "tempctrl-lna-block" },
+    { label: "LOAD", stream: "tempctrl_load", containerId: "tempctrl-load-block" },
   ];
-  let any = false;
-  for (const { label, stream } of channels) {
+  for (const { label, stream, containerId } of channels) {
+    const container = document.getElementById(containerId);
+    if (!container) continue;
+    container.replaceChildren();
     const entry = meta[stream];
-    if (!entry) continue;
-    any = true;
+    if (!entry) {
+      container.textContent = `no ${label.toLowerCase()} data`;
+      continue;
+    }
     const value = entry.value || {};
     const tClass = (entry.classify || {})[`${stream}.T_now`] || "unknown";
     const dClass = (entry.classify || {})[`${stream}.drive_level`] || "unknown";
-    const row = document.createElement("div");
-    row.className = "tempctrl-row";
-    row.append(
-      makeSpan("label", label),
+    container.appendChild(makePaneStatusHeader(label, entry));
+    const rowT = document.createElement("div");
+    rowT.className = "tempctrl-row";
+    rowT.append(
+      makeSpan("label", "now"),
       makeSpan(tileClass(tClass), `${fmt(value.T_now, 2)} C`),
-      makeSpan(tileClass(dClass), `drive ${fmt(value.drive_level, 2)}`)
+      makeSpan("value", ""),
     );
-    container.appendChild(row);
-  }
-  if (!any) {
-    container.textContent = "no tempctrl data";
+    container.appendChild(rowT);
+    const rowD = document.createElement("div");
+    rowD.className = "tempctrl-row";
+    rowD.append(
+      makeSpan("label", "drive"),
+      makeSpan(tileClass(dClass), `${fmt(value.drive_level, 2)}`),
+      makeSpan("value", ""),
+    );
+    container.appendChild(rowD);
   }
 }
 
-function renderAdcTiles(adc) {
-  const container = document.getElementById("adc-tiles");
+// ---- new per-pico renderers ----------------------------------------
+
+function renderImu(meta) {
+  const blocks = [
+    { id: "imu-el-block", stream: "imu_el", label: "IMU el" },
+    { id: "imu-az-block", stream: "imu_az", label: "IMU az" },
+  ];
+  for (const { id, stream, label } of blocks) {
+    const container = document.getElementById(id);
+    if (!container) continue;
+    container.replaceChildren();
+    const entry = meta[stream];
+    if (!entry) {
+      container.textContent = `no ${stream} data`;
+      continue;
+    }
+    const value = entry.value || {};
+    container.appendChild(makePaneStatusHeader(label, entry));
+    const rows = [
+      ["yaw", fmt(value.yaw, 2) + "°"],
+      ["pitch", fmt(value.pitch, 2) + "°"],
+      ["roll", fmt(value.roll, 2) + "°"],
+    ];
+    for (const [lab, txt] of rows) {
+      const row = document.createElement("div");
+      row.className = "metadata-row";
+      row.append(
+        makeSpan("label", lab),
+        makeSpan("value", txt, "grid-column: span 2;"),
+      );
+      container.appendChild(row);
+    }
+    const accelRow = document.createElement("div");
+    accelRow.className = "metadata-row";
+    const accelText = `${fmt(value.accel_x, 2)} / ${fmt(value.accel_y, 2)} / ${fmt(value.accel_z, 2)}`;
+    accelRow.append(
+      makeSpan("label", "accel"),
+      makeSpan("value", accelText, "grid-column: span 2;"),
+    );
+    container.appendChild(accelRow);
+  }
+}
+
+function renderMotor(meta) {
+  const container = document.getElementById("motor-block");
+  if (!container) return;
   container.replaceChildren();
-  if (!adc.per_input) return;
-  for (const entry of adc.per_input) {
+  const entry = meta["motor"];
+  if (!entry) {
+    container.textContent = "no motor data";
+    return;
+  }
+  const v = entry.value || {};
+  container.appendChild(makePaneStatusHeader("motor", entry));
+  const rows = [
+    ["az", `${fmt(v.az_pos, 1)} / ${fmt(v.az_target_pos, 1)}`],
+    ["el", `${fmt(v.el_pos, 1)} / ${fmt(v.el_target_pos, 1)}`],
+  ];
+  for (const [lab, txt] of rows) {
     const row = document.createElement("div");
-    row.className = "adc-row";
+    row.className = "metadata-row";
+    row.append(
+      makeSpan("label", lab),
+      makeSpan("value", txt, "grid-column: span 2;"),
+    );
+    container.appendChild(row);
+  }
+}
+
+function renderPotmon(meta) {
+  const container = document.getElementById("potmon-block");
+  if (!container) return;
+  container.replaceChildren();
+  const entry = meta["potmon"];
+  if (!entry) {
+    container.textContent = "no potmon data";
+    return;
+  }
+  const v = entry.value || {};
+  container.appendChild(makePaneStatusHeader("potmon", entry));
+  const rows = [
+    ["el", `${fmt(v.pot_el_angle, 2)}° (${fmt(v.pot_el_voltage, 3)} V)`],
+    ["az", `${fmt(v.pot_az_angle, 2)}° (${fmt(v.pot_az_voltage, 3)} V)`],
+  ];
+  for (const [lab, txt] of rows) {
+    const row = document.createElement("div");
+    row.className = "metadata-row";
+    row.append(
+      makeSpan("label", lab),
+      makeSpan("value", txt, "grid-column: span 2;"),
+    );
+    container.appendChild(row);
+  }
+}
+
+function renderLidar(meta) {
+  const container = document.getElementById("lidar-block");
+  if (!container) return;
+  container.replaceChildren();
+  const entry = meta["lidar"];
+  if (!entry) {
+    container.textContent = "no lidar data";
+    return;
+  }
+  const v = entry.value || {};
+  container.appendChild(makePaneStatusHeader("lidar", entry));
+  const row = document.createElement("div");
+  row.className = "metadata-row";
+  row.append(
+    makeSpan("label", "distance"),
+    makeSpan("value", `${fmt(v.distance_m, 2)} m`, "grid-column: span 2;"),
+  );
+  container.appendChild(row);
+}
+
+// ADC stats live as a sub-section of the corr-spectra card so the
+// clipping/RMS diagnostic sits right under the spectrum it describes.
+// Two-column grid, 12 cells (6 inputs x 2 cores).
+function renderAdcInCorr(adc) {
+  const container = document.getElementById("corr-adc-section");
+  if (!container) return;
+  container.replaceChildren();
+  const heading = document.createElement("h3");
+  heading.textContent = "ADC (clipping + RMS)";
+  container.appendChild(heading);
+  if (!adc || !adc.per_input) return;
+  const grid = document.createElement("div");
+  grid.className = "adc-grid";
+  for (const entry of adc.per_input) {
+    const cell = document.createElement("div");
+    cell.className = "adc-cell";
     const rmsStr = entry.rms !== null ? fmt(entry.rms, 1) : "—";
     const clipStr =
       entry.clip_frac !== null && entry.clip_frac !== undefined
         ? fmt(entry.clip_frac * 100, 2) + "%"
         : "—";
     const inputName = pickLabel(`in${entry.input}`, entry.label);
-    row.append(
+    cell.append(
       makeSpan("label", `${inputName}/c${entry.core}`),
       makeSpan("value", `rms ${rmsStr}`),
-      makeSpan("value", `clip ${clipStr}`)
+      makeSpan("value", `clip ${clipStr}`),
     );
-    container.appendChild(row);
+    grid.appendChild(cell);
   }
+  container.appendChild(grid);
 }
 
-function renderRfswitch(rf) {
+function renderRfswitch(rf, metaEntry) {
   const el = document.getElementById("rfswitch");
   el.replaceChildren();
+  if (metaEntry) {
+    el.appendChild(makePaneStatusHeader("rfswitch", metaEntry));
+  }
   if (!rf.state) {
-    el.textContent = "no switch data";
+    const empty = document.createElement("div");
+    empty.textContent = "no switch data";
+    el.appendChild(empty);
     return;
   }
   // on_schedule is tri-state: true = ok, false = warn, null = undefined
@@ -582,10 +725,13 @@ async function tick() {
     lastAdc = adc.data;
     updateHealth(health.data, file.data);
     updateCorr(corr.data);
-    renderMetadataTiles(metadata.data);
     renderTempctrlTiles(metadata.data, null);
-    renderAdcTiles(adc.data);
-    renderRfswitch(rfswitch.data);
+    renderImu(metadata.data);
+    renderMotor(metadata.data);
+    renderPotmon(metadata.data);
+    renderLidar(metadata.data);
+    renderRfswitch(rfswitch.data, metadata.data["rfswitch"]);
+    renderAdcInCorr(adc.data);
     renderStatusLog(status.data);
     updateVna(vna.data);
   } catch (e) {
@@ -600,7 +746,7 @@ function initWiringToggle() {
   cb.addEventListener("change", () => {
     setUseWiringLabels(cb.checked);
     if (lastCorr) updateCorr(lastCorr);
-    if (lastAdc) renderAdcTiles(lastAdc);
+    if (lastAdc) renderAdcInCorr(lastAdc);
   });
 }
 

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -480,7 +480,8 @@ function renderTempctrlTiles(meta) {
     appendValueRow(container, "active", boolText(value.active));
     const wdTripped = value.watchdog_tripped === true;
     const wdCls = wdTripped ? "danger" : (value.watchdog_tripped === false ? "ok" : "unknown");
-    appendTileRow(container, "watchdog", tileClass(wdCls), wdTripped ? "TRIPPED" : "ok");
+    const wdText = wdTripped ? "TRIPPED" : (value.watchdog_tripped === false ? "ok" : "—");
+    appendTileRow(container, "watchdog", tileClass(wdCls), wdText);
   }
 }
 

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -451,8 +451,10 @@ function updateHealth(h, fileData) {
 
 // ---- metadata + adc + tempctrl + rfswitch --------------------------
 
-// Render the two tempctrl streams as separate sub-blocks (LNA, LOAD),
-// each with its own pane-status header and two data rows (now, drive).
+// Render the two tempctrl streams (LNA, LOAD) into side-by-side
+// sub-blocks. Each block shows status/age, the live temperature vs
+// setpoint, the current drive level, the enable/active control flags,
+// and the watchdog fault flag.
 function renderTempctrlTiles(meta, classifiers) {
   const channels = [
     { label: "LNA", stream: "tempctrl_lna", containerId: "tempctrl-lna-block" },
@@ -471,23 +473,42 @@ function renderTempctrlTiles(meta, classifiers) {
     const tClass = (entry.classify || {})[`${stream}.T_now`] || "unknown";
     const dClass = (entry.classify || {})[`${stream}.drive_level`] || "unknown";
     container.appendChild(makePaneStatusHeader(label, entry));
-    const rowT = document.createElement("div");
-    rowT.className = "tempctrl-row";
-    rowT.append(
-      makeSpan("label", "now"),
-      makeSpan(tileClass(tClass), `${fmt(value.T_now, 2)} C`),
-      makeSpan("value", ""),
-    );
-    container.appendChild(rowT);
-    const rowD = document.createElement("div");
-    rowD.className = "tempctrl-row";
-    rowD.append(
-      makeSpan("label", "drive"),
-      makeSpan(tileClass(dClass), `${fmt(value.drive_level, 2)}`),
-      makeSpan("value", ""),
-    );
-    container.appendChild(rowD);
+    appendTileRow(container, "now", tileClass(tClass), `${fmt(value.T_now, 2)} C`);
+    appendValueRow(container, "set", `${fmt(value.T_target, 2)} C`);
+    appendTileRow(container, "drive", tileClass(dClass), fmt(value.drive_level, 2));
+    appendValueRow(container, "enabled", boolText(value.enabled));
+    appendValueRow(container, "active", boolText(value.active));
+    const wdTripped = value.watchdog_tripped === true;
+    const wdCls = wdTripped ? "danger" : (value.watchdog_tripped === false ? "ok" : "unknown");
+    appendTileRow(container, "watchdog", tileClass(wdCls), wdTripped ? "TRIPPED" : "ok");
   }
+}
+
+function boolText(v) {
+  if (v === true) return "yes";
+  if (v === false) return "no";
+  return "—";
+}
+
+function appendValueRow(container, label, text) {
+  const row = document.createElement("div");
+  row.className = "metadata-row";
+  row.append(
+    makeSpan("label", label),
+    makeSpan("value", text, "grid-column: span 2;"),
+  );
+  container.appendChild(row);
+}
+
+function appendTileRow(container, label, tileCls, text) {
+  const row = document.createElement("div");
+  row.className = "metadata-row";
+  row.append(
+    makeSpan("label", label),
+    makeSpan(tileCls, text),
+    makeSpan("value", ""),
+  );
+  container.appendChild(row);
 }
 
 // ---- new per-pico renderers ----------------------------------------
@@ -533,29 +554,27 @@ function renderImu(meta) {
   }
 }
 
+// Motor is a single stream that drives two axes (az, el). The status
+// and age are stream-wide, so the same entry feeds both column headers;
+// the column label (az / el) is what makes the split readable.
 function renderMotor(meta) {
-  const container = document.getElementById("motor-block");
-  if (!container) return;
-  container.replaceChildren();
   const entry = meta["motor"];
-  if (!entry) {
-    container.textContent = "no motor data";
-    return;
-  }
-  const v = entry.value || {};
-  container.appendChild(makePaneStatusHeader("motor", entry));
-  const rows = [
-    ["az", `${fmt(v.az_pos, 1)} / ${fmt(v.az_target_pos, 1)}`],
-    ["el", `${fmt(v.el_pos, 1)} / ${fmt(v.el_target_pos, 1)}`],
+  const axes = [
+    { label: "az", containerId: "motor-az-block", posKey: "az_pos", targetKey: "az_target_pos" },
+    { label: "el", containerId: "motor-el-block", posKey: "el_pos", targetKey: "el_target_pos" },
   ];
-  for (const [lab, txt] of rows) {
-    const row = document.createElement("div");
-    row.className = "metadata-row";
-    row.append(
-      makeSpan("label", lab),
-      makeSpan("value", txt, "grid-column: span 2;"),
-    );
-    container.appendChild(row);
+  for (const { label, containerId, posKey, targetKey } of axes) {
+    const container = document.getElementById(containerId);
+    if (!container) continue;
+    container.replaceChildren();
+    if (!entry) {
+      container.textContent = "no motor data";
+      continue;
+    }
+    const v = entry.value || {};
+    container.appendChild(makePaneStatusHeader(label, entry));
+    appendValueRow(container, "position", fmt(v[posKey], 1));
+    appendValueRow(container, "target", fmt(v[targetKey], 1));
   }
 }
 

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -455,7 +455,7 @@ function updateHealth(h, fileData) {
 // sub-blocks. Each block shows status/age, the live temperature vs
 // setpoint, the current drive level, the enable/active control flags,
 // and the watchdog fault flag.
-function renderTempctrlTiles(meta, classifiers) {
+function renderTempctrlTiles(meta) {
   const channels = [
     { label: "LNA", stream: "tempctrl_lna", containerId: "tempctrl-lna-block" },
     { label: "LOAD", stream: "tempctrl_load", containerId: "tempctrl-load-block" },

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -49,28 +49,33 @@
     <div id="plot-vna" class="plot"></div>
   </section>
 
-  <section class="card">
-    <h2>RF switch</h2>
-    <div id="rfswitch"></div>
-  </section>
-
-  <section class="card">
+  <section class="card wide">
     <h2>Tempctrl</h2>
-    <div id="tempctrl-lna-block" class="stream-block"></div>
-    <div id="tempctrl-load-block" class="stream-block"></div>
+    <div class="two-col-grid">
+      <div id="tempctrl-lna-block" class="col-block"></div>
+      <div id="tempctrl-load-block" class="col-block"></div>
+    </div>
   </section>
 
   <section class="card wide">
     <h2>IMU</h2>
-    <div class="imu-grid">
-      <div id="imu-el-block" class="imu-col"></div>
-      <div id="imu-az-block" class="imu-col"></div>
+    <div class="two-col-grid">
+      <div id="imu-el-block" class="col-block"></div>
+      <div id="imu-az-block" class="col-block"></div>
+    </div>
+  </section>
+
+  <section class="card wide">
+    <h2>Motor</h2>
+    <div class="two-col-grid">
+      <div id="motor-az-block" class="col-block"></div>
+      <div id="motor-el-block" class="col-block"></div>
     </div>
   </section>
 
   <section class="card">
-    <h2>Motor</h2>
-    <div id="motor-block"></div>
+    <h2>RF switch</h2>
+    <div id="rfswitch"></div>
   </section>
 
   <section class="card">

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -34,6 +34,7 @@
     <h2>Correlation spectra</h2>
     <div id="plot-mag" class="plot"></div>
     <div id="plot-phase" class="plot"></div>
+    <div id="corr-adc-section" class="adc-section"></div>
   </section>
 
   <section class="card wide">
@@ -54,18 +55,32 @@
   </section>
 
   <section class="card">
-    <h2>ADC (clipping + RMS)</h2>
-    <div id="adc-tiles"></div>
-  </section>
-
-  <section class="card">
     <h2>Tempctrl</h2>
-    <div id="tempctrl-tiles"></div>
+    <div id="tempctrl-lna-block" class="stream-block"></div>
+    <div id="tempctrl-load-block" class="stream-block"></div>
+  </section>
+
+  <section class="card wide">
+    <h2>IMU</h2>
+    <div class="imu-grid">
+      <div id="imu-el-block" class="imu-col"></div>
+      <div id="imu-az-block" class="imu-col"></div>
+    </div>
   </section>
 
   <section class="card">
-    <h2>Picos (status + age)</h2>
-    <div id="metadata-tiles"></div>
+    <h2>Motor</h2>
+    <div id="motor-block"></div>
+  </section>
+
+  <section class="card">
+    <h2>Potmon</h2>
+    <div id="potmon-block"></div>
+  </section>
+
+  <section class="card">
+    <h2>Lidar</h2>
+    <div id="lidar-block"></div>
   </section>
 
   <section class="card wide">


### PR DESCRIPTION
- **feat(live-status): per-hardware panes with status/age headers**
- **feat(live-status): widen tempctrl + motor; show tempctrl setpoint/watchdog**
