### PR TITLE
fix(live-status): persist corr legend toggles across integrations

### DIFF
--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -196,6 +196,16 @@ const magLayoutRaw = {
   },
   showlegend: true,
   legend: { orientation: "h", y: -0.2 },
+  // Persist user-driven UI state (legend trace toggles, zoom/pan) across
+  // the per-integration ``Plotly.react`` updates. A constant ``uirevision``
+  // tells plotly "this is the same figure, keep what the user touched";
+  // without it react resets a legend-hidden trace back to visible on the
+  // next integration (~1 s). New y data still flows in each react (data
+  // arrays aren't persisted), and cal-mode autorange still applies because
+  // the user never manually edited the axes. The same value carries into
+  // ``magLayoutCal`` via the spread below, so toggling calibrated mode does
+  // not clear the user's legend selection either.
+  uirevision: "corr-mag",
 };
 const magLayoutCal = {
   ...magLayoutRaw,
@@ -220,6 +230,8 @@ const phaseLayout = {
   },
   showlegend: true,
   legend: { orientation: "h", y: -0.2 },
+  // See magLayoutRaw: keep legend toggles / zoom across react updates.
+  uirevision: "corr-phase",
 };
 
 const RAD_TO_DEG = 180 / Math.PI;


### PR DESCRIPTION
## Summary

In the live-status dashboard, clicking a correlation plot's legend entry hides that trace — but only for ~1 second. On the next integration the trace reappears.

**Cause:** `updateCorr` redraws the corr mag/phase plots every integration with `Plotly.react` (`dashboard.js`), rebuilding the trace array from scratch with no `visible` field. A legend click sets `visible: "legendonly"` (user-driven UI state), but without a `uirevision` on the layout, `Plotly.react` treats each redraw as a fresh figure and discards that interaction.

**Fix:** add a constant `uirevision` to `magLayoutRaw` (inherited by `magLayoutCal` via the spread) and to `phaseLayout`. A stable `uirevision` tells Plotly "same figure, keep what the user touched," so legend toggles — and as a bonus zoom/pan — persist across the per-integration updates until the entry is clicked again.

Data arrays aren't part of Plotly's persisted set, so new spectra still stream in each integration; calibrated-mode autorange is unaffected since the user never manually edits the axes. Toggling calibrated mode also no longer clears the legend selection (the shared `uirevision` carries through the `magLayoutCal` spread).

## Testing

Frontend-only change. The repo's test suite is pytest against the Flask/Python backend with no JS test harness, so there's nothing to add a unit test to. Verified by reasoning about Plotly's `uirevision` semantics; manual check is: click a legend entry and confirm it stays hidden across several integrations, then click again to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)