### PR TITLE
feat(tempctrl): expose PI gains through TempCtrlClient

### DIFF
--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -14,6 +14,11 @@ Controls:
   + / -    LNA setpoint +/- 0.5 deg C
   ] / [    LOAD setpoint +/- 0.5 deg C
   c        cycle clamp through (0.1, 0.3, 0.5, 1.0) on both channels
+  g / G    LNA Kp +/- 0.05
+  h / H    LOAD Kp +/- 0.05
+  i / I    LNA Ki +/- 0.005
+  k / K    LOAD Ki +/- 0.005
+  z / Z    reset LNA / LOAD PI integrator
   w        push a 5 s watchdog (should trip if not refreshed)
   r        re-enable both channels at their last setpoint
   q        quit
@@ -40,6 +45,10 @@ logger = logging.getLogger(__name__)
 
 CLAMPS = (0.1, 0.3, 0.5, 1.0)
 SETPOINT_STEP_C = 0.5
+KP_STEP = 0.05
+KI_STEP = 0.005  # smaller — integral accumulates over many ticks
+DEFAULT_KP = 0.2  # firmware default, matches TempCtrlEmulator
+DEFAULT_KI = 0.0  # firmware default — opt-in via this script or yaml
 WATCHDOG_PROBE_MS = 5000
 
 
@@ -48,17 +57,31 @@ class _State:
 
     Firmware is the source of truth for ``T_now`` / ``drive_level`` /
     ``watchdog_tripped`` (read from snapshot). The local copies of
-    setpoints, enable flags, and the clamp index are only used so the
-    +/- keys can bump them — they're seeded from the snapshot on
-    startup if available, and re-pushed on every change so a missed
+    setpoints, enable flags, gains, and the clamp index are only used
+    so the bump keys can step them — they're seeded from the snapshot
+    on startup if available, and re-pushed on every change so a missed
     command can't leave the firmware and the UI disagreeing.
     """
 
-    def __init__(self, lna_setpoint, load_setpoint, lna_enabled, load_enabled):
+    def __init__(
+        self,
+        lna_setpoint,
+        load_setpoint,
+        lna_enabled,
+        load_enabled,
+        lna_Kp,
+        lna_Ki,
+        load_Kp,
+        load_Ki,
+    ):
         self.lna_setpoint = lna_setpoint
         self.load_setpoint = load_setpoint
         self.lna_enabled = lna_enabled
         self.load_enabled = load_enabled
+        self.lna_Kp = lna_Kp
+        self.lna_Ki = lna_Ki
+        self.load_Kp = load_Kp
+        self.load_Ki = load_Ki
         self.clamp_idx = 2  # default 0.5
         self.last_message = ""
 
@@ -78,11 +101,23 @@ def _seed_state(snapshot):
     load = _snap(snapshot, "tempctrl_load") or {}
     lna_t = lna.get("T_target")
     load_t = load.get("T_target")
+
+    def _f(d, k, default):
+        v = d.get(k)
+        return (
+            float(v)
+            if isinstance(v, (int, float)) and not isinstance(v, bool)
+            else default
+        )
     return _State(
         lna_setpoint=float(lna_t) if lna_t is not None else 20.0,
         load_setpoint=float(load_t) if load_t is not None else 20.0,
         lna_enabled=bool(lna.get("enabled") or False),
         load_enabled=bool(load.get("enabled") or False),
+        lna_Kp=_f(lna, "Kp", DEFAULT_KP),
+        lna_Ki=_f(lna, "Ki", DEFAULT_KI),
+        load_Kp=_f(load, "Kp", DEFAULT_KP),
+        load_Ki=_f(load, "Ki", DEFAULT_KI),
     )
 
 
@@ -125,6 +160,22 @@ def _push_clamp(proxy, state):
     state.last_message = _send(proxy, "set_clamp", LNA=value, LOAD=value)
 
 
+def _push_gains(proxy, state):
+    """Push all four gains. Mirrors `apply_settings`' partial-kwarg
+    pattern: the LNA/LOAD knobs are independent, but bundling the push
+    means one round-trip per keypress and matches what the operator
+    sees in the readout.
+    """
+    state.last_message = _send(
+        proxy,
+        "set_gains",
+        LNA_Kp=state.lna_Kp,
+        LNA_Ki=state.lna_Ki,
+        LOAD_Kp=state.load_Kp,
+        LOAD_Ki=state.load_Ki,
+    )
+
+
 def _fmt(value, fmt):
     if not isinstance(value, (int, float)):
         return "    --"
@@ -159,23 +210,51 @@ def _render(screen, snapshot, state):
         f"{_fmt(load.get('clamp'), '6.2f')}  "
         f"{str(load.get('enabled')):>7}  {load.get('status')!r}",
     )
+    # PI controller readout — Kp/Ki are config-set (last-write-wins
+    # cached in PicoPeltier._last_gains), `integral` is the firmware
+    # accumulator.
+    screen.addstr(5, 0, "channel   Kp     Ki      integral")
+    screen.addstr(
+        6,
+        0,
+        "LNA      "
+        f"{_fmt(lna.get('Kp'), '6.3f')}  "
+        f"{_fmt(lna.get('Ki'), '6.3f')}  "
+        f"{_fmt(lna.get('integral'), '8.3f')}",
+    )
+    screen.addstr(
+        7,
+        0,
+        "LOAD     "
+        f"{_fmt(load.get('Kp'), '6.3f')}  "
+        f"{_fmt(load.get('Ki'), '6.3f')}  "
+        f"{_fmt(load.get('integral'), '8.3f')}",
+    )
     # watchdog_tripped is duplicated across both streams (see
     # _PELTIER_SCHEMA) — read from either; LNA is fine.
     screen.addstr(
-        5, 0, f"watchdog_tripped: {bool(lna.get('watchdog_tripped'))}"
+        9, 0, f"watchdog_tripped: {bool(lna.get('watchdog_tripped'))}"
     )
     screen.addstr(
-        6,
+        10,
         0,
         f"client setpoints: LNA={state.lna_setpoint:.2f} "
         f"LOAD={state.load_setpoint:.2f}  "
         f"clamp={CLAMPS[state.clamp_idx]:.2f}",
     )
-    screen.addstr(8, 0, "l/L enable LNA on/off       o/O enable LOAD on/off")
-    screen.addstr(9, 0, "+/- LNA setpoint  ][ LOAD setpoint  c cycle clamp")
-    screen.addstr(10, 0, "w push 5s watchdog   r re-enable both   q quit")
+    screen.addstr(
+        11,
+        0,
+        f"client gains: LNA(Kp={state.lna_Kp:.3f}, Ki={state.lna_Ki:.3f})  "
+        f"LOAD(Kp={state.load_Kp:.3f}, Ki={state.load_Ki:.3f})",
+    )
+    screen.addstr(13, 0, "l/L enable LNA on/off       o/O enable LOAD on/off")
+    screen.addstr(14, 0, "+/- LNA setpoint  ][ LOAD setpoint  c cycle clamp")
+    screen.addstr(15, 0, "g/G LNA Kp  h/H LOAD Kp  i/I LNA Ki  k/K LOAD Ki")
+    screen.addstr(16, 0, "z/Z reset LNA/LOAD integral")
+    screen.addstr(17, 0, "w push 5s watchdog   r re-enable both   q quit")
     if state.last_message:
-        screen.addstr(12, 0, f"> {state.last_message}"[: curses.COLS - 1])
+        screen.addstr(19, 0, f"> {state.last_message}"[: curses.COLS - 1])
     screen.refresh()
 
 
@@ -209,6 +288,34 @@ def _handle_key(ch, proxy, state):
     elif ch == ord("c"):
         state.clamp_idx = (state.clamp_idx + 1) % len(CLAMPS)
         _push_clamp(proxy, state)
+    elif ch == ord("g"):
+        state.lna_Kp = max(0.0, state.lna_Kp + KP_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("G"):
+        state.lna_Kp = max(0.0, state.lna_Kp - KP_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("h"):
+        state.load_Kp = max(0.0, state.load_Kp + KP_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("H"):
+        state.load_Kp = max(0.0, state.load_Kp - KP_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("i"):
+        state.lna_Ki = max(0.0, state.lna_Ki + KI_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("I"):
+        state.lna_Ki = max(0.0, state.lna_Ki - KI_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("k"):
+        state.load_Ki = max(0.0, state.load_Ki + KI_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("K"):
+        state.load_Ki = max(0.0, state.load_Ki - KI_STEP)
+        _push_gains(proxy, state)
+    elif ch == ord("z"):
+        state.last_message = _send(proxy, "reset_integral", LNA=True)
+    elif ch == ord("Z"):
+        state.last_message = _send(proxy, "reset_integral", LOAD=True)
     elif ch == ord("w"):
         state.last_message = _send(
             proxy, "set_watchdog_timeout", timeout_ms=WATCHDOG_PROBE_MS

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -42,6 +42,7 @@ timer but no longer clear the trip flag.
 from argparse import ArgumentParser
 import curses
 import logging
+import time
 
 from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
@@ -60,6 +61,13 @@ KI_STEP = 0.005  # smaller — integral accumulates over many ticks
 DEFAULT_KP = 0.2  # firmware default, matches TempCtrlEmulator
 DEFAULT_KI = 0.0  # firmware default — opt-in via this script or yaml
 WATCHDOG_PROBE_MS = 5000
+# picohost STATUS_CADENCE_MS = 200; poll at the same cadence so we
+# wake on the next publish without busy-spinning.
+PICO_PUBLISH_INTERVAL_S = 0.2
+# Headroom over the 200 ms cadence: a healthy pico publishes within
+# one tick; 5 s of slack absorbs a slow PicoManager restart without
+# masking a stuck producer.
+SEED_TIMEOUT_S = 5.0
 
 
 class _State:
@@ -100,17 +108,56 @@ def _snap(snapshot, name):
     return snapshot.get().get(name)
 
 
-def _seed_state(snapshot):
-    """Build a starting :class:`_State` from whatever the firmware reports.
+def _seed_state(
+    snapshot,
+    *,
+    timeout_s=SEED_TIMEOUT_S,
+    poll_interval_s=PICO_PUBLISH_INTERVAL_S,
+):
+    """Block until firmware has published ``T_target`` on both
+    ``tempctrl_lna`` and ``tempctrl_load``, then build a starting
+    :class:`_State` from those values.
 
-    Defaults if a field is missing or the channel hasn't published yet
-    are deliberately conservative: 20 deg C setpoint, channels off, so
-    the operator has to opt into actually driving the peltier.
+    No hardcoded setpoint fallback — the pico's own ``T_target``
+    (firmware default 30 deg C until reconfigured) is the single
+    source of truth, so the UI can never disagree with what the
+    firmware is actually driving. ``enabled`` likewise comes from the
+    pico; missing ``Kp`` / ``Ki`` fall back to the firmware-side
+    defaults (``DEFAULT_KP`` / ``DEFAULT_KI``).
+
+    Raises
+    ------
+    SystemExit
+        ``T_target`` did not appear on one or both streams within
+        ``timeout_s``. ``require_pico`` passed first, so the proxy
+        heartbeat is live — that means the pico is registered but the
+        firmware tempctrl publisher hasn't pushed a status frame yet.
+        Usually a misflashed pico or a stuck producer thread.
     """
-    lna = _snap(snapshot, "tempctrl_lna") or {}
-    load = _snap(snapshot, "tempctrl_load") or {}
-    lna_t = lna.get("T_target")
-    load_t = load.get("T_target")
+    deadline = time.monotonic() + timeout_s
+    while True:
+        lna = _snap(snapshot, "tempctrl_lna") or {}
+        load = _snap(snapshot, "tempctrl_load") or {}
+        if (
+            lna.get("T_target") is not None
+            and load.get("T_target") is not None
+        ):
+            break
+        if time.monotonic() >= deadline:
+            missing = [
+                name
+                for name, d in (
+                    ("tempctrl_lna", lna),
+                    ("tempctrl_load", load),
+                )
+                if d.get("T_target") is None
+            ]
+            raise SystemExit(
+                f"ERROR: tempctrl pico is registered but did not publish "
+                f"T_target on {missing} within {timeout_s:.1f}s. "
+                f"Check pico-manager logs."
+            )
+        time.sleep(poll_interval_s)
 
     def _f(d, k, default):
         v = d.get(k)
@@ -119,9 +166,10 @@ def _seed_state(snapshot):
             if isinstance(v, (int, float)) and not isinstance(v, bool)
             else default
         )
+
     return _State(
-        lna_setpoint=float(lna_t) if lna_t is not None else 20.0,
-        load_setpoint=float(load_t) if load_t is not None else 20.0,
+        lna_setpoint=float(lna["T_target"]),
+        load_setpoint=float(load["T_target"]),
         lna_enabled=bool(lna.get("enabled") or False),
         load_enabled=bool(load.get("enabled") or False),
         lna_Kp=_f(lna, "Kp", DEFAULT_KP),

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -27,6 +27,16 @@ Every command goes through :class:`picohost.proxy.PicoProxy` so
 behavior mirrors the production tempctrl_loop path. Setpoints and
 clamp values are tracked client-side so the +/- keys can bump them
 without round-tripping the firmware to read back the current value.
+
+Trip clearing (picohost >= 3.4.0 / pico-firmware e0724e0): ``enabled``
+is host intent only — firmware never mutates it. Drive engages iff
+``enabled && !int_disabled && !stall_tripped && !watchdog_tripped``
+(shown as the ``armed`` column in the readout). The sticky trips
+``stall_tripped`` and ``watchdog_tripped`` are cleared by an explicit
+``*_enable=true`` rising edge from the host. From this UI that means
+``l`` (LNA on), ``o`` (LOAD on), or ``r`` (re-enable both) double as
+the operator's trip-clear ack — bare keepalives refresh the watchdog
+timer but no longer clear the trip flag.
 """
 
 from argparse import ArgumentParser
@@ -182,13 +192,34 @@ def _fmt(value, fmt):
     return format(value, fmt)
 
 
+def _armed(channel):
+    """Derive whether firmware drive is engaged for ``channel``.
+
+    Mirrors the firmware gate (picohost >= 3.4.0): drive engages iff
+    ``enabled && !int_disabled && !stall_tripped && !watchdog_tripped``.
+    Since ``enabled`` is now host intent only (firmware never clears
+    it on trip), this derived flag is what the operator actually wants
+    to read off the panel to confirm the channel is driving.
+    """
+    if not channel:
+        return None
+    return bool(
+        channel.get("enabled")
+        and not channel.get("int_disabled")
+        and not channel.get("stall_tripped")
+        and not channel.get("watchdog_tripped")
+    )
+
+
 def _render(screen, snapshot, state):
     lna = _snap(snapshot, "tempctrl_lna") or {}
     load = _snap(snapshot, "tempctrl_load") or {}
     screen.clear()
     screen.addstr(0, 0, "=== tempctrl manual ===")
     screen.addstr(
-        1, 0, "channel  T_now    T_target  drive   clamp   enabled  status"
+        1,
+        0,
+        "channel  T_now    T_target  drive   clamp   enabled  armed  status",
     )
     screen.addstr(
         2,
@@ -198,7 +229,8 @@ def _render(screen, snapshot, state):
         f"{_fmt(lna.get('T_target'), '6.2f')}    "
         f"{_fmt(lna.get('drive_level'), '6.2f')}  "
         f"{_fmt(lna.get('clamp'), '6.2f')}  "
-        f"{str(lna.get('enabled')):>7}  {lna.get('status')!r}",
+        f"{str(lna.get('enabled')):>7}  "
+        f"{str(_armed(lna)):>5}  {lna.get('status')!r}",
     )
     screen.addstr(
         3,
@@ -208,19 +240,22 @@ def _render(screen, snapshot, state):
         f"{_fmt(load.get('T_target'), '6.2f')}    "
         f"{_fmt(load.get('drive_level'), '6.2f')}  "
         f"{_fmt(load.get('clamp'), '6.2f')}  "
-        f"{str(load.get('enabled')):>7}  {load.get('status')!r}",
+        f"{str(load.get('enabled')):>7}  "
+        f"{str(_armed(load)):>5}  {load.get('status')!r}",
     )
     # PI controller readout — Kp/Ki are config-set (last-write-wins
     # cached in PicoPeltier._last_gains), `integral` is the firmware
-    # accumulator.
-    screen.addstr(5, 0, "channel   Kp     Ki      integral")
+    # accumulator. `stall_tripped` is per-channel and sticky; clear it
+    # with an `l on` / `o on` (or `r`) rising-edge ack.
+    screen.addstr(5, 0, "channel   Kp     Ki      integral  stall_tripped")
     screen.addstr(
         6,
         0,
         "LNA      "
         f"{_fmt(lna.get('Kp'), '6.3f')}  "
         f"{_fmt(lna.get('Ki'), '6.3f')}  "
-        f"{_fmt(lna.get('integral'), '8.3f')}",
+        f"{_fmt(lna.get('integral'), '8.3f')}  "
+        f"{str(lna.get('stall_tripped')):>13}",
     )
     screen.addstr(
         7,
@@ -228,7 +263,8 @@ def _render(screen, snapshot, state):
         "LOAD     "
         f"{_fmt(load.get('Kp'), '6.3f')}  "
         f"{_fmt(load.get('Ki'), '6.3f')}  "
-        f"{_fmt(load.get('integral'), '8.3f')}",
+        f"{_fmt(load.get('integral'), '8.3f')}  "
+        f"{str(load.get('stall_tripped')):>13}",
     )
     # watchdog_tripped is duplicated across both streams (see
     # _PELTIER_SCHEMA) — read from either; LNA is fine.

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -50,8 +50,15 @@ tempctrl_settings:
     target_C: 25.0
     hysteresis_C: 0.5
     clamp: 0.6
+    # PI gains — omit to keep firmware defaults (Kp=0.2, Ki=0.0).
+    # Ki=0 ships pico-firmware PR #88 as a pure discontinuity fix; opt in to
+    # integral action by uncommenting and tuning per-channel.
+    # Kp: 0.2
+    # Ki: 0.0
   LOAD:
     enable: true
     target_C: 25.0
     hysteresis_C: 0.5
     clamp: 0.6
+    # Kp: 0.2
+    # Ki: 0.0

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -108,6 +108,41 @@ SIGNAL_REGISTRY: dict[str, Signal] = {
         "LOAD drive level",
         enabled_by="use_tempctrl",
     ),
+    # PI controller diagnostics. Threshold-less — Kp/Ki are config and
+    # `integral` is unbounded by design (anti-windup clamps it at the
+    # saturation boundary). Surfaced so the operator can confirm tuned
+    # gains landed and watch the integrator settle after a setpoint
+    # step or a `reset_integral` command.
+    "tempctrl_lna.Kp": Signal(
+        "tempctrl_lna.Kp",
+        "LNA Kp",
+        enabled_by="use_tempctrl",
+    ),
+    "tempctrl_load.Kp": Signal(
+        "tempctrl_load.Kp",
+        "LOAD Kp",
+        enabled_by="use_tempctrl",
+    ),
+    "tempctrl_lna.Ki": Signal(
+        "tempctrl_lna.Ki",
+        "LNA Ki",
+        enabled_by="use_tempctrl",
+    ),
+    "tempctrl_load.Ki": Signal(
+        "tempctrl_load.Ki",
+        "LOAD Ki",
+        enabled_by="use_tempctrl",
+    ),
+    "tempctrl_lna.integral": Signal(
+        "tempctrl_lna.integral",
+        "LNA integral",
+        enabled_by="use_tempctrl",
+    ),
+    "tempctrl_load.integral": Signal(
+        "tempctrl_load.integral",
+        "LOAD integral",
+        enabled_by="use_tempctrl",
+    ),
     # Site-geometry signals — YAML override only (TODO after deploy).
     "lidar.distance_m": Signal(
         "lidar.distance_m",

--- a/src/eigsep_observing/tempctrl_client.py
+++ b/src/eigsep_observing/tempctrl_client.py
@@ -34,6 +34,8 @@ class TempCtrlClient:
                     "target_C": float,
                     "hysteresis_C": float,
                     "clamp": float,
+                    "Kp": float,   # optional; firmware default 0.2
+                    "Ki": float,   # optional; firmware default 0.0
                 },
                 "LOAD": {... same keys as LNA ...},
             }
@@ -43,7 +45,10 @@ class TempCtrlClient:
         override." The yaml schema is kept readable (``target_C``,
         ``hysteresis_C``) and translated to firmware field names
         (``LNA_temp_target``, ``LNA_hysteresis``, ...) inside
-        :meth:`apply_settings`.
+        :meth:`apply_settings`. ``Kp`` and ``Ki`` are firmware-side
+        field names already and are forwarded unchanged via
+        :meth:`set_gains`. Omitting either gain leaves the firmware
+        default in place (``Kp=0.2``, ``Ki=0.0``).
     source : str
         Identifier stamped on proxy command stream entries.
     """
@@ -104,7 +109,7 @@ class TempCtrlClient:
                     f"{type(section).__name__}"
                 )
             coerced = {}
-            for fname in ("target_C", "hysteresis_C", "clamp"):
+            for fname in ("target_C", "hysteresis_C", "clamp", "Kp", "Ki"):
                 if fname in section:
                     val = section[fname]
                     try:
@@ -178,6 +183,45 @@ class TempCtrlClient:
         if kwargs:
             self._proxy.send_command("set_clamp", **kwargs)
 
+    def set_gains(
+        self, *, LNA_Kp=None, LNA_Ki=None, LOAD_Kp=None, LOAD_Ki=None
+    ):
+        """Set PI gains per channel.
+
+        Mirrors :meth:`picohost.base.PicoPeltier.set_gains`. Only the
+        kwargs that are not ``None`` are forwarded, so partial
+        application (e.g. tuning ``LNA_Ki`` while leaving everything
+        else alone) does not disturb other gains. Firmware caches the
+        last gains for replay on reconnect, so this method does not
+        need its own re-push loop.
+        """
+        kwargs = {}
+        if LNA_Kp is not None:
+            kwargs["LNA_Kp"] = float(LNA_Kp)
+        if LNA_Ki is not None:
+            kwargs["LNA_Ki"] = float(LNA_Ki)
+        if LOAD_Kp is not None:
+            kwargs["LOAD_Kp"] = float(LOAD_Kp)
+        if LOAD_Ki is not None:
+            kwargs["LOAD_Ki"] = float(LOAD_Ki)
+        if kwargs:
+            self._proxy.send_command("set_gains", **kwargs)
+
+    def reset_integral(self, *, LNA=False, LOAD=False):
+        """Clear the PI integrator on the selected channel(s).
+
+        One-shot. No-op if both channels are ``False`` so a
+        partial-application caller doesn't reset the wrong channel.
+        Operator-driven (e.g. after a large setpoint step that
+        accumulated integral that's no longer relevant); the steady
+        state controller does its own anti-windup.
+        """
+        if not LNA and not LOAD:
+            return
+        self._proxy.send_command(
+            "reset_integral", LNA=bool(LNA), LOAD=bool(LOAD)
+        )
+
     def set_temperature(
         self, *, T_LNA=None, LNA_hyst=None, T_LOAD=None, LOAD_hyst=None
     ):
@@ -225,22 +269,27 @@ class TempCtrlClient:
     def apply_settings(self):
         """Push the full config to the pico in safe order.
 
-        Order:
+        Order matches ``PicoPeltier``'s reconnect replay
+        (watchdog → clamp → gains → temperature → enable):
 
         1. ``set_watchdog_timeout`` first so any subsequent
            delay-between-commands cannot trip a zero-timeout default.
         2. ``set_clamp`` — establish the duty-cycle ceiling before
            anything is armed.
-        3. ``set_temperature`` — publish the target (and hysteresis)
+        3. ``set_gains`` — tune the PI controller before the setpoint
+           is published, so the very first PI tick on the new target
+           uses the configured Kp/Ki rather than firmware defaults.
+        4. ``set_temperature`` — publish the target (and hysteresis)
            while still disarmed (or at prior arm state).
-        4. ``set_enable`` — arm last, so by the time the channel turns
-           on the clamp and setpoint are already in place.
+        5. ``set_enable`` — arm last, so by the time the channel turns
+           on the clamp, gains, and setpoint are already in place.
 
         Idempotent: calling repeatedly with unchanged settings is a
         no-op on the hardware side (firmware replaces current values
         with identical ones). Missing sections are skipped — e.g.
         omitting ``watchdog_timeout_ms`` leaves whatever the firmware
-        currently has.
+        currently has. Missing ``Kp``/``Ki`` likewise leaves the
+        firmware defaults in place.
 
         Raises
         ------
@@ -259,6 +308,12 @@ class TempCtrlClient:
         self.set_clamp(
             LNA=lna.get("clamp"),
             LOAD=load.get("clamp"),
+        )
+        self.set_gains(
+            LNA_Kp=lna.get("Kp"),
+            LNA_Ki=lna.get("Ki"),
+            LOAD_Kp=load.get("Kp"),
+            LOAD_Ki=load.get("Ki"),
         )
         self.set_temperature(
             T_LNA=lna.get("target_C"),

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -7,6 +7,7 @@ sent via :class:`TempCtrlClient` land with the right fields.
 """
 
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -20,12 +21,16 @@ SETTINGS = {
         "target_C": 27.5,
         "hysteresis_C": 0.3,
         "clamp": 0.5,
+        "Kp": 0.25,
+        "Ki": 0.01,
     },
     "LOAD": {
         "enable": True,
         "target_C": 22.0,
         "hysteresis_C": 0.4,
         "clamp": 0.7,
+        "Kp": 0.18,
+        "Ki": 0.02,
     },
 }
 
@@ -70,15 +75,21 @@ def test_apply_settings_pushes_all_fields(client):
             and em.load.T_target == pytest.approx(22.0)
             and em.lna.hysteresis == pytest.approx(0.3)
             and em.load.hysteresis == pytest.approx(0.4)
+            and em.lna.Kp == pytest.approx(0.25)
+            and em.lna.Ki == pytest.approx(0.01)
+            and em.load.Kp == pytest.approx(0.18)
+            and em.load.Ki == pytest.approx(0.02)
             and em.lna.enabled is True
             and em.load.enabled is True
         )
     ), (
         f"emulator state did not converge: watchdog={em.watchdog_timeout_ms}, "
         f"LNA(clamp={em.lna.clamp}, T_target={em.lna.T_target}, "
-        f"hyst={em.lna.hysteresis}, enabled={em.lna.enabled}), "
+        f"hyst={em.lna.hysteresis}, Kp={em.lna.Kp}, Ki={em.lna.Ki}, "
+        f"enabled={em.lna.enabled}), "
         f"LOAD(clamp={em.load.clamp}, T_target={em.load.T_target}, "
-        f"hyst={em.load.hysteresis}, enabled={em.load.enabled})"
+        f"hyst={em.load.hysteresis}, Kp={em.load.Kp}, Ki={em.load.Ki}, "
+        f"enabled={em.load.enabled})"
     )
 
 
@@ -161,6 +172,83 @@ def test_set_enable_uses_settings_for_unspecified_channel(client):
     )
 
 
+def test_set_gains_pushes_to_emulator(client):
+    """Full-kwargs set_gains lands on both channels."""
+    em = _emulator(client)
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.set_gains(LNA_Kp=0.3, LNA_Ki=0.02, LOAD_Kp=0.15, LOAD_Ki=0.005)
+    assert _wait_until(
+        lambda: (
+            em.lna.Kp == pytest.approx(0.3)
+            and em.lna.Ki == pytest.approx(0.02)
+            and em.load.Kp == pytest.approx(0.15)
+            and em.load.Ki == pytest.approx(0.005)
+        )
+    ), (
+        f"gains did not land: LNA(Kp={em.lna.Kp}, Ki={em.lna.Ki}), "
+        f"LOAD(Kp={em.load.Kp}, Ki={em.load.Ki})"
+    )
+
+
+def test_set_gains_partial_leaves_other_channel(client):
+    """Partial-kwargs set_gains touches only the named channel."""
+    em = _emulator(client)
+    load_Kp_before = em.load.Kp
+    load_Ki_before = em.load.Ki
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.set_gains(LNA_Kp=0.4, LNA_Ki=0.03)
+    assert _wait_until(
+        lambda: (
+            em.lna.Kp == pytest.approx(0.4)
+            and em.lna.Ki == pytest.approx(0.03)
+        )
+    )
+    assert em.load.Kp == pytest.approx(load_Kp_before)
+    assert em.load.Ki == pytest.approx(load_Ki_before)
+
+
+def test_set_gains_no_kwargs_is_no_op(client):
+    """``set_gains()`` with everything None must not send a command —
+    otherwise the proxy round-trip would fire for nothing."""
+    tc = TempCtrlClient(client.transport, settings={})
+    with patch.object(tc._proxy, "send_command") as send:
+        tc.set_gains()
+    send.assert_not_called()
+
+
+def test_reset_integral_clears_channel(client):
+    """``reset_integral(LNA=True)`` zeroes the LNA accumulator via the
+    emulator's reset hook. (LOAD-channel isolation is verified at the
+    proxy boundary in ``test_reset_integral_sends_per_channel_kwargs``;
+    the disabled-channel reset that the emulator runs every tick would
+    mask any direct LOAD-state assertion here.)"""
+    em = _emulator(client)
+    em.lna.integral = 1.234
+    tc = TempCtrlClient(client.transport, settings={})
+    tc.reset_integral(LNA=True)
+    assert _wait_until(lambda: em.lna.integral == pytest.approx(0.0))
+
+
+def test_reset_integral_sends_per_channel_kwargs(client):
+    """Spy on the proxy: ``reset_integral`` must forward exactly the
+    channel kwargs it was called with (so LOAD stays untouched on an
+    LNA-only reset)."""
+    tc = TempCtrlClient(client.transport, settings={})
+    with patch.object(tc._proxy, "send_command") as send:
+        tc.reset_integral(LNA=True)
+    send.assert_called_once_with("reset_integral", LNA=True, LOAD=False)
+
+
+def test_reset_integral_no_channels_is_no_op(client):
+    """Both channels False must skip the command — otherwise an
+    operator press with no channel selected would silently bounce
+    nothing across the proxy."""
+    tc = TempCtrlClient(client.transport, settings={})
+    with patch.object(tc._proxy, "send_command") as send:
+        tc.reset_integral()
+    send.assert_not_called()
+
+
 def test_set_watchdog_timeout(client):
     em = _emulator(client)
     tc = TempCtrlClient(client.transport, settings={})
@@ -214,6 +302,8 @@ def test_is_available_reflects_registration(client):
         # YAML `enable: "false"` parses as the truthy string "False";
         # bool(...) would silently arm the channel. Reject it loudly.
         ({"LNA": {"enable": "false"}}, "enable"),
+        ({"LNA": {"Kp": "tiny"}}, "Kp"),
+        ({"LOAD": {"Ki": [0.0, 0.1]}}, "Ki"),
     ],
 )
 def test_coerce_settings_raises_on_bad_config(bad_settings, needle):
@@ -231,7 +321,8 @@ def test_coerce_settings_none_returns_empty():
 
 def test_coerce_settings_normalizes_types():
     """Int literals in float fields are accepted and promoted to float;
-    bool ``enable`` is preserved as-is."""
+    bool ``enable`` is preserved as-is. Kp/Ki ride the same float-coerce
+    path as the other numeric fields."""
     out = TempCtrlClient._coerce_settings(
         {
             "watchdog_timeout_ms": 30000,
@@ -239,6 +330,8 @@ def test_coerce_settings_normalizes_types():
                 "enable": True,
                 "target_C": 25,  # int in a float field
                 "clamp": 1,
+                "Kp": 0,  # int in a float field
+                "Ki": 0,
             },
         }
     )
@@ -247,3 +340,7 @@ def test_coerce_settings_normalizes_types():
     assert out["LNA"]["target_C"] == 25.0
     assert isinstance(out["LNA"]["clamp"], float)
     assert out["LNA"]["enable"] is True
+    assert isinstance(out["LNA"]["Kp"], float)
+    assert out["LNA"]["Kp"] == 0.0
+    assert isinstance(out["LNA"]["Ki"], float)
+    assert out["LNA"]["Ki"] == 0.0

--- a/tests/test_tempctrl_manual.py
+++ b/tests/test_tempctrl_manual.py
@@ -1,0 +1,133 @@
+"""Tests for the seed-state polling helper in ``scripts/tempctrl_manual.py``.
+
+The script previously seeded the operator-facing setpoints with a
+hardcoded 20 deg C fallback whenever the firmware hadn't yet published
+``T_target``. That left the UI disagreeing with the firmware (firmware
+default 30 deg C) for the brief startup race. The new ``_seed_state``
+polls the snapshot until both ``tempctrl_lna`` and ``tempctrl_load``
+have published ``T_target``, then seeds from those values directly —
+the pico is the single source of truth.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from eigsep_redis import MetadataSnapshotReader, MetadataWriter
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(name):
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _publish(transport, *, lna=None, load=None):
+    """Minimal tempctrl_lna / tempctrl_load entries — only the fields
+    ``_seed_state`` reads. Other fields are absent on purpose so the
+    test fails loudly if the helper grows a dependency on them."""
+    writer = MetadataWriter(transport)
+    if lna is not None:
+        writer.add("tempctrl_lna", lna)
+    if load is not None:
+        writer.add("tempctrl_load", load)
+
+
+def test_seed_state_uses_firmware_t_target(transport):
+    """When both streams have published ``T_target``, the seed picks
+    those values up — no hardcoded fallback."""
+    mod = _load("tempctrl_manual")
+    _publish(
+        transport,
+        lna={
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
+            "T_target": 30.0,
+            "enabled": False,
+            "Kp": 0.25,
+            "Ki": 0.01,
+        },
+        load={
+            "sensor_name": "tempctrl_load",
+            "status": "update",
+            "T_target": 28.5,
+            "enabled": True,
+            "Kp": 0.18,
+            "Ki": 0.0,
+        },
+    )
+    snapshot = MetadataSnapshotReader(transport)
+    state = mod._seed_state(snapshot, timeout_s=1.0, poll_interval_s=0.01)
+    assert state.lna_setpoint == 30.0
+    assert state.load_setpoint == 28.5
+    assert state.lna_enabled is False
+    assert state.load_enabled is True
+    assert state.lna_Kp == 0.25
+    assert state.lna_Ki == 0.01
+    assert state.load_Kp == 0.18
+    assert state.load_Ki == 0.0
+
+
+def test_seed_state_falls_back_to_default_gains_only(transport):
+    """``T_target`` and ``enabled`` come from the pico; missing
+    ``Kp`` / ``Ki`` fall back to the firmware-side defaults."""
+    mod = _load("tempctrl_manual")
+    _publish(
+        transport,
+        lna={
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
+            "T_target": 30.0,
+        },
+        load={
+            "sensor_name": "tempctrl_load",
+            "status": "update",
+            "T_target": 30.0,
+        },
+    )
+    snapshot = MetadataSnapshotReader(transport)
+    state = mod._seed_state(snapshot, timeout_s=1.0, poll_interval_s=0.01)
+    assert state.lna_Kp == mod.DEFAULT_KP
+    assert state.lna_Ki == mod.DEFAULT_KI
+    assert state.load_Kp == mod.DEFAULT_KP
+    assert state.load_Ki == mod.DEFAULT_KI
+
+
+def test_seed_state_times_out_when_streams_silent(transport):
+    """If the pico is registered (``require_pico`` already passed) but
+    never publishes a ``T_target``, the seed exits with a SystemExit
+    message naming the silent streams — rather than papering over the
+    silence with a hardcoded default."""
+    mod = _load("tempctrl_manual")
+    snapshot = MetadataSnapshotReader(transport)
+    with pytest.raises(SystemExit) as exc:
+        mod._seed_state(snapshot, timeout_s=0.05, poll_interval_s=0.01)
+    msg = str(exc.value)
+    assert "tempctrl_lna" in msg
+    assert "tempctrl_load" in msg
+    assert "T_target" in msg
+
+
+def test_seed_state_times_out_when_one_stream_silent(transport):
+    """One stream silent is still a timeout — both must publish before
+    the UI is allowed to come up with consistent state."""
+    mod = _load("tempctrl_manual")
+    _publish(
+        transport,
+        lna={
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
+            "T_target": 30.0,
+        },
+    )
+    snapshot = MetadataSnapshotReader(transport)
+    with pytest.raises(SystemExit) as exc:
+        mod._seed_state(snapshot, timeout_s=0.05, poll_interval_s=0.01)
+    msg = str(exc.value)
+    assert "tempctrl_load" in msg
+    assert "tempctrl_lna" not in msg


### PR DESCRIPTION
## Summary

Panda-side surface for the PI controller landing in pico-firmware [PR #88](https://github.com/EIGSEP/pico-firmware/pull/88). Additive across every touch point — no behavior change until an operator opts into integral action.

- `TempCtrlClient.set_gains(LNA_Kp=, LNA_Ki=, LOAD_Kp=, LOAD_Ki=)` and `TempCtrlClient.reset_integral(LNA=, LOAD=)`, mirroring `picohost.base.PicoPeltier`.
- `_coerce_settings` accepts optional `Kp`/`Ki` floats per channel; omitting them keeps the firmware default (`Kp=0.2`, `Ki=0.0`) in place — so existing deployments inherit PR #88's discontinuity fix as a pure pre-image of the bang-bang law.
- `apply_settings` reorders to `watchdog → clamp → gains → temperature → enable`, matching `PicoPeltier`'s reconnect replay so the channel is fully tuned the instant it arms.
- `_PELTIER_SCHEMA` in `io.py` extended with `Kp`/`Ki`/`integral` (all float). The existing `_avg_sensor_values` float→mean reduction handles them correctly: Kp/Ki are config so mean is a no-op on agreement, `integral` averages across the integration window for a smoothed readout.
- `live_status/signals.py` adds six diagnostic signals (threshold-less by design — `integral` is unbounded by construction with anti-windup clamping at saturation).
- `scripts/tempctrl_manual.py` gains keybindings: `g/G h/H` for per-channel Kp ±0.05, `i/I k/K` for per-channel Ki ±0.005, `z/Z` to reset the LNA/LOAD integrator. Readout extended to show Kp/Ki/integral per channel.
- `dummy_config.yaml` shows the `Kp`/`Ki` knobs commented under each channel so operators see what's tunable.

## Why a draft

This PR depends on pico-firmware PR #88 shipping in a picohost release. `pyproject.toml` bumps `picohost>=3.3.0` → `picohost>=3.4.0` as the next minor release ought to capture PR #88. CI will fail on the pin bump until that release lands.

To undraft after PR #88 merges:
1. Confirm picohost release version (`3.4.0` is the placeholder — adjust if release-please cuts a different number).
2. Run `pytest -k tempctrl_client` locally to confirm the emulator surface still matches.
3. Mark ready for review.

## Test plan

Already exercised locally against pico-firmware [`origin/worktree-tempctrl-fixes`](https://github.com/EIGSEP/pico-firmware/tree/worktree-tempctrl-fixes) installed in-venv:

- [x] `pytest tests/test_tempctrl_client.py` — 26 passed (5 new tests: set_gains full/partial/no-op, reset_integral clear/per-channel-kwargs/no-op; existing apply_settings test extended to assert Kp/Ki land).
- [x] `pytest tests/test_io.py tests/test_client.py src/eigsep_observing/contract_tests/` — 172 passed (end-to-end metadata round-trip auto-picks up the three new schema fields because `_test_fixtures.tempctrl_post_handler_reading` composes the live `TempCtrlEmulator + _peltier_redis_handler`).
- [x] `pytest tests/test_live_status_*` — 108 passed (new signals enumerate cleanly without bands).
- [x] `ruff check` / `ruff format --check` clean on touched files.
- [ ] Hardware: with PI tuning (Ki>0) confirm steady-state temperature error trends to 0 and the integrator readout settles after a setpoint step.
- [ ] Hardware: `reset_integral` keybinding clears the on-screen `integral` field within one update tick.

## Related

- Project memory `project_tempctrl_pi_followup` flagged this as the eigsep_observing-side follow-on.
- Project memory `project_tempctrl_bang_bang_controller` documents the PSU current-cycling root cause that motivated the controller swap.