### PR TITLE
fix(logging): make configure_eig_logger(console=False) actually silence stderr

### DIFF
--- a/src/eigsep_observing/__init__.py
+++ b/src/eigsep_observing/__init__.py
@@ -15,7 +15,11 @@ try:
 except ImportError as e:
     import logging
 
-    logging.warning(
+    # Use a named logger (not the root convenience function) so the
+    # warning does NOT trigger logging.basicConfig() and silently
+    # install a stderr StreamHandler on the root logger — that would
+    # defeat configure_eig_logger(console=False) callers downstream.
+    logging.getLogger(__name__).warning(
         f"Could not import testing module: {e}, use pip install .[dev] to "
         "install the required dependencies for testing if needed."
     )

--- a/src/eigsep_observing/utils.py
+++ b/src/eigsep_observing/utils.py
@@ -178,22 +178,44 @@ def configure_eig_logger(
 
     logger = logging.getLogger()  # get the root logger
     logger.setLevel(level)
-    if not logger.hasHandlers():
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # Attach the rotating file handler if one isn't already in place.
+    # A pre-existing StreamHandler from a stray logging.basicConfig()
+    # call must not block the file handler — we still want logs on disk.
+    has_file_handler = any(
+        isinstance(h, RotatingFileHandler) for h in logger.handlers
+    )
+    if not has_file_handler:
         file_handler = RotatingFileHandler(
             log_file, maxBytes=max_bytes, backupCount=backup_count
         )
         file_handler.setLevel(level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
-        if console:
+
+    # Honor `console` actively: when False, strip any plain
+    # StreamHandlers (e.g. installed by logging.basicConfig()) so a
+    # repainting UI script can guarantee a clean stderr. When True,
+    # attach one only if none is already present so repeated calls
+    # don't double-log to the terminal.
+    stream_handlers = [
+        h
+        for h in logger.handlers
+        if type(h) is logging.StreamHandler  # exact: don't strip subclasses
+    ]
+    if console:
+        if not stream_handlers:
             console_handler = logging.StreamHandler()
             console_handler.setLevel(level)
             console_handler.setFormatter(formatter)
             logger.addHandler(console_handler)
+    else:
+        for h in stream_handlers:
+            logger.removeHandler(h)
     return logger
 
 

--- a/src/eigsep_observing/utils.py
+++ b/src/eigsep_observing/utils.py
@@ -186,16 +186,20 @@ def configure_eig_logger(
     # Attach the rotating file handler if one isn't already in place.
     # A pre-existing StreamHandler from a stray logging.basicConfig()
     # call must not block the file handler — we still want logs on disk.
-    has_file_handler = any(
-        isinstance(h, RotatingFileHandler) for h in logger.handlers
-    )
-    if not has_file_handler:
+    file_handlers = [
+        h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+    ]
+    if not file_handlers:
         file_handler = RotatingFileHandler(
             log_file, maxBytes=max_bytes, backupCount=backup_count
         )
         file_handler.setLevel(level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
+    else:
+        for h in file_handlers:
+            h.setLevel(level)
+            h.setFormatter(formatter)
 
     # Honor `console` actively: when False, strip any plain
     # StreamHandlers (e.g. installed by logging.basicConfig()) so a
@@ -213,6 +217,10 @@ def configure_eig_logger(
             console_handler.setLevel(level)
             console_handler.setFormatter(formatter)
             logger.addHandler(console_handler)
+        else:
+            for h in stream_handlers:
+                h.setLevel(level)
+                h.setFormatter(formatter)
     else:
         for h in stream_handlers:
             logger.removeHandler(h)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -478,3 +478,39 @@ class TestConfigureEigLogger:
             h for h in root.handlers if type(h) is logging.StreamHandler
         ]
         assert len(stream_handlers) == 1
+
+    def test_console_true_reconfigures_pre_existing_stream(self, tmp_path):
+        root = logging.getLogger()
+        root.handlers.clear()
+        leaked = logging.StreamHandler()
+        leaked.setLevel(logging.ERROR)
+        leaked.setFormatter(logging.Formatter("%(message)s"))
+        root.addHandler(leaked)
+        with patch("eigsep_observing.utils.Path.home", return_value=tmp_path):
+            configure_eig_logger(level=logging.DEBUG)
+        stream_handlers = [
+            h for h in root.handlers if type(h) is logging.StreamHandler
+        ]
+        assert stream_handlers == [leaked]
+        assert leaked.level == logging.DEBUG
+        assert leaked.formatter._fmt == (
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+
+    def test_existing_rotating_file_handler_is_reconfigured(self, tmp_path):
+        root = logging.getLogger()
+        root.handlers.clear()
+        target = tmp_path / "preexisting.log"
+        existing = RotatingFileHandler(target, maxBytes=1, backupCount=1)
+        existing.setLevel(logging.ERROR)
+        existing.setFormatter(logging.Formatter("%(message)s"))
+        root.addHandler(existing)
+        configure_eig_logger(level=logging.WARNING, console=False)
+        file_handlers = [
+            h for h in root.handlers if isinstance(h, RotatingFileHandler)
+        ]
+        assert file_handlers == [existing]
+        assert existing.level == logging.WARNING
+        assert existing.formatter._fmt == (
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -353,12 +353,10 @@ class TestConfigureEigLogger:
     """Test configure_eig_logger.
 
     pytest's logging plugin attaches a ``LogCaptureHandler`` to the
-    root logger right before each test body, so ``hasHandlers()``
-    always returns ``True`` from inside a test — which would
-    short-circuit ``configure_eig_logger``'s idempotency guard and
-    prevent our handlers from being added. Each test clears
-    ``root.handlers`` inline before calling, and the autouse fixture
-    restores the original handlers on teardown.
+    root logger right before each test body. Most tests want to
+    inspect the exact handler set after ``configure_eig_logger``, so
+    each test clears ``root.handlers`` inline first and the autouse
+    fixture restores the original handlers on teardown.
     """
 
     @pytest.fixture(autouse=True)
@@ -413,8 +411,9 @@ class TestConfigureEigLogger:
         assert not any(type(h) is logging.StreamHandler for h in handlers)
 
     def test_idempotent_no_duplicate_handlers(self, tmp_path):
-        """A second call must not stack handlers — we already guard on
-        ``hasHandlers``, this is the regression test."""
+        """A second call must not stack handlers. The function checks
+        for an existing ``RotatingFileHandler`` and an existing plain
+        ``StreamHandler`` separately and skips each if already present."""
         logging.getLogger().handlers.clear()
         with patch("eigsep_observing.utils.Path.home", return_value=tmp_path):
             configure_eig_logger()
@@ -446,3 +445,36 @@ class TestConfigureEigLogger:
             if isinstance(h, RotatingFileHandler)
         ]
         assert Path(file_handlers[0].baseFilename) == target
+
+    def test_console_false_strips_pre_existing_stream_handler(self, tmp_path):
+        """A stray ``StreamHandler`` (e.g. from a leaked
+        ``logging.basicConfig()`` call earlier in the import chain)
+        must be removed when ``console=False`` so the repainting UI
+        scripts get a clean stderr. Without this, ``console=False`` is
+        a silent no-op behind the ``hasHandlers`` guard."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        leaked = logging.StreamHandler()
+        root.addHandler(leaked)
+        assert root.hasHandlers()
+        with patch("eigsep_observing.utils.Path.home", return_value=tmp_path):
+            configure_eig_logger(console=False)
+        handlers = root.handlers
+        assert any(isinstance(h, RotatingFileHandler) for h in handlers)
+        assert not any(type(h) is logging.StreamHandler for h in handlers)
+
+    def test_console_true_does_not_duplicate_pre_existing_stream(
+        self, tmp_path
+    ):
+        """If a ``StreamHandler`` is already attached, ``console=True``
+        must not stack a second one. Pairs with the strip behavior so
+        the function is idempotent regardless of prior state."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.addHandler(logging.StreamHandler())
+        with patch("eigsep_observing.utils.Path.home", return_value=tmp_path):
+            configure_eig_logger()
+        stream_handlers = [
+            h for h in root.handlers if type(h) is logging.StreamHandler
+        ]
+        assert len(stream_handlers) == 1


### PR DESCRIPTION
The bring-up UI scripts (lidar_manual.py, imu_manual.py, etc.) call
configure_eig_logger(console=False) at module load to stop log lines
from corrupting their repainting ANSI/curses readouts. On installs
without the [dev] extras (e.g. the panda) that was a silent no-op:

1. eigsep_observing/__init__.py guards `from . import testing` with
   `logging.warning(...)`. That convenience function triggers
   logging.basicConfig() when root has no handlers, which installs a
   stderr StreamHandler before configure_eig_logger runs.
2. configure_eig_logger guarded its whole handler-setup block behind
   `if not logger.hasHandlers()` — so the leaked StreamHandler made
   the function a complete no-op, console=False included.

Fixes:
- Use a named logger (`logging.getLogger(__name__).warning(...)`) in
  the testing-import fallback so the warning still prints once via
  lastResort but does NOT attach a persistent handler to root.
- Rework configure_eig_logger to manage handlers per-type: attach the
  RotatingFileHandler if missing (regardless of other handlers), and
  actively strip any plain StreamHandler when console=False. console=True
  remains idempotent — it only attaches a StreamHandler if none is
  present, so repeated calls don't double-log.

Regression tests cover both the strip-on-false and no-duplicate-on-true
behavior. Existing idempotency tests still pass under the new mechanism.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
