### PR TITLE
feat(motor-manual): show axis degrees alongside raw step counts

### DIFF
--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -7,10 +7,12 @@ rendering, and the same logic is reachable by unit tests without a
 terminal.
 """
 
+import inspect
 import logging
 import time
 
 from eigsep_redis import MetadataSnapshotReader
+from picohost.motor import PicoMotor
 from picohost.proxy import PicoProxy
 
 logger = logging.getLogger(__name__)
@@ -19,6 +21,42 @@ logger = logging.getLogger(__name__)
 # (Ubuntu + Raspberry Pi). Other platforms may send KEY_ENTER / "\r".
 _KEY_ENTER = ord("\n")
 _REQUIRE_STATUS_RETRY_S = 0.5
+
+
+def _default_cal_motor():
+    """A serial-less :class:`PicoMotor` carrying only the calibration
+    constants, used purely to convert step counts to axis degrees for
+    display.
+
+    ``PicoManager`` constructs the real motor pico with ``PicoMotor``'s
+    constructor defaults and never overrides ``step_angle_deg`` /
+    ``gear_teeth`` / ``microstep`` (see ``picohost.manager``), so reusing
+    those defaults here makes the displayed degrees match the mover's
+    own ``deg_to_steps`` exactly instead of duplicating the gear math.
+    Pulling the values from the constructor signature keeps them in
+    lockstep with picohost. The ``__new__`` bypass (no serial I/O)
+    mirrors ``contract_tests.test_producer_contracts``.
+    """
+    sig = inspect.signature(PicoMotor.__init__)
+    cal = PicoMotor.__new__(PicoMotor)
+    for attr in ("step_angle_deg", "gear_teeth", "microstep"):
+        setattr(cal, attr, sig.parameters[attr].default)
+    return cal
+
+
+_CAL_MOTOR = _default_cal_motor()
+
+
+def _format_pos(raw):
+    """Render a raw motor step count as ``"<steps> (<deg> deg)"``.
+
+    Non-numeric values (sentinels like ``"?"`` for a missing key) are
+    returned verbatim so a partial status dict never crashes the UI.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return str(raw)
+    steps = int(round(raw))
+    return f"{steps} ({_CAL_MOTOR.steps_to_deg(steps):.1f} deg)"
 
 
 class MotorZeroer:
@@ -107,7 +145,7 @@ class MotorZeroer:
             return "WAITING", "---", connected
         az_pos = status.get("az_pos", "?")
         el_pos = status.get("el_pos", "?")
-        return str(az_pos), str(el_pos), connected
+        return _format_pos(az_pos), _format_pos(el_pos), connected
 
     def handle_key(self, ch, deg_state):
         """Advance the zeroing state machine in response to one keystroke.

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 from eigsep_observing import MotorZeroer
+from eigsep_observing.motor_zeroer import _CAL_MOTOR, _format_pos
 from eigsep_redis.keys import METADATA_HASH
 
 
@@ -95,7 +96,11 @@ def test_status_text_reflects_live_metadata(client):
     )
     expected_az = zeroer._reader.get("motor")["az_pos"]
     az, _, connected = zeroer.status_text()
-    assert az == str(expected_az)
+    # status_text renders the raw step count plus the equivalent axis
+    # degrees, so an operator jogging in degrees can read the step
+    # counter back in the same unit.
+    steps = int(round(expected_az))
+    assert az == f"{steps} ({_CAL_MOTOR.steps_to_deg(steps):.1f} deg)"
     assert connected is True
 
 
@@ -197,3 +202,18 @@ def test_handle_key_directional_jogs(client):
         zeroer.handle_key(ord(key), 1.0)
         after = getter()
         assert after - before == factor * motor.deg_to_steps(1.0)
+
+
+def test_format_pos_renders_axis_degrees():
+    # The user-facing round trip: a 30 deg jog becomes deg_to_steps(30)
+    # motor steps, and reading that step count back must display
+    # "30.0 deg" — the same calibration the mover uses, not a duplicated
+    # copy. Locks the steps<->deg display contract.
+    steps = _CAL_MOTOR.deg_to_steps(30.0)
+    assert _format_pos(steps) == f"{steps} (30.0 deg)"
+    # Positions are published as floats (PicoMotor._motor_redis_handler
+    # casts the firmware's int step counts); they round to int steps.
+    assert _format_pos(float(steps)) == f"{steps} (30.0 deg)"
+    # Non-numeric sentinels (e.g. a missing position key) pass through
+    # verbatim so a partial status dict never crashes the UI.
+    assert _format_pos("?") == "?"

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -96,11 +96,10 @@ def test_status_text_reflects_live_metadata(client):
     )
     expected_az = zeroer._reader.get("motor")["az_pos"]
     az, _, connected = zeroer.status_text()
-    # status_text renders the raw step count plus the equivalent axis
-    # degrees, so an operator jogging in degrees can read the step
-    # counter back in the same unit.
-    steps = int(round(expected_az))
-    assert az == f"{steps} ({_CAL_MOTOR.steps_to_deg(steps):.1f} deg)"
+    # Detailed rendering behavior belongs in
+    # test_format_pos_renders_axis_degrees; here we only verify that
+    # status_text reflects the live metadata using the shared formatter.
+    assert az == _format_pos(expected_az)
     assert connected is True
 
 


### PR DESCRIPTION
## Problem

In `motor_manual`, the jog step is labelled in **degrees** but `az_pos`/`el_pos` were displayed as **raw motor step counts** — two different units shown side by side with nothing to indicate it. A 30 deg jog reads back as ~1883 steps, which looks like a unit bug.

It isn't: positions are raw step counts, and the conversion is **62.78 steps/deg** (1.8 deg stepper × 113:1 gear, `microstep=1`) in `picohost.motor.PicoMotor.deg_to_steps`. So 30 deg → 1883 steps, and the motor turning ~9.4 revolutions for a 30 deg axis move is the worm-gear reduction doing its job — all expected.

## Change

Render positions as `"<steps> (<deg> deg)"` so the operator reads the step counter back in the same unit they jog in:

```
Jog step: 30.0 deg
AZ pos: 1883 (30.0 deg)
EL pos: 0 (0.0 deg)
```

- Degrees come from a serial-less `PicoMotor` (`__new__` bypass, same pattern as `contract_tests.test_producer_contracts`) carrying picohost's default calibration constants, pulled from the constructor signature. `PicoManager` builds the real motor with those exact defaults and never overrides them, so the display reuses the mover's own `steps_to_deg` rather than duplicating the gear math, and auto-follows any picohost default change.
- Non-numeric sentinels (e.g. `"?"` for a missing key) pass through verbatim so a partial status dict never crashes the UI.

## Tests

- Updated `test_status_text_reflects_live_metadata` for the new format.
- Added `test_format_pos_renders_axis_degrees` locking the 30 deg → 1883 steps → `"30.0 deg"` round trip, plus float-rounding and sentinel edge cases.
- `pytest tests/test_motor_zeroer.py` → 14 passed; ruff check + format clean.

## Not in scope

Whether `microstep=1` / `gear_teeth=113` match the deployed hardware is a picohost-side calibration question. Worth a one-time physical check (command `move_to(az_deg=90)`, measure actual axis rotation); a constant-factor error would point at the `microstep` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)