### PR TITLE
fix(motor_manual): recover integer step ladder from 0.1 floor

### DIFF
--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -147,6 +147,11 @@ class MotorZeroer:
         if key == "q":
             return deg_state, True, False
         if key == "+":
+            # Snap back to integer ladder when climbing out of the
+            # 0.1 fine-jog floor; otherwise "- - + +" leaves a 0.1
+            # offset baked in forever (1.1, 2.1, ...).
+            if deg_state < 1.0:
+                return 1.0, False, False
             return deg_state + 1, False, False
         if key == "-":
             return max(0.1, deg_state - 1), False, False

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -153,6 +153,16 @@ def test_handle_key_plus_minus_adjusts_step(client):
     assert deg == pytest.approx(0.1)
 
 
+def test_handle_key_plus_recovers_integer_steps_from_floor(client):
+    # After bottoming out at 0.1, "+" must snap back to a clean
+    # integer ladder instead of producing 1.1, 2.1, 3.1, ...
+    zeroer = _zeroer(client.transport)
+    deg, _, _ = zeroer.handle_key(ord("+"), 0.1)
+    assert deg == 1.0
+    deg, _, _ = zeroer.handle_key(ord("+"), deg)
+    assert deg == 2.0
+
+
 def test_handle_key_enter_zeroes(client):
     zeroer = _zeroer(client.transport)
     motor = client._manager.picos["motor"]


### PR DESCRIPTION
## Summary
- `motor_manual.py` jog step size hits a hard floor of 0.1 deg on `-`, but `+` then yielded 1.1, 2.1, 3.1, ... — no way to recover whole-degree steps.
- `MotorZeroer.handle_key` now snaps to 1.0 when `+` is pressed while below the floor, restoring a clean integer ladder.
- Per-motor step sizes intentionally left shared — operator confirmed the dual-motor coupling is acceptable.

## Test plan
- [x] `pytest tests/test_motor_zeroer.py` (13 passed)
- [x] New regression test `test_handle_key_plus_recovers_integer_steps_from_floor` covers 0.1 → 1.0 → 2.0
- [ ] Manual smoke on hardware: `-` to 0.1, then `+` returns to 1.0 in the curses UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)