### PR TITLE
feat(live-status): sunlight-readable themes (Sun/Light/Dark toggle)

### DIFF
--- a/src/eigsep_observing/live_status/static/css/dashboard.css
+++ b/src/eigsep_observing/live_status/static/css/dashboard.css
@@ -1,14 +1,48 @@
+/* Theme tiers. The default ``:root`` block is the Light theme — a
+   fresh tablet boots into it (matches getTheme()'s default in
+   dashboard.js). ``[data-theme="dark"]`` restores the original lab
+   look exactly; ``[data-theme="sun"]`` is the max-contrast tier for
+   direct sunlight. dashboard.js stamps ``data-theme`` on <html> (and a
+   tiny inline <head> script applies the persisted choice before first
+   paint to avoid a flash). Only chrome colors and the event-log text
+   colors change between tiers; the semantic status palette
+   (--ok/--warn/--danger/--stale/--unknown), used as filled tiles with
+   their own text colors, is readable on any background and stays
+   constant. --warn-text/--danger-text exist because the warn amber is
+   fine as a tile fill but too low-contrast as text on a white page. */
 :root {
-  --bg: #111;
-  --fg: #eee;
-  --muted: #999;
-  --card: #1a1a1a;
-  --border: #333;
+  --bg: #ffffff;
+  --fg: #111111;
+  --muted: #555555;
+  --card: #f4f6f8;
+  --border: #cfd4d8;
   --ok: #2d7a2d;
   --warn: #c79b00;
   --danger: #b00020;
   --stale: #555;
   --unknown: #444;
+  --warn-text: #8a6d00;
+  --danger-text: #9b001c;
+}
+
+:root[data-theme="dark"] {
+  --bg: #111;
+  --fg: #eee;
+  --muted: #999;
+  --card: #1a1a1a;
+  --border: #333;
+  --warn-text: #c79b00;
+  --danger-text: #b00020;
+}
+
+:root[data-theme="sun"] {
+  --bg: #ffffff;
+  --fg: #000000;
+  --muted: #333333;
+  --card: #ffffff;
+  --border: #333333;
+  --warn-text: #6e5500;
+  --danger-text: #7a0016;
 }
 
 html, body {
@@ -125,8 +159,8 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
   border-bottom: 1px solid var(--border);
 }
 
-#status-log li.level-30 { color: var(--warn); }
-#status-log li.level-40 { color: var(--danger); }
+#status-log li.level-30 { color: var(--warn-text); }
+#status-log li.level-40 { color: var(--danger-text); }
 
 /* VNA pane: card-header lays out the title and the mode toggle on
    one row so the toggle doesn't push the plot down. */
@@ -139,9 +173,11 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
 
 .card-header h2 { margin: 0; }
 
-.vna-mode-toggle { display: inline-flex; gap: 4px; }
+/* Segmented button group. Shared by the VNA mode toggle and the
+   Sun/Light/Dark theme toggle (.seg-toggle) so both look identical. */
+.vna-mode-toggle, .seg-toggle { display: inline-flex; gap: 4px; }
 
-.vna-mode-btn {
+.vna-mode-btn, .seg-btn {
   background: var(--card);
   color: var(--muted);
   border: 1px solid var(--border);
@@ -151,7 +187,7 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
   cursor: pointer;
 }
 
-.vna-mode-btn.active {
+.vna-mode-btn.active, .seg-btn.active {
   background: var(--ok);
   color: #fff;
   border-color: var(--ok);

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -8,6 +8,66 @@ const PANE_STALE_AGE_S = 10;
 const WIRING_TOGGLE_KEY = "eigsep.useWiringLabels";
 const CALIBRATED_TOGGLE_KEY = "eigsep.useCalibrated";
 const VNA_MODE_KEY = "eigsep.vnaMode";
+const THEME_KEY = "eigsep.theme";
+
+// Dark, saturated, glare-surviving trace colors for the Light and Sun
+// themes. Avoids Plotly's default yellow and pale green, which wash out
+// against a white background in direct sunlight. Dark mode keeps
+// Plotly's default colorway (colorway: null → Plotly decides).
+const LIGHT_COLORWAY = [
+  "#1f4e79", "#b00020", "#186a3b", "#7d3c98",
+  "#b9770e", "#117a8b", "#7a0016", "#1c2833",
+];
+
+// Per-theme Plotly styling. Plotly can't read the CSS variables that
+// drive the page chrome, so plot colors/fonts/line widths live here and
+// are stamped onto the layout objects by applyThemeToLayouts(). The
+// background hex deliberately mirror the CSS --bg/--card values for the
+// matching [data-theme] block — keep them in sync. Sunlight tiers use
+// thicker lines, larger fonts, and a firmer grid (faint grids are the
+// first thing to wash out under glare).
+const THEMES = {
+  sun: {
+    paperBg: "#ffffff", plotBg: "#ffffff", font: "#000000",
+    grid: "#999999", lineWidth: 3, fontSize: 16, colorway: LIGHT_COLORWAY,
+  },
+  light: {
+    paperBg: "#ffffff", plotBg: "#ffffff", font: "#111111",
+    grid: "#cccccc", lineWidth: 2.25, fontSize: 14, colorway: LIGHT_COLORWAY,
+  },
+  dark: {
+    paperBg: "#1a1a1a", plotBg: "#111111", font: "#eeeeee",
+    grid: "#333333", lineWidth: 1.5, fontSize: 12, colorway: null,
+  },
+};
+
+// Theme selector. Default "light" so a freshly-flashed field tablet is
+// readable outdoors without anyone touching it; OS prefers-color-scheme
+// is deliberately ignored (a tablet on a dark-at-night OS must still
+// boot light in the sun). Persisted so the operator's choice — Sun
+// outdoors, Dark in the lab — survives reloads.
+function getTheme() {
+  try {
+    const t = localStorage.getItem(THEME_KEY);
+    return t === "dark" || t === "sun" ? t : "light";
+  } catch (e) {
+    return "light";
+  }
+}
+
+function setTheme(mode) {
+  try {
+    localStorage.setItem(THEME_KEY, mode);
+  } catch (e) {
+    // localStorage unavailable (e.g. private mode); the attribute and
+    // in-memory activeTheme still apply for this session.
+  }
+}
+
+// The active theme's Plotly styling, read by applyThemeToLayouts() and
+// the trace builders. Initialized from the persisted choice; updated by
+// applyTheme() on a toggle.
+let activeTheme = THEMES[getTheme()];
 
 // Wiring-labels toggle. Persisted in localStorage so the user's
 // choice survives reloads; gracefully no-ops when no labels are
@@ -166,9 +226,10 @@ async function fetchJson(path) {
 // 500 MHz real-sampling Nyquist (data tops out at 249.76 MHz) — so
 // the highest tick is the band edge. dtick=25 from tick0=0 puts
 // ticks at 0, 25, ..., 250.
+// gridcolor (here and in every layout below) is stamped by
+// applyThemeToLayouts() from the active theme — see THEMES.
 const corrXaxis = {
   title: "Frequency [MHz]",
-  gridcolor: "#333",
   range: [-5, 250],
   tick0: 0,
   dtick: 25,
@@ -183,16 +244,12 @@ const corrXaxis = {
 // magnitude, well within plotly's autorange comfort zone.
 const magLayoutRaw = {
   margin: { l: 50, r: 20, t: 10, b: 40 },
-  paper_bgcolor: "#1a1a1a",
-  plot_bgcolor: "#111",
-  font: { color: "#eee" },
   xaxis: corrXaxis,
   yaxis: {
     title: "Amplitude [arb. units]",
     type: "log",
     range: [-2, 9],
     exponentformat: "e",
-    gridcolor: "#333",
   },
   showlegend: true,
   legend: { orientation: "h", y: -0.2 },
@@ -203,24 +260,46 @@ const magLayoutCal = {
     title: "Temperature [K]",
     type: "linear",
     autorange: true,
-    gridcolor: "#333",
   },
 };
 
 const phaseLayout = {
   margin: { l: 50, r: 20, t: 10, b: 40 },
-  paper_bgcolor: "#1a1a1a",
-  plot_bgcolor: "#111",
-  font: { color: "#eee" },
   xaxis: corrXaxis,
   yaxis: {
     title: "Phase [deg]",
     range: [-180, 180],
-    gridcolor: "#333",
   },
   showlegend: true,
   legend: { orientation: "h", y: -0.2 },
 };
+
+// Stamp the active theme's colors, fonts, grid, and trace colorway onto
+// every Plotly layout. Called once at startup and again on each theme
+// toggle (Plotly doesn't observe CSS, so a re-render is required). Note
+// magLayoutCal was built by spreading magLayoutRaw, which shallow-copies
+// the value fields but shares the xaxis (corrXaxis) object by reference;
+// we therefore set xaxis grid once via corrXaxis and the per-layout
+// fields on each object explicitly.
+function applyThemeToLayouts() {
+  const t = activeTheme;
+  for (const L of [magLayoutRaw, magLayoutCal, phaseLayout, vnaLayout]) {
+    L.paper_bgcolor = t.paperBg;
+    L.plot_bgcolor = t.plotBg;
+    L.font = { color: t.font, size: t.fontSize };
+    if (t.colorway) {
+      L.colorway = t.colorway;
+    } else {
+      delete L.colorway;
+    }
+  }
+  corrXaxis.gridcolor = t.grid;
+  magLayoutRaw.yaxis.gridcolor = t.grid;
+  magLayoutCal.yaxis.gridcolor = t.grid;
+  phaseLayout.yaxis.gridcolor = t.grid;
+  vnaLayout.xaxis.gridcolor = t.grid;
+  vnaLayout.yaxis.gridcolor = t.grid;
+}
 
 const RAD_TO_DEG = 180 / Math.PI;
 
@@ -279,7 +358,7 @@ function updateCorr(corr) {
         type: "scatter",
         mode: "lines",
         name,
-        line: { width: 1.5 },
+        line: { width: activeTheme.lineWidth },
       });
     }
     if (p.phase) {
@@ -289,7 +368,7 @@ function updateCorr(corr) {
         type: "scatter",
         mode: "lines",
         name,
-        line: { width: 1.5 },
+        line: { width: activeTheme.lineWidth },
       });
     }
   }
@@ -322,14 +401,10 @@ function updateCorr(corr) {
 
 const vnaLayout = {
   margin: { l: 50, r: 20, t: 10, b: 40 },
-  paper_bgcolor: "#1a1a1a",
-  plot_bgcolor: "#111",
-  font: { color: "#eee" },
-  xaxis: { title: "Frequency [MHz]", gridcolor: "#333" },
+  xaxis: { title: "Frequency [MHz]" },
   yaxis: {
     title: "|S11| [dB]",
     autorange: true,
-    gridcolor: "#333",
   },
   showlegend: false,
 };
@@ -386,7 +461,7 @@ function updateVna(vna) {
       y: vna.s11_db,
       type: "scatter",
       mode: "lines",
-      line: { width: 1.5 },
+      line: { width: activeTheme.lineWidth },
     },
   ];
   if (!vnaPlotInitialized) {
@@ -762,6 +837,7 @@ function renderStatusLog(entries) {
 // re-render immediately without waiting up to POLL_MS for the next tick.
 let lastCorr = null;
 let lastAdc = null;
+let lastVna = null;
 
 async function tick() {
   try {
@@ -779,6 +855,7 @@ async function tick() {
     ]);
     lastCorr = corr.data;
     lastAdc = adc.data;
+    lastVna = vna.data;
     updateHealth(health.data, file.data);
     updateCorr(corr.data);
     renderTempctrlTiles(metadata.data, null);
@@ -818,6 +895,44 @@ function initCalibratedToggle() {
   });
 }
 
+// Switch the active theme: update the in-memory styling, flip the
+// <html data-theme> attribute (CSS chrome follows instantly), restamp
+// the Plotly layouts, and re-render the plots from their cached
+// payloads so the new colors/widths/fonts take effect without waiting
+// for the next poll. Plotly doesn't read CSS, so this re-render is the
+// only way the plot styling tracks the toggle.
+function applyTheme(mode) {
+  activeTheme = THEMES[mode] || THEMES.light;
+  document.documentElement.setAttribute("data-theme", mode);
+  applyThemeToLayouts();
+  if (lastCorr) updateCorr(lastCorr); // also re-renders the phase plot
+  if (lastVna) updateVna(lastVna);
+}
+
+function initThemeToggle() {
+  const buttons = document.querySelectorAll("#theme-toggle .seg-btn");
+  if (!buttons.length) return;
+  const highlight = (mode) => {
+    for (const btn of buttons) {
+      const on = btn.dataset.themeMode === mode;
+      btn.classList.toggle("active", on);
+      btn.setAttribute("aria-pressed", on ? "true" : "false");
+    }
+  };
+  const current = getTheme();
+  applyThemeToLayouts(); // stamp the persisted theme before the first render
+  highlight(current);
+  for (const btn of buttons) {
+    btn.addEventListener("click", () => {
+      const mode = btn.dataset.themeMode;
+      if (!THEMES[mode]) return;
+      setTheme(mode);
+      applyTheme(mode);
+      highlight(mode);
+    });
+  }
+}
+
 function initVnaModeToggle() {
   const buttons = document.querySelectorAll(".vna-mode-btn");
   if (!buttons.length) return;
@@ -841,5 +956,6 @@ function initVnaModeToggle() {
 initWiringToggle();
 initCalibratedToggle();
 initVnaModeToggle();
+initThemeToggle();
 tick();
 setInterval(tick, POLL_MS);

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -3,6 +3,20 @@
 <head>
 <meta charset="utf-8">
 <title>EIGSEP live status</title>
+<script>
+  // Apply the persisted display theme before first paint so returning
+  // Dark/Sun users don't see a flash of the default Light theme. This
+  // deliberately mirrors THEME_KEY / getTheme() in dashboard.js; keep
+  // the key and the allowed values in sync with that module.
+  (function () {
+    var t = "light";
+    try {
+      var saved = localStorage.getItem("eigsep.theme");
+      if (saved === "dark" || saved === "sun") t = saved;
+    } catch (e) { /* localStorage unavailable; fall back to light */ }
+    document.documentElement.setAttribute("data-theme", t);
+  })();
+</script>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
 <script src="{{ url_for('plotly_js') }}"></script>
 </head>
@@ -25,6 +39,11 @@
       <input type="checkbox" id="toggle-calibrated">
       <span>Calibrated (T_sky)</span>
     </label>
+    <div class="seg-toggle" id="theme-toggle" role="group" aria-label="Display theme" title="Display theme. Light (default) and Sun (max contrast) are for outdoor/sunlight readability; Dark is the original lab look. Your choice is remembered on this browser.">
+      <button type="button" class="seg-btn" data-theme-mode="sun" aria-pressed="false">Sun</button>
+      <button type="button" class="seg-btn" data-theme-mode="light" aria-pressed="false">Light</button>
+      <button type="button" class="seg-btn" data-theme-mode="dark" aria-pressed="false">Dark</button>
+    </div>
   </div>
   <div id="calibration-bar" class="cal-bar" hidden></div>
 </header>

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1283,6 +1283,26 @@ def test_index_renders_with_aggregator_cfg(client):
     assert b"EIGSEP live status" in r.data
 
 
+def test_index_serves_theme_toggle(client):
+    """The Sun/Light/Dark theme control is present in the page.
+
+    A markup-presence guard: the dashboard's theming lives entirely in
+    HTML/CSS/JS (no JS test runner in this repo), so this is the cheapest
+    regression catch if the control is dropped from the template. Asserts
+    all three tier buttons plus the pre-paint theme bootstrap so a
+    returning Dark/Sun user doesn't flash the default Light theme.
+    """
+    r = client.get("/")
+    body = r.data
+    assert b'id="theme-toggle"' in body
+    for mode in (b"sun", b"light", b"dark"):
+        assert b'data-theme-mode="' + mode + b'"' in body
+    # The inline <head> bootstrap that applies the persisted theme before
+    # first paint reads this localStorage key; keep it in sync with
+    # THEME_KEY in dashboard.js.
+    assert b"eigsep.theme" in body
+
+
 def test_plotly_js_served_from_pypi_package(client):
     r = client.get("/plotly.min.js")
     assert r.status_code == 200


### PR DESCRIPTION
## What & why

In bright sunlight the dashboard's dark background washes out (dark pixels reflect ambient glare to gray, collapsing contrast against the thin bright traces). Light-on-white is the established win for outdoor/sunlit screens. This adds a **three-tier display theme** so the field tablet is readable in the sun while the lab keeps the dark look.

- **Light** — new default. White bg, dark text, curated dark-saturated trace palette, thicker lines, larger fonts. A freshly-flashed tablet boots into this (readable outdoors with nobody touching it).
- **Sun** — max-contrast tier for direct sunlight: pure black-on-white, fattest lines, largest ticks, firmer grid.
- **Dark** — the original lab look, preserved **exactly** (Plotly default palette, original chrome colors).

A segmented `[Sun][Light][Dark]` control in the header (reuses the existing VNA-mode button styling) switches between them. Choice persists in `localStorage`; OS `prefers-color-scheme` is deliberately **ignored** — a tablet on a dark-at-night OS must still boot light in the sun.

## How

- **Chrome** is themed via CSS: `:root` now holds the Light palette; `[data-theme="dark"]` / `[data-theme="sun"]` override. New `--warn-text` / `--danger-text` vars give the event-log warn/error lines a darker, readable variant on white (the warn amber is fine as a tile fill but unreadable as text on white).
- **Plots** can't read CSS, so plot styling (bg, font color/size, grid, line width, trace colorway) lives in a JS `THEMES` table, stamped onto the Plotly layouts and re-rendered on toggle. Light/Sun use a curated dark-saturated colorway that avoids Plotly's default yellow and pale green (which vanish on white); Dark keeps the default.
- A tiny inline `<head>` script applies the persisted theme before first paint, avoiding a flash of Light for returning Dark/Sun users.

## Verification

- `tests/test_live_status_app.py`: **51/51 pass**, including a new markup guard (`test_index_serves_theme_toggle`) asserting all three tier buttons + the pre-paint bootstrap are served.
- Drove the **real** `dashboard.js` theme functions in a stubbed context: each tier stamps the exact bg/font/grid/line-width/colorway onto all three plots (mag, phase, VNA); Dark keeps the default palette.
- Rendered all three tiers with real Plotly to screenshots (Light, Sun, Dark) to confirm the visual result.

> Note: the real readability test is the actual field/lab screen under real light — the palettes here are a strong starting point and easy to tune (all values centralized in the CSS `[data-theme]` blocks and the JS `THEMES` table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)