### PR TITLE
fix(scripts): silence console logs in repainting bring-up UIs

### DIFF
--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -24,7 +24,7 @@ from eigsep_observing.io import _IMU_SCHEMA
 from eigsep_observing.utils import configure_eig_logger
 
 
-configure_eig_logger(level=logging.INFO)
+configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
 # Field names this script renders. Asserting against the schema keeps

--- a/scripts/lidar_manual.py
+++ b/scripts/lidar_manual.py
@@ -20,7 +20,7 @@ from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
-configure_eig_logger(level=logging.INFO)
+configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
 BAR_WIDTH = 60

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -22,7 +22,7 @@ from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
-configure_eig_logger(level=logging.INFO)
+configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/potmon_manual.py
+++ b/scripts/potmon_manual.py
@@ -21,7 +21,7 @@ from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
-configure_eig_logger(level=logging.INFO)
+configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -35,7 +35,7 @@ from eigsep_observing._scripts_util import build_transport, require_pico
 from eigsep_observing.utils import configure_eig_logger
 
 
-configure_eig_logger(level=logging.INFO)
+configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
 CLAMPS = (0.1, 0.3, 0.5, 1.0)


### PR DESCRIPTION
## Summary
- Five interactive bring-up scripts (`tempctrl_manual`, `potmon_manual`, `motor_manual`, `imu_manual`, `lidar_manual`) called `configure_eig_logger(level=logging.INFO)` with the default `console=True`. The console `StreamHandler` writes to stderr, which interleaves with the curses / ANSI screen-clear repaint and corrupts the display (log lines flash too fast to read and clobber the pane in the process).
- Pass `console=False` so logs go only to `~/eigsep.log`. Operators who want a live log stream can `tail -f` it in another pane.
- `rfswitch_manual` is a command-prompt flow (no repainting), so it's left as-is — log interleaving there is cosmetic.

## Test plan
- [ ] Run `python scripts/tempctrl_manual.py --dummy` and confirm the pane no longer flashes; `~/eigsep.log` still receives entries.
- [ ] Same for `potmon_manual`, `motor_manual`, `imu_manual`, `lidar_manual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)