### PR TITLE
feat(provenance): gate obs_config uploads + run_tag every driver

### DIFF
--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -19,6 +19,7 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader
 
+from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.io import _IMU_SCHEMA
 from eigsep_observing.utils import configure_eig_logger
@@ -131,15 +132,16 @@ def _parse_args():
 def main():
     args = _parse_args()
     transport = build_transport(args.dummy)
-    snapshot = MetadataSnapshotReader(transport)
-    if args.which == "both":
-        names = ["imu_el", "imu_az"]
-    else:
-        names = [f"imu_{args.which}"]
-    try:
-        _render_loop(snapshot, names, args.interval)
-    except KeyboardInterrupt:
-        print()
+    with run_tag.session(transport, "imu_manual"):
+        snapshot = MetadataSnapshotReader(transport)
+        if args.which == "both":
+            names = ["imu_el", "imu_az"]
+        else:
+            names = [f"imu_{args.which}"]
+        try:
+            _render_loop(snapshot, names, args.interval)
+        except KeyboardInterrupt:
+            print()
 
 
 if __name__ == "__main__":

--- a/scripts/lidar_manual.py
+++ b/scripts/lidar_manual.py
@@ -16,6 +16,7 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader
 
+from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
@@ -101,11 +102,12 @@ def _parse_args():
 def main():
     args = _parse_args()
     transport = build_transport(args.dummy)
-    snapshot = MetadataSnapshotReader(transport)
-    try:
-        _render_loop(snapshot, args.interval, args.max_range)
-    except KeyboardInterrupt:
-        print()
+    with run_tag.session(transport, "lidar_manual"):
+        snapshot = MetadataSnapshotReader(transport)
+        try:
+            _render_loop(snapshot, args.interval, args.max_range)
+        except KeyboardInterrupt:
+            print()
 
 
 if __name__ == "__main__":

--- a/scripts/monitor_meta.py
+++ b/scripts/monitor_meta.py
@@ -3,13 +3,21 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader, Transport
 
-transport = Transport("10.10.10.11")
-snapshot = MetadataSnapshotReader(transport)
+from eigsep_observing import run_tag
 
-while True:
-    try:
-        m = snapshot.get()
-        print(json.dumps(m, indent=2, sort_keys=False))
-        time.sleep(1.0)
-    except KeyboardInterrupt:
-        break
+
+def main():
+    transport = Transport("10.10.10.11")
+    snapshot = MetadataSnapshotReader(transport)
+    with run_tag.session(transport, "monitor_meta"):
+        while True:
+            try:
+                m = snapshot.get()
+                print(json.dumps(m, indent=2, sort_keys=False))
+                time.sleep(1.0)
+            except KeyboardInterrupt:
+                break
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/motor_control.py
+++ b/scripts/motor_control.py
@@ -14,7 +14,7 @@ import time
 import numpy as np
 from eigsep_redis import StatusWriter
 
-from eigsep_observing import MotorClient
+from eigsep_observing import MotorClient, run_tag
 from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
@@ -24,34 +24,35 @@ logger = logging.getLogger(__name__)
 
 
 def main(transport, args):
-    status = StatusWriter(transport)
-    motor = MotorClient(transport)
+    with run_tag.session(transport, "motor_control"):
+        status = StatusWriter(transport)
+        motor = MotorClient(transport)
 
-    started = time.monotonic()
-    status.send("motor_control started")
-    logger.info("motor_control started")
+        started = time.monotonic()
+        status.send("motor_control started")
+        logger.info("motor_control started")
 
-    try:
-        motor.set_delay()
-        motor.halt()
-        motor.scan(
-            az_range_deg=np.linspace(-180.0, 180.0, 10),
-            el_range_deg=np.linspace(-180.0, 180.0, 10),
-            el_first=args.el_first,
-            repeat_count=args.count,
-            pause_s=args.pause_s,
-            sleep_between=args.sleep_s,
-        )
-    except KeyboardInterrupt:
-        logger.info("Scan interrupted by user")
-    except (TimeoutError, RuntimeError) as exc:
-        logger.error("Motor scan aborted: %s", exc)
-    finally:
-        motor.halt()
-        elapsed = time.monotonic() - started
-        msg = f"motor_control ended (duration={elapsed:.1f}s)"
-        status.send(msg)
-        logger.info(msg)
+        try:
+            motor.set_delay()
+            motor.halt()
+            motor.scan(
+                az_range_deg=np.linspace(-180.0, 180.0, 10),
+                el_range_deg=np.linspace(-180.0, 180.0, 10),
+                el_first=args.el_first,
+                repeat_count=args.count,
+                pause_s=args.pause_s,
+                sleep_between=args.sleep_s,
+            )
+        except KeyboardInterrupt:
+            logger.info("Scan interrupted by user")
+        except (TimeoutError, RuntimeError) as exc:
+            logger.error("Motor scan aborted: %s", exc)
+        finally:
+            motor.halt()
+            elapsed = time.monotonic() - started
+            msg = f"motor_control ended (duration={elapsed:.1f}s)"
+            status.send(msg)
+            logger.info(msg)
 
 
 def _parse_args():

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -17,7 +17,7 @@ from argparse import ArgumentParser
 import curses
 import logging
 
-from eigsep_observing import MotorZeroer
+from eigsep_observing import MotorZeroer, run_tag
 from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
@@ -90,7 +90,12 @@ def _parse_args():
     return parser.parse_args()
 
 
-if __name__ == "__main__":
+def main():
     args = _parse_args()
     transport = build_transport(args.dummy)
-    curses.wrapper(_curses_main, transport, args)
+    with run_tag.session(transport, "motor_manual"):
+        curses.wrapper(_curses_main, transport, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/no_switch_observation.py
+++ b/scripts/no_switch_observation.py
@@ -25,9 +25,8 @@ import yaml
 
 from eigsep_redis import ConfigStore, StatusWriter, Transport
 
-from eigsep_observing import PandaClient
-from eigsep_observing.run_tag import clear as clear_run_tag
-from eigsep_observing.run_tag import publish as publish_run_tag
+from eigsep_observing import PandaClient, run_tag
+from eigsep_observing.obs_config_owner import publish_owner
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 
 
@@ -52,10 +51,11 @@ def _build_client(transport, cfg, dummy):
     cfg["use_switches"] = False
     cfg["serialize_motion_and_switching"] = True
     ConfigStore(transport).upload(cfg)
+    publish_owner(transport, "no_switch_observation")
     if dummy:
         from eigsep_observing.testing import DummyPandaClient
 
-        return DummyPandaClient(transport=transport, default_cfg=cfg)
+        return DummyPandaClient(transport=transport, cfg=cfg)
     return PandaClient(transport)
 
 
@@ -90,49 +90,55 @@ def main(transport, args):
     status = StatusWriter(transport)
     client = None
     try:
-        client = _build_client(transport, cfg, args.dummy)
-        if client.motor_client is None:
-            raise RuntimeError(
-                "Motor client not initialized; check motor pico registration."
-            )
-        if client.vna is None:
-            raise RuntimeError("VNA not initialized; check vna config block.")
+        with run_tag.session(transport, "no_switch_observation"):
+            client = _build_client(transport, cfg, args.dummy)
+            if client.motor_client is None:
+                raise RuntimeError(
+                    "Motor client not initialized; check motor pico "
+                    "registration."
+                )
+            if client.vna is None:
+                raise RuntimeError(
+                    "VNA not initialized; check vna config block."
+                )
 
-        publish_run_tag(transport, "no_switch_observation")
-        status.send("no_switch_observation started")
-        logger.info("no_switch_observation started")
+            status.send("no_switch_observation started")
+            logger.info("no_switch_observation started")
 
-        client.motor_client.set_delay()
-        client.motor_client.halt()
-        client.motor_client.home()
+            client.motor_client.set_delay()
+            client.motor_client.halt()
+            client.motor_client.home()
 
-        if not _calibration(client, status, "pre-scan"):
-            return
+            if not _calibration(client, status, "pre-scan"):
+                return
 
-        # Pin RFANT for the duration of the scan. switch_session
-        # holds coord.switch_section() across the whole block;
-        # per-move motion_section calls re-acquire the same RLock
-        # from this thread, which is the load-bearing reason the
-        # underlying lock is an RLock and not a plain Lock.
-        with client.switch_session() as sw:
-            if not sw("RFANT"):
-                raise RuntimeError("Failed to pin rfswitch to RFANT for scan.")
-            status.send(
-                "no_switch_observation: rfswitch pinned RFANT, scanning"
-            )
-            logger.info("rfswitch pinned RFANT; starting scan")
-            client.motor_client.scan(
-                stop_event=client.stop_client, **scan_kwargs
-            )
+            # Pin RFANT for the duration of the scan. switch_session
+            # holds coord.switch_section() across the whole block;
+            # per-move motion_section calls re-acquire the same RLock
+            # from this thread, which is the load-bearing reason the
+            # underlying lock is an RLock and not a plain Lock.
+            with client.switch_session() as sw:
+                if not sw("RFANT"):
+                    raise RuntimeError(
+                        "Failed to pin rfswitch to RFANT for scan."
+                    )
+                status.send(
+                    "no_switch_observation: rfswitch pinned RFANT, scanning"
+                )
+                logger.info("rfswitch pinned RFANT; starting scan")
+                client.motor_client.scan(
+                    stop_event=client.stop_client, **scan_kwargs
+                )
 
-        client.motor_client.home()
+            client.motor_client.home()
 
-        if client.stop_client.is_set():
-            logger.warning(
-                "stop_client set after scan; skipping post-scan calibration"
-            )
-            return
-        _calibration(client, status, "post-scan")
+            if client.stop_client.is_set():
+                logger.warning(
+                    "stop_client set after scan; skipping post-scan "
+                    "calibration"
+                )
+                return
+            _calibration(client, status, "post-scan")
     except KeyboardInterrupt:
         logger.info("Observation interrupted by user")
     except (TimeoutError, RuntimeError) as exc:
@@ -146,7 +152,6 @@ def main(transport, args):
             if client.motor_client is not None:
                 client.motor_client.halt()
             client.stop()
-        clear_run_tag(transport)
         status.send("no_switch_observation ended")
         logger.info("no_switch_observation ended")
 

--- a/scripts/pico_preflight.py
+++ b/scripts/pico_preflight.py
@@ -30,6 +30,7 @@ import argparse
 import sys
 import time
 
+from eigsep_observing import run_tag
 from eigsep_observing.io import SENSOR_SCHEMAS
 from eigsep_redis import HeartbeatReader, MetadataSnapshotReader, Transport
 from picohost.buses import PicoConfigStore
@@ -207,22 +208,24 @@ def parse_args():
 def main():
     args = parse_args()
     transport = Transport(args.host)
-    if args.watch is None:
-        render(transport)
-        return 0
-    try:
-        while True:
-            # ANSI clear + home so the table redraws in place.
-            sys.stdout.write("\x1b[2J\x1b[H")
-            print(
-                f"pico_preflight @ {args.host}  ({time.strftime('%H:%M:%S')})"
-            )
-            print()
+    with run_tag.session(transport, "pico_preflight"):
+        if args.watch is None:
             render(transport)
-            sys.stdout.flush()
-            time.sleep(args.watch)
-    except KeyboardInterrupt:
-        return 0
+            return 0
+        try:
+            while True:
+                # ANSI clear + home so the table redraws in place.
+                sys.stdout.write("\x1b[2J\x1b[H")
+                print(
+                    f"pico_preflight @ {args.host}  "
+                    f"({time.strftime('%H:%M:%S')})"
+                )
+                print()
+                render(transport)
+                sys.stdout.flush()
+                time.sleep(args.watch)
+        except KeyboardInterrupt:
+            return 0
 
 
 if __name__ == "__main__":

--- a/scripts/potmon_manual.py
+++ b/scripts/potmon_manual.py
@@ -17,6 +17,7 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader
 
+from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.utils import configure_eig_logger
 
@@ -100,11 +101,12 @@ def _parse_args():
 def main():
     args = _parse_args()
     transport = build_transport(args.dummy)
-    snapshot = MetadataSnapshotReader(transport)
-    try:
-        _render_loop(snapshot, args.interval)
-    except KeyboardInterrupt:
-        print()
+    with run_tag.session(transport, "potmon_manual"):
+        snapshot = MetadataSnapshotReader(transport)
+        try:
+            _render_loop(snapshot, args.interval)
+        except KeyboardInterrupt:
+            print()
 
 
 if __name__ == "__main__":

--- a/scripts/rfswitch_manual.py
+++ b/scripts/rfswitch_manual.py
@@ -20,6 +20,7 @@ from eigsep_redis import MetadataSnapshotReader
 from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
+from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport, require_pico
 from eigsep_observing.utils import configure_eig_logger
 
@@ -135,13 +136,14 @@ def _parse_args():
 def main():
     args = _parse_args()
     transport = build_transport(args.dummy)
-    proxy = PicoProxy("rfswitch", transport, source="rfswitch_manual")
-    require_pico(proxy)
-    snapshot = MetadataSnapshotReader(transport)
-    try:
-        _repl(proxy, snapshot, args.cycle_dwell)
-    except KeyboardInterrupt:
-        print()
+    with run_tag.session(transport, "rfswitch_manual"):
+        proxy = PicoProxy("rfswitch", transport, source="rfswitch_manual")
+        require_pico(proxy)
+        snapshot = MetadataSnapshotReader(transport)
+        try:
+            _repl(proxy, snapshot, args.cycle_dwell)
+        except KeyboardInterrupt:
+            print()
 
 
 if __name__ == "__main__":

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -47,6 +47,7 @@ import time
 from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
 
+from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport, require_pico
 from eigsep_observing.utils import configure_eig_logger
 
@@ -451,7 +452,8 @@ def _parse_args():
 def main():
     args = _parse_args()
     transport = build_transport(args.dummy)
-    curses.wrapper(_curses_main, transport, args)
+    with run_tag.session(transport, "tempctrl_manual"):
+        curses.wrapper(_curses_main, transport, args)
 
 
 if __name__ == "__main__":

--- a/scripts/vna_manual.py
+++ b/scripts/vna_manual.py
@@ -25,10 +25,10 @@ from pathlib import Path
 import numpy as np
 import yaml
 
-from eigsep_redis import ConfigStore, Transport
+from eigsep_redis import Transport
 from picohost.proxy import PicoProxy
 
-from eigsep_observing import PandaClient
+from eigsep_observing import PandaClient, run_tag
 from eigsep_observing._scripts_util import require_pico
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 from eigsep_observing.vna import save_vna_manual_h5
@@ -48,18 +48,23 @@ def _build_transport(dummy):
 
 
 def _build_client(transport, cfg, dummy):
+    # Build a transient local cfg view: vna_manual is a bring-up tool,
+    # not an authorized uploader. Mutating the persistent Redis cfg
+    # would stamp these bring-up flags into corr-file overlays opened
+    # by ``eigsep-observe`` while this script runs, misrepresenting the
+    # rig's true operating intent. Pass cfg= directly so PandaClient
+    # uses it in-process without touching ConfigStore.
     cfg = dict(cfg)
     cfg["use_vna"] = True
     cfg["use_switches"] = False
     cfg["use_motor"] = False
     cfg["use_tempctrl"] = False
     cfg["serialize_motion_and_switching"] = False
-    ConfigStore(transport).upload(cfg)
     if dummy:
         from eigsep_observing.testing import DummyPandaClient
 
-        return DummyPandaClient(transport=transport, default_cfg=cfg)
-    return PandaClient(transport)
+        return DummyPandaClient(transport=transport, cfg=cfg)
+    return PandaClient(transport, cfg=cfg)
 
 
 def _summary_db(arr):
@@ -188,15 +193,18 @@ def main():
 
     transport = _build_transport(args.dummy)
 
-    client = _build_client(transport, cfg, args.dummy)
-    try:
-        require_pico(PicoProxy("rfswitch", transport, source="vna_manual"))
-        if client.vna is None:
-            raise SystemExit("VNA not initialized; check vna config block.")
-        _print_banner(cfg, args.save_dir)
-        _repl(client, args.save_dir)
-    finally:
-        client.stop()
+    with run_tag.session(transport, "vna_manual"):
+        client = _build_client(transport, cfg, args.dummy)
+        try:
+            require_pico(PicoProxy("rfswitch", transport, source="vna_manual"))
+            if client.vna is None:
+                raise SystemExit(
+                    "VNA not initialized; check vna config block."
+                )
+            _print_banner(cfg, args.save_dir)
+            _repl(client, args.save_dir)
+        finally:
+            client.stop()
 
 
 if __name__ == "__main__":

--- a/scripts/vna_position_sweep.py
+++ b/scripts/vna_position_sweep.py
@@ -30,9 +30,8 @@ import yaml
 
 from eigsep_redis import ConfigStore, StatusWriter, Transport
 
-from eigsep_observing import PandaClient
-from eigsep_observing.run_tag import clear as clear_run_tag
-from eigsep_observing.run_tag import publish as publish_run_tag
+from eigsep_observing import PandaClient, run_tag
+from eigsep_observing.obs_config_owner import publish_owner
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 
 
@@ -65,10 +64,11 @@ def _build_client(transport, cfg, dummy):
     cfg["use_tempctrl"] = cfg.get("use_tempctrl", False)
     cfg["serialize_motion_and_switching"] = True
     ConfigStore(transport).upload(cfg)
+    publish_owner(transport, "vna_position_sweep")
     if dummy:
         from eigsep_observing.testing import DummyPandaClient
 
-        return DummyPandaClient(transport=transport, default_cfg=cfg)
+        return DummyPandaClient(transport=transport, cfg=cfg)
     return PandaClient(transport)
 
 
@@ -104,42 +104,47 @@ def main(transport, args):
     status = StatusWriter(transport)
     client = None
     try:
-        client = _build_client(transport, cfg, args.dummy)
-        if client.motor_client is None:
-            raise RuntimeError(
-                "Motor client not initialized; check motor pico registration."
+        with run_tag.session(transport, "vna_position_sweep"):
+            client = _build_client(transport, cfg, args.dummy)
+            if client.motor_client is None:
+                raise RuntimeError(
+                    "Motor client not initialized; check motor pico "
+                    "registration."
+                )
+            if client.vna is None:
+                raise RuntimeError(
+                    "VNA not initialized; check vna config block."
+                )
+
+            status.send(
+                f"vna_position_sweep started ({len(grid)} grid points, "
+                f"settle_s={settle_s})"
             )
-        if client.vna is None:
-            raise RuntimeError("VNA not initialized; check vna config block.")
+            logger.info(
+                f"vna_position_sweep started ({len(grid)} grid points, "
+                f"settle_s={settle_s})"
+            )
 
-        publish_run_tag(transport, "vna_position_sweep")
-        status.send(
-            f"vna_position_sweep started ({len(grid)} grid points, "
-            f"settle_s={settle_s})"
-        )
-        logger.info(
-            f"vna_position_sweep started ({len(grid)} grid points, "
-            f"settle_s={settle_s})"
-        )
-
-        client.motor_client.set_delay()
-        client.motor_client.halt()
-        client.motor_client.home()
-        for idx, (az, el) in enumerate(grid):
-            if client.stop_client.is_set():
-                logger.info("stop_client set; aborting sweep")
-                break
-            logger.info(f"[{idx + 1}/{len(grid)}] move_to az={az}, el={el}")
-            client.motor_client.move_to(az_deg=az, el_deg=el)
-            if settle_s > 0 and client.stop_client.wait(settle_s):
-                break
-            with client.coord.switch_section():
-                for mode in ("ant", "rec"):
-                    logger.info(
-                        f"[{idx + 1}/{len(grid)}] measure_s11({mode!r})"
-                    )
-                    client.measure_s11(mode)
-        client.motor_client.home()
+            client.motor_client.set_delay()
+            client.motor_client.halt()
+            client.motor_client.home()
+            for idx, (az, el) in enumerate(grid):
+                if client.stop_client.is_set():
+                    logger.info("stop_client set; aborting sweep")
+                    break
+                logger.info(
+                    f"[{idx + 1}/{len(grid)}] move_to az={az}, el={el}"
+                )
+                client.motor_client.move_to(az_deg=az, el_deg=el)
+                if settle_s > 0 and client.stop_client.wait(settle_s):
+                    break
+                with client.coord.switch_section():
+                    for mode in ("ant", "rec"):
+                        logger.info(
+                            f"[{idx + 1}/{len(grid)}] measure_s11({mode!r})"
+                        )
+                        client.measure_s11(mode)
+            client.motor_client.home()
     except KeyboardInterrupt:
         logger.info("Sweep interrupted by user")
     except (TimeoutError, RuntimeError) as exc:
@@ -153,7 +158,6 @@ def main(transport, args):
             if client.motor_client is not None:
                 client.motor_client.halt()
             client.stop()
-        clear_run_tag(transport)
         status.send("vna_position_sweep ended")
         logger.info("vna_position_sweep ended")
 

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -3,8 +3,6 @@ import threading
 import time
 from contextlib import contextmanager
 
-import yaml
-
 from cmt_vna import VNA
 from eigsep_redis import (
     ConfigStore,
@@ -15,18 +13,14 @@ from eigsep_redis import (
 from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
-from . import run_tag
+from . import obs_config_owner, run_tag
 from .io import _validate_vna_s11_data, _validate_vna_s11_header
 from .motion_switch import MotionSwitchCoordinator
 from .motor_client import MotorClient
 from .tempctrl_client import TempCtrlClient
-from .utils import get_config_path
 from .vna import VnaWriter
 
 logger = logging.getLogger(__name__)
-default_cfg_file = get_config_path("obs_config.yaml")
-with open(default_cfg_file, "r") as f:
-    default_cfg = yaml.safe_load(f)
 
 # Valid RF switch state names, sourced from the firmware-side class so
 # that a pico firmware change flows through automatically.
@@ -50,11 +44,16 @@ class PandaClient:
         snapshot, status, heartbeat, VNA producer) — not the full
         observer-side bus. Wrong-role access (e.g. ``corr_reader``) is
         an ``AttributeError`` rather than a runtime foot-gun.
-    default_cfg : dict
-        Default configuration to use if no config is found in Redis.
+    cfg : dict, optional
+        Transient observing config. If ``None`` (default), read the
+        persistent cfg from Redis (raise ``RuntimeError`` if absent —
+        an uploader script such as ``panda_observe`` must have seeded
+        Redis first). If a dict, use it directly and skip the Redis
+        read entirely. Bring-up scripts pass a local cfg here so they
+        do not mutate the persistent cfg used by file-header overlays.
     """
 
-    def __init__(self, transport, default_cfg=default_cfg):
+    def __init__(self, transport, *, cfg=None):
         self.logger = logger
         self.transport = transport
         self.config = ConfigStore(transport)
@@ -63,13 +62,14 @@ class PandaClient:
         self.heartbeat = HeartbeatWriter(transport)
         self.vna_writer = VnaWriter(transport)
         self.stop_client = threading.Event()
-        cfg = self._get_cfg()
         if cfg is None:
-            self.logger.warning(
-                "No configuration found in Redis, using default config."
-            )
-            self.config.upload(default_cfg)
             cfg = self._get_cfg()
+            if cfg is None:
+                raise RuntimeError(
+                    "No obs_config in Redis; start panda_observe "
+                    "(or another uploader) first, or pass cfg=<dict> "
+                    "for transient use."
+                )
         self.cfg = cfg
 
         # RF switch proxy is a thin Redis-key facade — no hardware
@@ -604,12 +604,21 @@ class PandaClient:
         # EigObserver._with_header_overlays. self.cfg is canonical
         # here because PandaClient owns the obs_config upload.
         tag = run_tag.read(self.transport)
+        owner = obs_config_owner.read_owner(self.transport)
         header["run_tag"] = (
             tag["run_tag"] if tag["run_tag"] is not None else "UNKNOWN"
         )
         header["run_started_at_unix"] = (
             tag["run_started_at_unix"]
             if tag["run_started_at_unix"] is not None
+            else 0.0
+        )
+        header["obs_config_owner"] = (
+            owner["owner"] if owner["owner"] is not None else "UNKNOWN"
+        )
+        header["obs_config_owner_uploaded_unix"] = (
+            owner["uploaded_at_unix"]
+            if owner["uploaded_at_unix"] is not None
             else 0.0
         )
         header["obs_config"] = dict(self.cfg)

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -273,7 +273,7 @@ def test_measure_s11_publishes_conforming_payload(mode, tmp_path):
         cfg = yaml.safe_load(f)
     cfg["use_vna"] = True
     transport = DummyTransport()
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         client.measure_s11(mode)
         # The reader skips producer-backlog by design (see

--- a/src/eigsep_observing/obs_config_owner.py
+++ b/src/eigsep_observing/obs_config_owner.py
@@ -1,0 +1,107 @@
+"""Persistent record of who last uploaded the panda obs_config.
+
+Mirrors :mod:`eigsep_observing.run_tag` in shape — a single Redis key
+holds a small JSON blob, overwritten on each publish — but with one
+critical lifecycle difference: there is no ``clear``. The owner record
+represents "the last script that legitimately uploaded an obs_config",
+and the cfg it uploaded persists in Redis after the script exits. A
+``clear`` on exit would falsely declare the cfg unowned even though
+its content is still authoritative.
+
+Published by the three uploader scripts (``eigsep-panda``,
+``scripts/no_switch_observation.py``, ``scripts/vna_position_sweep.py``)
+immediately after their ``ConfigStore.upload(cfg)`` call. Consumed by
+``EigObserver._with_header_overlays`` and ``PandaClient.measure_s11``
+so corr- and VNA-file headers carry the cfg provenance alongside the
+cfg block itself.
+
+Downstream trust checks:
+
+- ``header["obs_config_owner"] != "UNKNOWN"`` — necessary condition:
+  someone with authority uploaded the cfg at some point.
+- ``header["run_tag"] == header["obs_config_owner"]`` — stronger
+  condition: the active driver is the cfg owner, so the cfg block in
+  the same header reflects what is running right now (not a
+  bring-up script's transient view).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+OBS_CONFIG_OWNER_KEY = "eigsep:obs_config_owner"
+
+_EMPTY = {
+    "owner": None,
+    "uploaded_at_unix": None,
+}
+
+
+def publish_owner(
+    transport, owner: str, *, uploaded_at_unix: Optional[float] = None
+) -> None:
+    """Stamp the cfg uploader's identity into Redis.
+
+    Any exception is logged at WARNING and swallowed. The owner record
+    is provenance, not correctness — losing it must never block the
+    script's main work.
+    """
+    if uploaded_at_unix is None:
+        t = time.time()
+    else:
+        try:
+            t = float(uploaded_at_unix)
+        except (ValueError, TypeError) as exc:
+            t = 0.0
+            logger.warning(
+                f"invalid uploaded_at_unix {uploaded_at_unix!r} for "
+                f"obs_config_owner {owner!r}: {exc}; using 0.0."
+            )
+    try:
+        payload = json.dumps({"owner": str(owner), "uploaded_at_unix": t})
+        transport.add_raw(OBS_CONFIG_OWNER_KEY, payload)
+    except Exception as exc:
+        logger.warning("failed to publish obs_config_owner: %s", exc)
+
+
+def read_owner(transport) -> dict:
+    """Fetch the latest cfg-owner record.
+
+    A missing key, transport error, malformed payload, or null payload
+    all resolve to the empty-sentinel dict ``{"owner": None,
+    "uploaded_at_unix": None}``. Consumers should treat ``owner is
+    None`` as a misconfiguration signal (no authorized uploader has
+    seeded Redis yet), not the steady-state default.
+    """
+    try:
+        raw = transport.get_raw(OBS_CONFIG_OWNER_KEY)
+    except Exception as exc:
+        logger.warning("failed to read obs_config_owner: %s", exc)
+        return dict(_EMPTY)
+    if raw is None:
+        return dict(_EMPTY)
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode()
+    try:
+        obj = json.loads(raw)
+        owner = obj["owner"]
+        uploaded = obj["uploaded_at_unix"]
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+        logger.warning("malformed obs_config_owner payload %r: %s", raw, exc)
+        return dict(_EMPTY)
+    if owner is None and uploaded is None:
+        return dict(_EMPTY)
+    if owner is None or uploaded is None:
+        logger.warning(
+            "partial obs_config_owner payload (%r, %r); "
+            "returning empty sentinel",
+            owner,
+            uploaded,
+        )
+        return dict(_EMPTY)
+    return {"owner": str(owner), "uploaded_at_unix": float(uploaded)}

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -9,7 +9,7 @@ from eigsep_redis import (
     StatusReader,
 )
 
-from . import io, run_tag
+from . import io, obs_config_owner, run_tag
 from .corr import CorrConfigStore, CorrReader
 from .file_heartbeat import publish as publish_file_heartbeat
 from .status_log_handler import PANDA_RELAY_LOGGER, StatusStreamHandler
@@ -198,23 +198,32 @@ class EigObserver:
         """Return a copy of ``header`` with panda-side overlay fields merged in.
 
         Adds ``run_tag`` / ``run_started_at_unix`` (from
-        :mod:`eigsep_observing.run_tag`) and ``obs_config`` (from
-        :class:`eigsep_redis.ConfigStore`) so each corr file records the
-        active panda script and the panda-side config snapshot at
-        file-open time.
+        :mod:`eigsep_observing.run_tag`),
+        ``obs_config_owner`` / ``obs_config_owner_uploaded_unix`` (from
+        :mod:`eigsep_observing.obs_config_owner`), and ``obs_config``
+        (from :class:`eigsep_redis.ConfigStore`) so each corr file
+        records the active panda script, the last script to upload the
+        config, and the panda-side config snapshot at file-open time.
+
+        Downstream trust check: ``obs_config_owner != "UNKNOWN"`` means
+        someone legitimately uploaded the cfg at some point;
+        ``run_tag == obs_config_owner`` means that same script is the
+        active driver right now.
 
         All overlay reads are defensive: a missing or malformed
-        run_tag, a missing obs_config, or a transient transport
-        failure all resolve to ``"UNKNOWN"`` / ``0.0`` / ``{}`` rather
-        than raising. Corr data is sacred — overlay enrichment must
-        never block a corr file from being written. Sentinel values
-        (rather than dropping the keys) guarantee every post-PR file
-        carries the field and let downstream distinguish
-        "no producer info" from "old file without this field."
+        run_tag, a missing obs_config_owner, a missing obs_config, or a
+        transient transport failure all resolve to ``"UNKNOWN"`` /
+        ``0.0`` / ``{}`` rather than raising. Corr data is sacred —
+        overlay enrichment must never block a corr file from being
+        written. Sentinel values (rather than dropping the keys)
+        guarantee every post-PR file carries the field and let
+        downstream distinguish "no producer info" from "old file
+        without this field."
         """
         out = dict(header)
         if self.transport_panda is not None:
             tag = run_tag.read(self.transport_panda)
+            owner = obs_config_owner.read_owner(self.transport_panda)
             try:
                 obs_cfg = self.config.get()
             except Exception as exc:
@@ -222,6 +231,7 @@ class EigObserver:
                 obs_cfg = {}
         else:
             tag = {"run_tag": None, "run_started_at_unix": None}
+            owner = {"owner": None, "uploaded_at_unix": None}
             obs_cfg = {}
         out["run_tag"] = (
             tag["run_tag"] if tag["run_tag"] is not None else "UNKNOWN"
@@ -229,6 +239,14 @@ class EigObserver:
         out["run_started_at_unix"] = (
             tag["run_started_at_unix"]
             if tag["run_started_at_unix"] is not None
+            else 0.0
+        )
+        out["obs_config_owner"] = (
+            owner["owner"] if owner["owner"] is not None else "UNKNOWN"
+        )
+        out["obs_config_owner_uploaded_unix"] = (
+            owner["uploaded_at_unix"]
+            if owner["uploaded_at_unix"] is not None
             else 0.0
         )
         out["obs_config"] = obs_cfg

--- a/src/eigsep_observing/run_tag.py
+++ b/src/eigsep_observing/run_tag.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from contextlib import contextmanager
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -41,10 +42,24 @@ _EMPTY = {
 def publish(transport, tag: str, started_unix: Optional[float] = None) -> None:
     """Stamp the active script's tag into Redis.
 
+    Logs a WARNING if an existing non-empty tag with a different name
+    is being overwritten — catches the "two driver scripts started
+    concurrently" race that ``session``'s pre-publish refuse check
+    can lose. The publish still proceeds (provenance is best-effort);
+    the WARNING is the second-line audit trail.
+
     Any exception is logged at WARNING and swallowed. ``run_tag`` is
     provenance, not correctness — losing it must never block the
     script's main work.
     """
+    existing = read(transport)
+    if existing["run_tag"] is not None and existing["run_tag"] != str(tag):
+        logger.warning(
+            "run_tag %r is overwriting existing %r — two driver scripts "
+            "may be running concurrently.",
+            str(tag),
+            existing["run_tag"],
+        )
     if started_unix is None:
         t = time.time()
     else:
@@ -112,3 +127,34 @@ def read(transport) -> dict:
         )
         return dict(_EMPTY)
     return {"run_tag": str(tag), "run_started_at_unix": float(started)}
+
+
+@contextmanager
+def session(transport, tag: str):
+    """Publish ``tag`` for the duration of the with-block.
+
+    Refuses to enter if a different non-empty tag is already published
+    (raises ``RuntimeError``). On exit, clears only if our tag is still
+    the active one — a later script that overwrote it (in violation of
+    the refuse-on-conflict policy) is not trampled.
+
+    The pre-publish refuse check is best-effort: there is no atomic
+    compare-and-set between ``read`` and ``publish``, so two scripts
+    starting in the same millisecond can both pass the check. The
+    publish-time overwrite WARNING in :func:`publish` surfaces the
+    collision in that case.
+    """
+    existing = read(transport)
+    if existing["run_tag"] not in (None, str(tag)):
+        raise RuntimeError(
+            f"Another driver script is already publishing run_tag="
+            f"{existing['run_tag']!r}; refusing to start {str(tag)!r}. "
+            f"Stop the other script first."
+        )
+    publish(transport, tag)
+    try:
+        yield
+    finally:
+        current = read(transport)
+        if current["run_tag"] == str(tag):
+            clear(transport)

--- a/src/eigsep_observing/scripts/panda_observe.py
+++ b/src/eigsep_observing/scripts/panda_observe.py
@@ -94,19 +94,27 @@ def main() -> int:
         logger.warning("Running in DUMMY mode, no hardware will be used.")
         transport = Transport(host="localhost", port=6380)
         transport.reset()  # reset test redis database
-        ConfigStore(transport).upload(cfg)
-        publish_owner(transport, "panda_observe")
-        client = DummyPandaClient(transport=transport, cfg=cfg)
     else:
         transport = Transport(host="localhost", port=6379)
-        ConfigStore(transport).upload(cfg)
-        publish_owner(transport, "panda_observe")
-        client = PandaClient(transport)
 
-    logger.info(f"Client configuration: {client.cfg}")
+    client = None
     thds = {}
     try:
         with run_tag.session(transport, "panda_observe"):
+            # Upload obs_config + claim ownership inside the session so
+            # that if another driver currently owns the run_tag, the
+            # RuntimeError from session() fires before we overwrite the
+            # legitimate owner's obs_config / obs_config_owner stamps
+            # (obs_config_owner has no clear() — once written, it
+            # persists until the next uploader).
+            ConfigStore(transport).upload(cfg)
+            publish_owner(transport, "panda_observe")
+            if args.dummy:
+                client = DummyPandaClient(transport=transport, cfg=cfg)
+            else:
+                client = PandaClient(transport)
+            logger.info(f"Client configuration: {client.cfg}")
+
             # switches
             if client.cfg["use_switches"]:
                 switch_thd = Thread(target=client.switch_loop)
@@ -139,7 +147,8 @@ def main() -> int:
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt received, stopping threads")
     finally:
-        client.stop()
+        if client is not None:
+            client.stop()
         for name, t in thds.items():
             logger.info(f"Joining thread {name}")
             t.join()

--- a/src/eigsep_observing/scripts/panda_observe.py
+++ b/src/eigsep_observing/scripts/panda_observe.py
@@ -31,9 +31,8 @@ import yaml
 
 from eigsep_redis import ConfigStore, Transport
 
-from eigsep_observing import PandaClient
-from eigsep_observing.run_tag import clear as clear_run_tag
-from eigsep_observing.run_tag import publish as publish_run_tag
+from eigsep_observing import PandaClient, run_tag
+from eigsep_observing.obs_config_owner import publish_owner
 
 try:
     from eigsep_observing.testing import DummyPandaClient
@@ -96,46 +95,47 @@ def main() -> int:
         transport = Transport(host="localhost", port=6380)
         transport.reset()  # reset test redis database
         ConfigStore(transport).upload(cfg)
-        client = DummyPandaClient(transport=transport, default_cfg=cfg)
+        publish_owner(transport, "panda_observe")
+        client = DummyPandaClient(transport=transport, cfg=cfg)
     else:
         transport = Transport(host="localhost", port=6379)
         ConfigStore(transport).upload(cfg)
+        publish_owner(transport, "panda_observe")
         client = PandaClient(transport)
 
     logger.info(f"Client configuration: {client.cfg}")
     thds = {}
     try:
-        publish_run_tag(transport, "panda_observe")
+        with run_tag.session(transport, "panda_observe"):
+            # switches
+            if client.cfg["use_switches"]:
+                switch_thd = Thread(target=client.switch_loop)
+                thds["switch"] = switch_thd
+                logger.info("Starting switch thread")
+                switch_thd.start()
 
-        # switches
-        if client.cfg["use_switches"]:
-            switch_thd = Thread(target=client.switch_loop)
-            thds["switch"] = switch_thd
-            logger.info("Starting switch thread")
-            switch_thd.start()
+            # VNA
+            if client.cfg["use_vna"]:
+                vna_thd = Thread(target=client.vna_loop)
+                thds["vna"] = vna_thd
+                logger.info("Starting VNA thread")
+                vna_thd.start()
 
-        # VNA
-        if client.cfg["use_vna"]:
-            vna_thd = Thread(target=client.vna_loop)
-            thds["vna"] = vna_thd
-            logger.info("Starting VNA thread")
-            vna_thd.start()
+            # motor (periodic az/el scans)
+            if client.cfg.get("use_motor", False):
+                motor_thd = Thread(target=client.motor_loop)
+                thds["motor"] = motor_thd
+                logger.info("Starting motor thread")
+                motor_thd.start()
 
-        # motor (periodic az/el scans)
-        if client.cfg.get("use_motor", False):
-            motor_thd = Thread(target=client.motor_loop)
-            thds["motor"] = motor_thd
-            logger.info("Starting motor thread")
-            motor_thd.start()
+            # tempctrl
+            if client.cfg.get("use_tempctrl", False):
+                tempctrl_thd = Thread(target=client.tempctrl_loop)
+                thds["tempctrl"] = tempctrl_thd
+                logger.info("Starting tempctrl thread")
+                tempctrl_thd.start()
 
-        # tempctrl
-        if client.cfg.get("use_tempctrl", False):
-            tempctrl_thd = Thread(target=client.tempctrl_loop)
-            thds["tempctrl"] = tempctrl_thd
-            logger.info("Starting tempctrl thread")
-            tempctrl_thd.start()
-
-        client.stop_client.wait()  # wait until stop signal is set
+            client.stop_client.wait()  # wait until stop signal is set
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt received, stopping threads")
     finally:
@@ -144,7 +144,6 @@ def main() -> int:
             logger.info(f"Joining thread {name}")
             t.join()
             logger.info(f"Thread {name} joined")
-        clear_run_tag(transport)
         logger.info("All threads joined, exiting.")
 
     return 0

--- a/src/eigsep_observing/testing/client.py
+++ b/src/eigsep_observing/testing/client.py
@@ -2,18 +2,16 @@ from functools import partial
 
 import yaml
 from cmt_vna.testing import DummyVNA
-from eigsep_redis import HeartbeatWriter, MetadataWriter
+from eigsep_redis import ConfigStore, HeartbeatWriter, MetadataWriter
 from eigsep_redis.testing import DummyTransport
 import picohost.testing
 from picohost.keys import pico_heartbeat_name
 from picohost.manager import HEARTBEAT_TTL, PicoManager
 
 from .. import PandaClient
+from ..utils import get_config_path
 
-default_cfg_file = (
-    "/home/christian/Documents/research/eigsep/eigsep_observing/src/"
-    "eigsep_observing/config/dummy_config.yaml"
-)
+_dummy_cfg_file = get_config_path("dummy_config.yaml")
 
 
 # Picohost ships a single ``DummyPicoIMU`` class whose ``EMULATOR_CLASS``
@@ -67,20 +65,35 @@ class DummyPandaClient(PandaClient):
     their devices already registered.
     """
 
-    def __init__(self, transport=None, default_cfg=None):
+    def __init__(self, transport=None, *, cfg=None):
         if transport is None:
             transport = DummyTransport()
-        if default_cfg is None:
+        if cfg is None:
+            # Mirror the parent's cfg=None semantics: when Redis has a
+            # cfg, forward cfg=None so the parent's ``_get_cfg`` reads
+            # it and emits the canonical "Using config from Redis" log.
+            # Only fall back to the packaged dummy yaml when Redis is
+            # empty — testing convenience that lets
+            # ``DummyPandaClient()`` work standalone without forcing
+            # every test to upload a cfg first. The fallback is
+            # in-memory only (no Redis upload), so it does not pollute
+            # the cfg-owner provenance.
             try:
-                with open(default_cfg_file, "r") as f:
-                    default_cfg = yaml.safe_load(f)
-            except FileNotFoundError:
-                default_cfg = {}
+                ConfigStore(transport).get()
+                forwarded_cfg = None
+            except ValueError:
+                try:
+                    with open(_dummy_cfg_file, "r") as f:
+                        forwarded_cfg = yaml.safe_load(f)
+                except FileNotFoundError:
+                    forwarded_cfg = {}
+        else:
+            forwarded_cfg = cfg
         # Start the embedded manager BEFORE super().__init__ so that
         # PicoProxy.is_available is True when the parent constructor
         # builds sw_proxy.
         self._manager = self._start_dummy_manager(transport)
-        super().__init__(transport, default_cfg=default_cfg)
+        super().__init__(transport, cfg=forwarded_cfg)
 
     def _start_dummy_manager(self, transport):
         """Create and start a PicoManager with dummy devices.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,6 @@ def transport():
 
 @pytest.fixture
 def client(transport, dummy_cfg):
-    c = DummyPandaClient(transport, default_cfg=dummy_cfg)
+    c = DummyPandaClient(transport, cfg=dummy_cfg)
     yield c
     c.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ from eigsep_redis.testing import DummyTransport
 from picohost.proxy import PicoProxy
 
 import eigsep_observing
-from eigsep_observing import MotorClient, TempCtrlClient, run_tag
+from eigsep_observing import MotorClient, PandaClient, TempCtrlClient, run_tag
 from eigsep_observing.testing import DummyPandaClient
 from eigsep_observing.testing.utils import compare_dicts
 
@@ -57,47 +57,61 @@ def test_client(client):
         assert client.vna is None
 
 
-def test_get_cfg(caplog, dummy_cfg):
-    caplog.set_level("INFO")
-
-    # should be no config in redis at start
-    t = DummyTransport()  # different transport for test isolation
+def test_panda_client_uses_caller_cfg_without_touching_redis(dummy_cfg):
+    """``PandaClient(..., cfg=<dict>)`` uses the caller's cfg directly
+    and does not write it to Redis. Persistent Redis cfg is the
+    province of uploader scripts (panda_observe, vna_position_sweep,
+    no_switch_observation) — bring-up tools must not mutate it."""
+    t = DummyTransport()
     with pytest.raises(ValueError):
-        ConfigStore(t).get()
-    client2 = DummyPandaClient(t, default_cfg={})
-    client3 = None
+        ConfigStore(t).get()  # baseline: Redis is empty
+    client = DummyPandaClient(t, cfg=dummy_cfg)
     try:
-        # should have created a logger warning about missing config
-        for record in caplog.records:
-            if "No configuration found in Redis" in record.getMessage():
-                assert record.levelname == "WARNING"
-        # after init of client2, the cfg should be in redis
-        cfg_in_redis = client2._get_cfg()
-        assert "upload_time" in cfg_in_redis
-
-        # upload the dummy config to client2's redis
-        client2.config.upload(dummy_cfg)
-
-        # check that they're the same
-        retrieved_cfg = client2._get_cfg()
-        retrieved_cfg_copy = retrieved_cfg.copy()
-        del retrieved_cfg_copy["upload_time"]
-        dummy_cfg_serialized = json.loads(json.dumps(dummy_cfg))
-        compare_dicts(dummy_cfg_serialized, retrieved_cfg_copy)
-
-        # if reinit client2, it should get the config from redis
-        client3 = DummyPandaClient(t, default_cfg={})
-        retrieved_cfg2 = client3._get_cfg()
-        compare_dicts(client3.cfg, retrieved_cfg2)
-
-        # check logging
-        for record in caplog.records:
-            if "Using config from Redis" in record.getMessage():
-                assert record.levelname == "INFO"
+        assert client.cfg == dummy_cfg
+        # No side-effect upload: ConfigStore still sees an empty Redis.
+        with pytest.raises(ValueError):
+            ConfigStore(t).get()
     finally:
-        client2.stop()
-        if client3 is not None:
-            client3.stop()
+        client.stop()
+
+
+def test_panda_client_raises_when_cfg_kwarg_none_and_redis_empty():
+    """Bare ``PandaClient(transport)`` with no ``cfg=`` kwarg and an
+    empty Redis raises ``RuntimeError`` rather than silently bootstrapping
+    a default. The packaged default was the source of the
+    ``vna_manual``-style trust-eroding upload; the loud raise forces the
+    caller to either start an uploader or pass an explicit
+    ``cfg=<dict>``."""
+    t = DummyTransport()
+    with pytest.raises(RuntimeError, match="No obs_config in Redis"):
+        PandaClient(t)
+
+
+def test_panda_client_reads_cfg_from_redis_when_cfg_kwarg_none(
+    caplog, dummy_cfg
+):
+    """``PandaClient(..., cfg=None)`` reads the persistent cfg from
+    Redis when an uploader has seeded it. Exercises the production
+    happy path: panda_observe uploads cfg, then constructs the client
+    without an explicit ``cfg=`` kwarg."""
+    caplog.set_level("INFO")
+    t = DummyTransport()
+    ConfigStore(t).upload(dummy_cfg)
+    # cfg=None → DummyPandaClient reads from Redis (mirrors parent
+    # semantics), so the cfg actually used comes from the Redis upload.
+    client = DummyPandaClient(t)
+    try:
+        cfg_copy = client.cfg.copy()
+        del cfg_copy["upload_time"]
+        dummy_cfg_serialized = json.loads(json.dumps(dummy_cfg))
+        compare_dicts(dummy_cfg_serialized, cfg_copy)
+        assert any(
+            "Using config from Redis" in r.getMessage()
+            and r.levelname == "INFO"
+            for r in caplog.records
+        )
+    finally:
+        client.stop()
 
 
 def test_switch_proxy_created(client):
@@ -208,7 +222,7 @@ def test_vna_loop_uses_redis_published_mode_for_switch_back(
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
     cfg["vna_interval"] = 60  # long: only one iteration before stop
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         # Pre-seed the rfswitch in Redis to simulate a state PicoManager
         # set before this PandaClient process started.
@@ -265,7 +279,7 @@ def test_vna_loop_warns_and_defaults_when_rfswitch_absent(
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
     cfg["vna_interval"] = 60
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         # Wipe the rfswitch entry so the helper returns None.
         client.transport.r.hdel("metadata", "rfswitch")
@@ -314,7 +328,7 @@ def test_vna_loop_warns_on_failed_switch_back(transport, dummy_cfg, caplog):
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
     cfg["vna_interval"] = 60  # long: only one iteration before stop
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client._safe_switch("RFNOFF")
         deadline = time.monotonic() + 2.0
@@ -366,7 +380,7 @@ def test_switch_loop_warns_on_failed_switch(transport, dummy_cfg, caplog):
     # Give the loop exactly one mode to try; cap wait so the stop event
     # breaks us out after the first iteration.
     cfg["switch_schedule"] = {"RFNOFF": 0.01}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
 
         def failing_switch(state):
@@ -573,7 +587,7 @@ def test_switch_session_serializes_with_switch_loop(transport, dummy_cfg):
     # Keep the schedule simple and long so switch_loop blocks on the
     # lock instead of racing through many iterations during the test.
     cfg["switch_schedule"] = {"RFANT": 60.0}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client._safe_switch("RFANT")
         _wait_for_published_mode(client, "RFANT")
@@ -662,7 +676,7 @@ def test_send_heartbeat_cycles_and_announces_shutdown(transport, dummy_cfg):
     hasn't expired yet), so we explicitly count ticks here by counting
     invocations of the writer's ``set`` method over a ~1.2s window."""
     calls = []
-    client = DummyPandaClient(transport, default_cfg=dummy_cfg)
+    client = DummyPandaClient(transport, cfg=dummy_cfg)
     try:
         original_set = client.heartbeat.set
 
@@ -732,7 +746,7 @@ def test_measure_s11_contract_violation_emits_on_both_channels(
     test)."""
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         _arm_status_reader(client)
         violations = ["missing key 'npoints'", "key 'mode': expected str"]
@@ -772,7 +786,7 @@ def test_measure_s11_clean_payload_does_not_send_status(transport, dummy_cfg):
     status stream during normal operation."""
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         _arm_status_reader(client)
         client.measure_s11("ant")
@@ -791,7 +805,7 @@ def test_measure_s11_returns_published_payload(transport, dummy_cfg):
     can write a local artifact without racing the VNA stream reader."""
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         result = client.measure_s11("ant")
         assert isinstance(result, tuple) and len(result) == 3
@@ -913,7 +927,7 @@ def test_switch_loop_survives_firmware_error(transport, dummy_cfg, caplog):
     still fire so the ground observer sees the stuck switch."""
     cfg = dict(dummy_cfg)
     cfg["switch_schedule"] = {"RFNOFF": 0.01}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         pico = client._manager.picos["rfswitch"]
 
@@ -949,7 +963,7 @@ def test_switch_loop_survives_timeout(transport, dummy_cfg, caplog):
     path."""
     cfg = dict(dummy_cfg)
     cfg["switch_schedule"] = {"RFNOFF": 0.01}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         client.sw_proxy.timeout = 0.1
         pico = client._manager.picos["rfswitch"]
@@ -986,7 +1000,7 @@ def test_vna_loop_survives_switch_back_error(transport, dummy_cfg, caplog):
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
     cfg["vna_interval"] = 60
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client._safe_switch("RFNOFF")
         _wait_for_published_mode(client, "RFNOFF")
@@ -1069,7 +1083,7 @@ def test_measure_s11_uses_mode_specific_power_dbm(transport, dummy_cfg):
     or hardcoded power that would silently bias either mode."""
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         client.measure_s11("rec")
         expected_rec = cfg["vna_settings"]["power_dBm"]["rec"]
@@ -1082,11 +1096,11 @@ def test_measure_s11_uses_mode_specific_power_dbm(transport, dummy_cfg):
 
 
 def test_measure_s11_injects_overlay_sentinels(transport, dummy_cfg):
-    """No run_tag published → ``UNKNOWN`` / ``0.0`` sentinels +
+    """No run_tag / owner published → ``UNKNOWN`` / ``0.0`` sentinels +
     ``obs_config`` snapshot from ``self.cfg``."""
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         with patch.object(client.vna_writer, "add") as mock_add:
             client.measure_s11("ant")
@@ -1094,6 +1108,8 @@ def test_measure_s11_injects_overlay_sentinels(transport, dummy_cfg):
         header = mock_add.call_args.kwargs["header"]
         assert header["run_tag"] == "UNKNOWN"
         assert header["run_started_at_unix"] == 0.0
+        assert header["obs_config_owner"] == "UNKNOWN"
+        assert header["obs_config_owner_uploaded_unix"] == 0.0
         assert header["obs_config"]["use_vna"] is True
         # Sanity: the existing fields are still present.
         assert header["mode"] == "ant"
@@ -1107,7 +1123,7 @@ def test_measure_s11_injects_published_run_tag(transport, dummy_cfg):
     measure_s11 call."""
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         run_tag.publish(transport, "vna_position_sweep", started_unix=12345.0)
         with patch.object(client.vna_writer, "add") as mock_add:
@@ -1115,6 +1131,26 @@ def test_measure_s11_injects_published_run_tag(transport, dummy_cfg):
         header = mock_add.call_args.kwargs["header"]
         assert header["run_tag"] == "vna_position_sweep"
         assert header["run_started_at_unix"] == 12345.0
+    finally:
+        client.stop()
+
+
+def test_measure_s11_injects_published_owner(transport, dummy_cfg):
+    """publish_owner flows into the VNA header on next measure_s11 call."""
+    from eigsep_observing import obs_config_owner
+
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        obs_config_owner.publish_owner(
+            transport, "panda_observe", uploaded_at_unix=7.5
+        )
+        with patch.object(client.vna_writer, "add") as mock_add:
+            client.measure_s11("ant")
+        header = mock_add.call_args.kwargs["header"]
+        assert header["obs_config_owner"] == "panda_observe"
+        assert header["obs_config_owner_uploaded_unix"] == 7.5
     finally:
         client.stop()
 
@@ -1144,7 +1180,7 @@ def test_boot_errors_when_rfant_initialization_fails(
     with patch.object(
         eigsep_observing.PandaClient, "_safe_switch", return_value=False
     ):
-        client = DummyPandaClient(transport, default_cfg=dummy_cfg)
+        client = DummyPandaClient(transport, cfg=dummy_cfg)
     try:
         assert any(
             "Boot-time RFANT initialization failed" in r.getMessage()
@@ -1169,7 +1205,7 @@ def test_vna_loop_recovers_to_rfant_on_measurement_exception(
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
     cfg["vna_interval"] = 60  # long: one iteration then stop via RFANT
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         # Pre-seed a non-RFANT prev_mode so the recovery to RFANT is
         # distinguishable from a restore to prev_mode.
@@ -1243,7 +1279,7 @@ def test_use_motor_true_builds_motor_client(transport, dummy_cfg):
     addressable through the client's proxy."""
     cfg = dict(dummy_cfg)
     cfg["use_motor"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert isinstance(client.motor_client, MotorClient)
         # Motor client shares the panda client's transport, i.e. the
@@ -1282,7 +1318,7 @@ def test_motor_loop_invalid_interval_returns(transport, dummy_cfg, caplog):
     cfg = dict(dummy_cfg)
     cfg["use_motor"] = True
     cfg["motor_interval"] = 0  # invalid
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         _arm_status_reader(client)
         caplog.set_level("WARNING")
@@ -1316,7 +1352,7 @@ def test_motor_loop_calls_scan_with_stop_event_and_cfg_kwargs(
         "el_range_deg": [-1.0, 0.0, 1.0],
         "repeat_count": 1,
     }
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         scan_calls = []
 
@@ -1350,7 +1386,7 @@ def test_motor_loop_survives_scan_timeout_error_and_parks_motors(
     cfg["use_motor"] = True
     cfg["motor_interval"] = 60
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         home_calls = []
 
@@ -1405,7 +1441,7 @@ def test_motor_loop_survives_scan_runtime_error(transport, dummy_cfg, caplog):
     cfg["use_motor"] = True
     cfg["motor_interval"] = 60
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         home_calls = []
 
@@ -1457,7 +1493,7 @@ def test_motor_loop_logs_error_when_post_failure_home_also_fails(
     cfg["use_motor"] = True
     cfg["motor_interval"] = 60
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
 
         def raising_scan(**kwargs):
@@ -1517,7 +1553,7 @@ def test_motor_loop_waits_motor_interval_when_inline_park_succeeds(
     cfg["motor_interval"] = 3600
     cfg["motor_failure_retry_s"] = 5
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         motor_waits = []
 
@@ -1562,7 +1598,7 @@ def test_motor_loop_uses_failure_retry_interval_after_failed_park(
     cfg["motor_interval"] = 3600
     cfg["motor_failure_retry_s"] = 5
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         motor_waits = []
 
@@ -1611,7 +1647,7 @@ def test_motor_loop_recovery_retries_home_only_not_full_scan(
     cfg["motor_interval"] = 3600
     cfg["motor_failure_retry_s"] = 5
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         scan_calls = []
         home_calls = []
@@ -1679,7 +1715,7 @@ def test_motor_loop_exits_recovery_when_home_finally_succeeds(
     cfg["motor_interval"] = 3600
     cfg["motor_failure_retry_s"] = 5
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         scan_calls = []
         home_calls = []
@@ -1743,7 +1779,7 @@ def test_motor_loop_uses_motor_interval_after_successful_scan(
     cfg["motor_interval"] = 3600
     cfg["motor_failure_retry_s"] = 5
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         motor_waits = []
 
@@ -1788,7 +1824,7 @@ def test_motor_loop_invalid_failure_retry_s_falls_back_to_interval(
     cfg["motor_interval"] = 42
     cfg["motor_failure_retry_s"] = 0  # invalid
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         motor_waits = []
 
@@ -1841,7 +1877,7 @@ def test_motor_loop_set_delay_failure_is_warning_not_fatal(
     cfg["use_motor"] = True
     cfg["motor_interval"] = 60
     cfg["motor_scan"] = {"repeat_count": 1}
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
 
         def fake_scan(**kwargs):
@@ -1884,7 +1920,7 @@ def test_use_tempctrl_false_leaves_client_none(transport, dummy_cfg):
     ``self.tempctrl`` as ``None`` and skip the init call."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = False
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client.cfg.get("use_tempctrl", False) is False
         assert client.tempctrl is None
@@ -1897,7 +1933,7 @@ def test_use_tempctrl_true_builds_client(transport, dummy_cfg):
     ``TempCtrlClient`` bound to the same transport."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert isinstance(client.tempctrl, TempCtrlClient)
         assert client.tempctrl.transport is client.transport
@@ -1976,7 +2012,7 @@ def test_tempctrl_settings_non_dict_disables_client(
     cfg["use_tempctrl"] = True
     cfg["tempctrl_settings"] = "not a dict"
     caplog.set_level("WARNING")
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client.tempctrl is None
         assert any(
@@ -2002,7 +2038,7 @@ def test_tempctrl_settings_bad_numeric_disables_client(
         "LNA": {"target_C": "twenty-five"},
     }
     caplog.set_level("WARNING")
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client.tempctrl is None
         assert any(
@@ -2022,7 +2058,7 @@ def test_tempctrl_loop_returns_when_client_is_none(
     spin, warning rides both channels."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = False
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client.tempctrl is None
         _arm_status_reader(client)
@@ -2047,7 +2083,7 @@ def test_tempctrl_loop_invalid_interval_returns(transport, dummy_cfg, caplog):
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
     cfg["tempctrl_interval"] = 0
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         _arm_status_reader(client)
         caplog.set_level("WARNING")
@@ -2072,7 +2108,7 @@ def test_tempctrl_loop_applies_settings_once_then_stops(transport, dummy_cfg):
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
     cfg["tempctrl_interval"] = 60  # long; only one iteration
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         apply_calls = []
 
@@ -2098,7 +2134,7 @@ def test_tempctrl_loop_does_not_reapply_after_success(transport, dummy_cfg):
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
     cfg["tempctrl_interval"] = 0.01  # fast so we run many iterations
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         apply_calls = []
         health_calls = []
@@ -2146,7 +2182,7 @@ def test_tempctrl_loop_retries_apply_until_success(
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
     cfg["tempctrl_interval"] = 0.01
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         _arm_status_reader(client)
         apply_calls = []
@@ -2219,7 +2255,7 @@ def test_tempctrl_loop_warns_on_watchdog_tripped(transport, dummy_cfg, caplog):
     going dark is visible ground-side."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         caplog.set_level("WARNING")
         # Sparse fixture — see branch-test rationale above.
@@ -2243,7 +2279,7 @@ def test_tempctrl_loop_warns_on_channel_error(transport, dummy_cfg, caplog):
     ride the status stream so the operator sees the dead sensor."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         caplog.set_level("WARNING")
         # Sparse fixture — see branch-test rationale above.
@@ -2271,7 +2307,7 @@ def test_tempctrl_loop_warns_on_saturated_drive(transport, dummy_cfg, caplog):
     peltier can't keep up. Log loudly for the operator."""
     cfg = dict(dummy_cfg)
     cfg["use_tempctrl"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         caplog.set_level("WARNING")
         # Sparse fixture — see branch-test rationale above. The drive/
@@ -2328,7 +2364,7 @@ def test_panda_client_builds_coord_serialize_on_when_flag_set(
     """When the yaml flag is true, the coord serializes."""
     cfg = dict(dummy_cfg)
     cfg["serialize_motion_and_switching"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         assert client.coord.serialize is True
     finally:
@@ -2365,7 +2401,7 @@ def test_run_calibration_sequence_filters_rfant(transport, dummy_cfg):
     """
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         seen = []
         with patch.object(client, "measure_s11", lambda mode: None):
@@ -2394,7 +2430,7 @@ def test_run_calibration_sequence_vna_first_then_dwells(transport, dummy_cfg):
     """
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         order = []
         with patch.object(
@@ -2422,7 +2458,7 @@ def test_run_calibration_sequence_respects_stop_event(transport, dummy_cfg):
     """
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         with patch.object(client, "measure_s11", lambda mode: None):
             with patch.object(client, "_safe_switch", return_value=True):
@@ -2457,7 +2493,7 @@ def test_run_calibration_sequence_rejects_non_dict_schedule(
     """
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = False
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         with pytest.raises(ValueError, match="switch_schedule must be a dict"):
             client.run_calibration_sequence(schedule=["RFNOFF", 0.05])
@@ -2473,7 +2509,7 @@ def test_run_calibration_sequence_skips_invalid_modes(
     """
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         seen = []
         caplog.set_level("WARNING")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,13 +169,25 @@ def test_switch_loop_does_not_mutate_cfg_schedule(client):
     assert client.cfg["switch_schedule"] == original
 
 
-def test_cfg_is_get_cfg_result_without_extra_roundtrip(client):
-    """``self.cfg`` must equal what ``_get_cfg`` returns. The previous
-    ``json.loads(json.dumps(cfg))`` step was dead code — ``config.get``
-    already returns a JSON-normalized dict (via ``json.loads`` on the
-    serialized payload) — and would silently re-introduce drift if
-    re-added on top of a different storage path."""
-    assert client.cfg == client._get_cfg()
+def test_cfg_is_get_cfg_result_without_extra_roundtrip(dummy_cfg):
+    """On the ``cfg=None`` + Redis-pre-seeded path, ``self.cfg`` must
+    equal what ``_get_cfg`` returns. ``config.get`` already returns a
+    JSON-normalized dict (via ``json.loads`` on the serialized
+    payload), so the previous ``json.loads(json.dumps(cfg))`` wrapper
+    was dead code; this guards against re-introducing it on top of a
+    different storage path.
+
+    The ``client`` fixture passes ``cfg=<dict>`` and so bypasses Redis
+    entirely (per the new constructor contract); the invariant only
+    applies to the production happy path where an uploader has seeded
+    Redis first."""
+    t = DummyTransport()
+    ConfigStore(t).upload(dummy_cfg)
+    client = DummyPandaClient(t)
+    try:
+        assert client.cfg == client._get_cfg()
+    finally:
+        client.stop()
 
 
 def test_read_switch_mode_from_redis_returns_published_mode(client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1965,7 +1965,7 @@ def test_init_tempctrl_warns_when_cooling_disabled(
         },
     }
     caplog.set_level("WARNING")
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         warnings = [
             r.getMessage() for r in caplog.records if r.levelname == "WARNING"
@@ -1990,7 +1990,7 @@ def test_init_tempctrl_no_warning_when_cooling_default(
     cfg["use_tempctrl"] = True
     # dummy_cfg already has tempctrl_settings without cooling_enabled.
     caplog.set_level("WARNING")
-    client = DummyPandaClient(transport, default_cfg=cfg)
+    client = DummyPandaClient(transport, cfg=cfg)
     try:
         warnings = [
             r.getMessage() for r in caplog.records if r.levelname == "WARNING"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,7 +32,7 @@ def transport():
 
 @pytest.fixture
 def client(transport, dummy_cfg):
-    c = DummyPandaClient(transport, default_cfg=dummy_cfg)
+    c = DummyPandaClient(transport, cfg=dummy_cfg)
     yield c
     c.stop()
 

--- a/tests/test_obs_config_owner.py
+++ b/tests/test_obs_config_owner.py
@@ -1,0 +1,123 @@
+"""Tests for eigsep_observing.obs_config_owner.
+
+Mirrors :mod:`tests.test_run_tag` but for the persistent
+``eigsep:obs_config_owner`` key (no ``clear`` — the owner stamp
+outlives the uploader script's process; it's only displaced by the
+next legitimate upload).
+"""
+
+from __future__ import annotations
+
+import json
+
+from eigsep_redis.testing import DummyTransport
+
+from eigsep_observing.obs_config_owner import (
+    OBS_CONFIG_OWNER_KEY,
+    publish_owner,
+    read_owner,
+)
+
+
+def test_read_empty_returns_none_fields():
+    t = DummyTransport()
+    assert read_owner(t) == {"owner": None, "uploaded_at_unix": None}
+
+
+def test_publish_then_read_roundtrip():
+    t = DummyTransport()
+    publish_owner(t, "panda_observe", uploaded_at_unix=1000.0)
+    assert read_owner(t) == {
+        "owner": "panda_observe",
+        "uploaded_at_unix": 1000.0,
+    }
+
+
+def test_publish_default_uploaded_unix_uses_now(monkeypatch):
+    t = DummyTransport()
+    monkeypatch.setattr(
+        "eigsep_observing.obs_config_owner.time.time", lambda: 4242.0
+    )
+    publish_owner(t, "no_switch_observation")
+    assert read_owner(t) == {
+        "owner": "no_switch_observation",
+        "uploaded_at_unix": 4242.0,
+    }
+
+
+def test_publish_overwrites_previous_owner():
+    """Owner key is the most-recent uploader by design (no cross-check)."""
+    t = DummyTransport()
+    publish_owner(t, "panda_observe", uploaded_at_unix=1.0)
+    publish_owner(t, "vna_position_sweep", uploaded_at_unix=2.0)
+    assert read_owner(t) == {
+        "owner": "vna_position_sweep",
+        "uploaded_at_unix": 2.0,
+    }
+
+
+def test_module_has_no_clear():
+    """No ``clear`` API: the owner record persists across uploader exits.
+
+    Clearing on exit would falsely declare the still-resident cfg
+    unowned. The key only changes when the next legitimate uploader
+    publishes.
+    """
+    import eigsep_observing.obs_config_owner as mod
+
+    assert not hasattr(mod, "clear"), (
+        "obs_config_owner intentionally has no clear(); persists across "
+        "uploader script exits."
+    )
+
+
+def test_read_malformed_payload_returns_empty(caplog):
+    t = DummyTransport()
+    t.add_raw(OBS_CONFIG_OWNER_KEY, b"not-json-at-all")
+    with caplog.at_level("WARNING"):
+        out = read_owner(t)
+    assert out == {"owner": None, "uploaded_at_unix": None}
+    assert any(
+        "malformed obs_config_owner" in rec.message for rec in caplog.records
+    )
+
+
+def test_read_partial_null_payload_warns(caplog):
+    t = DummyTransport()
+    t.add_raw(
+        OBS_CONFIG_OWNER_KEY,
+        json.dumps({"owner": "panda_observe", "uploaded_at_unix": None}),
+    )
+    with caplog.at_level("WARNING"):
+        out = read_owner(t)
+    assert out == {"owner": None, "uploaded_at_unix": None}
+    assert any(
+        "partial obs_config_owner" in rec.message for rec in caplog.records
+    )
+
+
+def test_publish_swallows_transport_error(caplog):
+    class BoomTransport:
+        def add_raw(self, key, value, ex=None):
+            raise RuntimeError("redis down")
+
+    with caplog.at_level("WARNING"):
+        publish_owner(BoomTransport(), "panda_observe", uploaded_at_unix=1.0)
+    assert any(
+        "failed to publish obs_config_owner" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_read_swallows_transport_error(caplog):
+    class BoomTransport:
+        def get_raw(self, key):
+            raise RuntimeError("redis down")
+
+    with caplog.at_level("WARNING"):
+        out = read_owner(BoomTransport())
+    assert out == {"owner": None, "uploaded_at_unix": None}
+    assert any(
+        "failed to read obs_config_owner" in rec.message
+        for rec in caplog.records
+    )

--- a/tests/test_obs_config_uploaders.py
+++ b/tests/test_obs_config_uploaders.py
@@ -1,0 +1,193 @@
+"""Structural guards on the obs_config upload + run_tag.session contract.
+
+Three AST-level invariants on the ``scripts/`` and
+``src/eigsep_observing/scripts/`` directories. They fail closed so a
+future PR can't quietly add a fourth uploader, drop a session wrap, or
+let an uploader stop publishing its owner.
+"""
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_DIRS = (
+    _REPO_ROOT / "scripts",
+    _REPO_ROOT / "src" / "eigsep_observing" / "scripts",
+)
+
+# Authorized scripts that may mutate persistent obs_config in Redis.
+UPLOADER_SCRIPTS = {
+    "panda_observe.py",
+    "no_switch_observation.py",
+    "vna_position_sweep.py",
+}
+
+# Panda-side bring-up scripts that must enter run_tag.session so corr
+# and VNA files written during their run carry the active driver's
+# identity in the run_tag overlay.
+BRING_UP_SCRIPTS = {
+    "vna_manual.py",
+    "rfswitch_manual.py",
+    "tempctrl_manual.py",
+    "motor_manual.py",
+    "motor_control.py",
+    "potmon_manual.py",
+    "imu_manual.py",
+    "lidar_manual.py",
+    "pico_preflight.py",
+    "monitor_meta.py",
+}
+
+# Scripts explicitly exempt from publishing run_tag:
+#   - live_status.py / live_plotter.py: long-running dashboards that
+#     may run alongside any driver; publishing would trample or be
+#     refused by the session check.
+#   - observe.py: ground-PC eigsep-observe writer, a consumer of the
+#     panda transport (it reads obs_config but never publishes run_tag).
+#   - SNAP-side scripts (republish_header.py, adc_snapshot*.py,
+#     capture_spectrum.py, fpga_init.py): use the SNAP transport, not
+#     the panda transport that hosts the run_tag key.
+RUN_TAG_EXEMPT = {
+    "live_status.py",
+    "live_plotter.py",
+    "observe.py",
+    "republish_header.py",
+    "adc_snapshot.py",
+    "adc_snapshot_bench.py",
+    "capture_spectrum.py",
+    "fpga_init.py",
+}
+
+
+def _iter_script_files():
+    for d in _SCRIPT_DIRS:
+        for f in sorted(d.glob("*.py")):
+            if f.name == "__init__.py":
+                continue
+            yield f
+
+
+def _parse(path):
+    with open(path) as f:
+        return ast.parse(f.read(), filename=str(path))
+
+
+def _dotted_call_name(call):
+    """Best-effort dotted name for ``call.func`` (e.g. 'run_tag.session')."""
+    func = call.func
+    parts = []
+    while isinstance(func, ast.Attribute):
+        parts.append(func.attr)
+        func = func.value
+    if isinstance(func, ast.Name):
+        parts.append(func.id)
+    return ".".join(reversed(parts))
+
+
+def _has_call_named(tree, target):
+    """True if any Call's dotted name equals or ends with '.<target>'."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _dotted_call_name(node)
+        if name == target or name.endswith("." + target):
+            return True
+    return False
+
+
+def _has_configstore_upload(tree):
+    """True if the AST has any ``ConfigStore(...).upload(...)`` call."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "upload"):
+            continue
+        inner = func.value
+        if not isinstance(inner, ast.Call):
+            continue
+        inner_func = inner.func
+        if isinstance(inner_func, ast.Name) and inner_func.id == "ConfigStore":
+            return True
+    return False
+
+
+def test_obs_config_upload_whitelist():
+    """Only authorized uploader scripts may call ``ConfigStore.upload``.
+
+    Bring-up tools like ``vna_manual`` route their local cfg through
+    ``PandaClient(..., cfg=...)`` instead of mutating the persistent
+    Redis cfg, so the cfg corr-file headers stamp keeps reflecting the
+    rig's true operating intent set by the active driver script.
+    """
+    offenders = []
+    for path in _iter_script_files():
+        tree = _parse(path)
+        if _has_configstore_upload(tree) and path.name not in UPLOADER_SCRIPTS:
+            offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        f"Unauthorized scripts call ConfigStore.upload: {offenders}. "
+        f"Only {sorted(UPLOADER_SCRIPTS)} may mutate persistent Redis cfg."
+    )
+
+
+def test_bring_up_scripts_use_run_tag_session():
+    """Every panda-side driver script enters ``run_tag.session``.
+
+    Together with the refuse-on-conflict policy in
+    :func:`eigsep_observing.run_tag.session`, this means corr / VNA
+    files written during a driver's run always carry that driver's
+    identity in the ``run_tag`` overlay.
+    """
+    must_publish = BRING_UP_SCRIPTS | UPLOADER_SCRIPTS
+    missing = []
+    for path in _iter_script_files():
+        if path.name not in must_publish:
+            continue
+        tree = _parse(path)
+        if not _has_call_named(tree, "run_tag.session"):
+            missing.append(str(path.relative_to(_REPO_ROOT)))
+    assert not missing, (
+        f"Scripts must wrap their main work in run_tag.session(...): {missing}"
+    )
+
+
+def test_uploader_scripts_publish_owner():
+    """Authorized uploaders publish ``obs_config_owner`` alongside upload.
+
+    Binds the two writes at source level so a future PR can't drop
+    ``publish_owner`` without dropping the ``ConfigStore.upload`` it
+    accompanies — the persistent owner key would otherwise go stale
+    and downstream's trust check (``obs_config_owner == run_tag``)
+    would silently break.
+    """
+    missing = []
+    for path in _iter_script_files():
+        if path.name not in UPLOADER_SCRIPTS:
+            continue
+        tree = _parse(path)
+        if not _has_call_named(tree, "publish_owner"):
+            missing.append(str(path.relative_to(_REPO_ROOT)))
+    assert not missing, (
+        "Uploader scripts must call publish_owner alongside "
+        f"ConfigStore.upload: {missing}"
+    )
+
+
+def test_script_directory_partition_is_total():
+    """No orphans: every panda-relevant script is categorized.
+
+    A new bring-up script committed without being added to
+    ``BRING_UP_SCRIPTS`` (or, explicitly, ``RUN_TAG_EXEMPT``) would
+    silently bypass the previous two guards. This check forces the
+    author to update the partition.
+    """
+    known = BRING_UP_SCRIPTS | UPLOADER_SCRIPTS | RUN_TAG_EXEMPT
+    orphans = []
+    for path in _iter_script_files():
+        if path.name not in known:
+            orphans.append(str(path.relative_to(_REPO_ROOT)))
+    assert not orphans, (
+        "New scripts must be added to BRING_UP_SCRIPTS, UPLOADER_SCRIPTS, "
+        f"or RUN_TAG_EXEMPT in {Path(__file__).name}: {orphans}"
+    )

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -131,6 +131,8 @@ def test_observer_init_panda_empty_config_does_not_raise():
         assert overlaid["obs_config"] == {}
         assert overlaid["run_tag"] == "UNKNOWN"
         assert overlaid["run_started_at_unix"] == 0.0
+        assert overlaid["obs_config_owner"] == "UNKNOWN"
+        assert overlaid["obs_config_owner_uploaded_unix"] == 0.0
     finally:
         observer.close()
 
@@ -444,6 +446,8 @@ def test_record_corr_data_transient_header_blip_uses_cache(
         **good_header,
         "run_tag": "UNKNOWN",
         "run_started_at_unix": 0.0,
+        "obs_config_owner": "UNKNOWN",
+        "obs_config_owner_uploaded_unix": 0.0,
         "obs_config": {},
     }
     mock_file.set_header.assert_any_call(header=expected_header)
@@ -958,12 +962,14 @@ def test_record_vna_data_stop_event(observer_panda_only, transport_panda):
 
 
 def test_with_header_overlays_no_panda_uses_sentinels(observer_snap_only):
-    """No transport_panda → run_tag sentinels + empty obs_config."""
+    """No transport_panda → run_tag + owner sentinels + empty obs_config."""
     observer = observer_snap_only
     out = observer._with_header_overlays({"sync_time": 12345.0})
     assert out["sync_time"] == 12345.0
     assert out["run_tag"] == "UNKNOWN"
     assert out["run_started_at_unix"] == 0.0
+    assert out["obs_config_owner"] == "UNKNOWN"
+    assert out["obs_config_owner_uploaded_unix"] == 0.0
     assert out["obs_config"] == {}
 
 
@@ -988,6 +994,54 @@ def test_with_header_overlays_panda_no_tag_published(
     assert out["run_started_at_unix"] == 0.0
     # obs_config is still populated — the fixture uploaded one.
     assert "vna_settings" in out["obs_config"]
+
+
+def test_with_header_overlays_owner_trusted(observer_both, transport_panda):
+    """run_tag == obs_config_owner: the active driver also uploaded the cfg.
+
+    Downstream's strongest trust check passes — the cfg block in the
+    header reflects what is running right now.
+    """
+    from eigsep_observing import obs_config_owner
+
+    run_tag.publish(transport_panda, "panda_observe", started_unix=10.0)
+    obs_config_owner.publish_owner(
+        transport_panda, "panda_observe", uploaded_at_unix=5.0
+    )
+    out = observer_both._with_header_overlays({"sync_time": 1.0})
+    assert out["run_tag"] == "panda_observe"
+    assert out["obs_config_owner"] == "panda_observe"
+    assert out["obs_config_owner_uploaded_unix"] == 5.0
+
+
+def test_with_header_overlays_bring_up_overlap(observer_both, transport_panda):
+    """run_tag=vna_manual, owner=panda_observe: bring-up tool overlap.
+
+    The persistent cfg was uploaded by panda_observe but a bring-up
+    tool (which never touches ConfigStore.upload) is currently driving
+    the panda. Downstream's necessary trust check
+    (owner != "UNKNOWN") passes; the stronger run_tag == owner check
+    distinguishes this case.
+    """
+    from eigsep_observing import obs_config_owner
+
+    obs_config_owner.publish_owner(
+        transport_panda, "panda_observe", uploaded_at_unix=5.0
+    )
+    run_tag.publish(transport_panda, "vna_manual", started_unix=10.0)
+    out = observer_both._with_header_overlays({"sync_time": 1.0})
+    assert out["run_tag"] == "vna_manual"
+    assert out["obs_config_owner"] == "panda_observe"
+    assert out["obs_config_owner_uploaded_unix"] == 5.0
+
+
+def test_with_header_overlays_owner_unknown(observer_both, transport_panda):
+    """No owner published → "UNKNOWN" sentinel; trust check fails closed."""
+    run_tag.publish(transport_panda, "vna_manual", started_unix=10.0)
+    out = observer_both._with_header_overlays({"sync_time": 1.0})
+    assert out["run_tag"] == "vna_manual"
+    assert out["obs_config_owner"] == "UNKNOWN"
+    assert out["obs_config_owner_uploaded_unix"] == 0.0
 
 
 def test_with_header_overlays_obs_config_failure_errors(observer_both, caplog):
@@ -1059,6 +1113,8 @@ def test_record_corr_data_writes_overlays_into_header(
     assert written["sync_time"] == sync_time
     assert written["run_tag"] == "no_switch_observation"
     assert written["run_started_at_unix"] == 100.0
+    assert written["obs_config_owner"] == "UNKNOWN"
+    assert written["obs_config_owner_uploaded_unix"] == 0.0
     assert written["obs_config"]["vna_interval"] == 0.5
 
 

--- a/tests/test_run_tag.py
+++ b/tests/test_run_tag.py
@@ -17,6 +17,7 @@ from eigsep_observing.run_tag import (
     clear,
     publish,
     read,
+    session,
 )
 
 
@@ -130,3 +131,72 @@ def test_read_partial_null_payload_warns(caplog):
         out = read(t)
     assert out == {"run_tag": None, "run_started_at_unix": None}
     assert any("partial run_tag" in rec.message for rec in caplog.records)
+
+
+def test_publish_overwrite_with_different_tag_warns(caplog):
+    """publish-time second-line audit: WARN when overwriting another tag."""
+    t = DummyTransport()
+    publish(t, "panda_observe", started_unix=1.0)
+    with caplog.at_level("WARNING"):
+        publish(t, "vna_manual", started_unix=2.0)
+    assert read(t)["run_tag"] == "vna_manual"
+    assert any(
+        "is overwriting existing" in rec.message
+        and "panda_observe" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_publish_same_tag_no_overwrite_warning(caplog):
+    """Re-publishing the same tag is a no-op for the overwrite WARN."""
+    t = DummyTransport()
+    publish(t, "panda_observe", started_unix=1.0)
+    with caplog.at_level("WARNING"):
+        publish(t, "panda_observe", started_unix=2.0)
+    assert not any(
+        "is overwriting existing" in rec.message for rec in caplog.records
+    )
+
+
+def test_session_publishes_and_clears_on_exit():
+    t = DummyTransport()
+    assert read(t) == {"run_tag": None, "run_started_at_unix": None}
+    with session(t, "panda_observe"):
+        assert read(t)["run_tag"] == "panda_observe"
+    assert read(t) == {"run_tag": None, "run_started_at_unix": None}
+
+
+def test_session_refuses_when_other_tag_already_published():
+    t = DummyTransport()
+    publish(t, "panda_observe", started_unix=1.0)
+    with pytest.raises(RuntimeError, match="panda_observe"):
+        with session(t, "vna_manual"):
+            pass
+    assert read(t)["run_tag"] == "panda_observe"
+
+
+def test_session_allows_reentry_with_same_tag():
+    t = DummyTransport()
+    publish(t, "vna_manual", started_unix=1.0)
+    with session(t, "vna_manual"):
+        assert read(t)["run_tag"] == "vna_manual"
+    assert read(t) == {"run_tag": None, "run_started_at_unix": None}
+
+
+def test_session_safe_clear_does_not_trample_overwriter():
+    """If another script overwrites our tag mid-session (refuse-on-conflict
+    race lost), __exit__ must not clear — that other script is now the
+    legitimate driver."""
+    t = DummyTransport()
+    with session(t, "panda_observe"):
+        publish(t, "vna_manual", started_unix=5.0)  # simulated overwrite
+    assert read(t)["run_tag"] == "vna_manual"
+
+
+def test_session_clears_even_when_block_raises():
+    t = DummyTransport()
+    with pytest.raises(ValueError):
+        with session(t, "panda_observe"):
+            assert read(t)["run_tag"] == "panda_observe"
+            raise ValueError("work failed")
+    assert read(t) == {"run_tag": None, "run_started_at_unix": None}


### PR DESCRIPTION
## Summary

- **Collapse `PandaClient.__init__` to a single `cfg=` parameter.** `cfg=None` reads from Redis (raises if empty, replacing the prior auto-upload-default bootstrap); `cfg=<dict>` uses the supplied view in-memory and skips the Redis read. Bring-up scripts like `vna_manual` now pass `cfg=` directly instead of mutating persistent Redis cfg — corr-file overlays no longer get stamped with a bring-up cfg while `eigsep-observe` is running.
- **New persistent `eigsep:obs_config_owner` Redis key** (separate module from the ephemeral `run_tag`) records who last uploaded cfg. The three authorized uploaders (`panda_observe`, `vna_position_sweep`, `no_switch_observation`) call `publish_owner` immediately after `ConfigStore.upload`. `EigObserver._with_header_overlays` and `PandaClient.measure_s11` stamp `obs_config_owner` / `obs_config_owner_uploaded_unix` into corr and VNA file headers.
- **`run_tag.session` context manager** with refuse-on-conflict (raises if another driver's tag is already published) and read-before-clear safety (doesn't trample a later overwriter on exit). Every panda-side driver script (3 uploaders + 10 bring-up tools) wraps its main work in it.
- **Four AST-level structural guards** (`tests/test_obs_config_uploaders.py`) enforce: only the three authorized scripts may call `ConfigStore.upload`, every driver script enters `run_tag.session`, uploaders publish_owner alongside their upload, and the script-directory partition is total (no orphans).

Downstream trust checks now layer cleanly:
- `header["obs_config_owner"] != "UNKNOWN"` — necessary: someone with authority uploaded the cfg.
- `header["run_tag"] == header["obs_config_owner"]` — stronger: the active driver also uploaded the cfg.
- `run_tag=vna_manual, obs_config_owner=panda_observe` — cfg is trustworthy, but a bring-up tool is currently driving the panda.

## Test plan

- [x] `pytest tests/test_obs_config_uploaders.py tests/test_obs_config_owner.py tests/test_run_tag.py` — 32 passed (structural guards, owner module, session CM).
- [x] `pytest tests/test_observer.py -k "header_overlay or record_corr_data_writes_overlays or record_corr_data_header_blip or observer_init_panda_empty_config_does_not_raise"` — 10 passed (corr file header overlays).
- [x] `pytest tests/test_client.py -k "measure_s11_injects or panda_client_uses_caller_cfg or panda_client_raises_when_cfg_kwarg or panda_client_reads_cfg_from_redis"` — 6 passed (cfg= API + VNA header overlay stamping).
- [x] `ruff check .` and `ruff format --check .` clean.
- [ ] Full CI suite.
- [ ] Manual smoke on a dev box: `panda_observe --dummy` + `vna_manual --dummy` against the same fakeredis; confirm corr files written during the bring-up window stamp `run_tag="vna_manual"`, `obs_config_owner="panda_observe"`, and that persistent obs_config in Redis is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)