### PR TITLE
feat(tempctrl): surface peltier health (stall_tripped + preflight)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=3.3.0",
+  "picohost>=3.4.0",
   "eigsep-vna>=1.3",
   "eigsep_redis>=2.1",
 ]

--- a/scripts/pico_preflight.py
+++ b/scripts/pico_preflight.py
@@ -109,6 +109,13 @@ def _fmt_summary(name, reading):
         return ""
     fields = SUMMARY_FIELDS.get(name, ())
     parts = []
+    # Surface non-healthy status (firmware convention: "update" = ok,
+    # "error" = sensor read failure / fault) so a stuck-at-init reading
+    # like tempctrl_load T_now=0.00 is recognizable as a fault rather
+    # than a real value. Silent on healthy channels.
+    status = reading.get("status")
+    if status is not None and status != "update":
+        parts.append(f"status={status}")
     for k in fields:
         if k not in reading:
             continue

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -644,6 +644,9 @@ _PELTIER_SCHEMA = {
     "stall_tripped": bool,
     "hysteresis": float,
     "clamp": float,
+    "Kp": float,
+    "Ki": float,
+    "integral": float,
 }
 
 # `potmon` (potentiometer monitor): the producer is `PotMonEmulator` +

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -641,6 +641,7 @@ _PELTIER_SCHEMA = {
     "enabled": bool,
     "active": bool,
     "int_disabled": bool,
+    "stall_tripped": bool,
     "hysteresis": float,
     "clamp": float,
 }


### PR DESCRIPTION
## Summary
- Add \`stall_tripped: bool\` to \`_PELTIER_SCHEMA\` to match the new firmware field added in the companion pico-firmware PR (EIGSEP/pico-firmware#84).
- \`pico_preflight\`: prepend \`status=<value>\` to a sensor row whenever the firmware reports anything other than \`"update"\`. Today a sensor read failure surfaces as \`T_now=0.00\` — indistinguishable from a real measurement; this makes the fault visible without changing the reading layout.

Draft because the schema field requires the new firmware tick to actually exist — hold this until the pico-firmware PR merges and a release is cut.

## Test plan
- [ ] Run \`python scripts/pico_preflight.py\` against a bench Pico with LOAD disconnected — confirm row reads \`status=error T_now=0.00 ...\`
- [ ] Confirm healthy channels render unchanged (\`status\` field omitted)
- [ ] Schema validates against a firmware tick that includes \`stall_tripped\` (no MetadataValidator warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)