### PR TITLE
feat(motor): zero confirmation + configurable scan grid

### DIFF
--- a/scripts/motor_control.py
+++ b/scripts/motor_control.py
@@ -5,6 +5,11 @@ Runs a beam scan through ``PicoManager`` via Redis — no direct serial
 to the motor pico, so the manager service stays up throughout. Log
 start/end boundaries to the shared status stream so the ground
 observer sees when a scan is active.
+
+The scan grid is configured per axis from the command line via
+``--az_start/--az_stop/--az_step`` and the ``--el_*`` equivalents
+(degrees). Bounds are inclusive of the stop endpoint, so e.g.
+``--az_start 0 --az_stop 180 --az_step 5`` sweeps 0..180 in 5 deg steps.
 """
 
 from argparse import ArgumentParser
@@ -24,7 +29,30 @@ configure_eig_logger(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _axis_range(start, stop, step):
+    """Build one scan axis from CLI bounds.
+
+    Grid points run from ``start`` to ``stop`` spaced by ``step``
+    degrees, *including* the ``stop`` endpoint when it lands on the step
+    grid (so ``0 -> 180`` reaches 180). A ``stop`` that doesn't land on
+    the grid stops at the last point ``<= stop`` rather than
+    overshooting the mechanical boundary. Direction is always ascending;
+    the serpentine traversal in ``MotorClient.scan`` handles sweep
+    direction, so an inverted ``stop < start`` is a user error.
+    """
+    if step <= 0:
+        raise ValueError(f"step must be positive, got {step}")
+    if stop < start:
+        raise ValueError(f"stop ({stop}) must be >= start ({start})")
+    # +step/2 epsilon so an on-grid stop survives float drift.
+    return np.arange(start, stop + step / 2.0, step)
+
+
 def main(transport, args):
+    # Build (and validate) the grid before touching hardware so bad
+    # bounds fail fast without opening a run_tag session.
+    az_range = _axis_range(args.az_start, args.az_stop, args.az_step)
+    el_range = _axis_range(args.el_start, args.el_stop, args.el_step)
     require_pico(PicoProxy("motor", transport, source="motor_control"))
     with run_tag.session(transport, "motor_control"):
         status = StatusWriter(transport)
@@ -33,13 +61,25 @@ def main(transport, args):
         started = time.monotonic()
         status.send("motor_control started")
         logger.info("motor_control started")
+        logger.info(
+            "Scan grid: az %g..%g step %g (%d pts), "
+            "el %g..%g step %g (%d pts)",
+            args.az_start,
+            args.az_stop,
+            args.az_step,
+            len(az_range),
+            args.el_start,
+            args.el_stop,
+            args.el_step,
+            len(el_range),
+        )
 
         try:
             motor.set_delay()
             motor.halt()
             motor.scan(
-                az_range_deg=np.linspace(-180.0, 180.0, 10),
-                el_range_deg=np.linspace(-180.0, 180.0, 10),
+                az_range_deg=az_range,
+                el_range_deg=el_range,
                 el_first=args.el_first,
                 repeat_count=args.count,
                 pause_s=args.pause_s,
@@ -68,6 +108,42 @@ def _parse_args():
         "--el_first",
         action="store_true",
         help="Scan az as outer loop (el is the fast axis); default is az fast.",
+    )
+    parser.add_argument(
+        "--az_start",
+        type=float,
+        default=-180.0,
+        help="Azimuth scan start in degrees (default: -180).",
+    )
+    parser.add_argument(
+        "--az_stop",
+        type=float,
+        default=180.0,
+        help="Azimuth scan stop in degrees, inclusive (default: 180).",
+    )
+    parser.add_argument(
+        "--az_step",
+        type=float,
+        default=5.0,
+        help="Azimuth grid step size in degrees (default: 5).",
+    )
+    parser.add_argument(
+        "--el_start",
+        type=float,
+        default=-180.0,
+        help="Elevation scan start in degrees (default: -180).",
+    )
+    parser.add_argument(
+        "--el_stop",
+        type=float,
+        default=180.0,
+        help="Elevation scan stop in degrees, inclusive (default: 180).",
+    )
+    parser.add_argument(
+        "--el_step",
+        type=float,
+        default=5.0,
+        help="Elevation grid step size in degrees (default: 5).",
     )
     parser.add_argument(
         "--count",

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -1,15 +1,18 @@
 """
 Interactive motor zeroing UI.
 
-Jog the motors into the desired home position, then Enter to zero
-the step counters. After zeroing, ``motor_control.py`` treats the
-current physical position as ``(0, 0)``.
+Jog the motors into the desired home position, then Enter to begin
+zeroing the step counters. Zeroing is two-step: Enter arms a
+confirmation and 'y' commits it, so an accidental Enter can't redefine
+home. After zeroing, ``motor_control.py`` treats the current physical
+position as ``(0, 0)``.
 
 Controls:
     u / d  - jog elevation up / down
     l / r  - jog azimuth left / right
     + / -  - increase / decrease jog step size
-    Enter  - zero step counters and exit
+    Enter  - arm zero confirmation
+    y      - confirm and zero (after Enter); any other key cancels
     q      - quit without zeroing
 """
 
@@ -41,7 +44,13 @@ def _render(screen, zeroer, deg):
         screen.addstr(4, 0, "EL pos: ---")
     screen.addstr(6, 0, "u/d = jog EL | l/r = jog AZ")
     screen.addstr(7, 0, "+/- = change step size")
-    screen.addstr(8, 0, "Enter = zero and exit | q = quit")
+    screen.addstr(8, 0, "Enter = zero (asks to confirm) | q = quit")
+    if zeroer.pending_zero:
+        screen.addstr(
+            10,
+            0,
+            ">>> ZERO HERE? 'y' to confirm, any other key to cancel <<<",
+        )
     screen.refresh()
 
 

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -86,10 +86,20 @@ class MotorZeroer:
             "el_dn_delay_us": el_dn_delay_us,
         }
         self.logger = logger
+        # Two-step zero guard: Enter arms this, a deliberate 'y' commits.
+        self._pending_zero = False
 
     @property
     def is_available(self):
         return self._proxy.is_available
+
+    @property
+    def pending_zero(self):
+        """True while a zero confirmation is armed — Enter has been
+        pressed and we are awaiting a deliberate 'y'. The curses layer
+        reads this to render the confirmation prompt.
+        """
+        return self._pending_zero
 
     def set_delay(self, **overrides):
         self._delay_kwargs.update(overrides)
@@ -165,20 +175,28 @@ class MotorZeroer:
             ``new_deg`` — possibly-adjusted jog step size.
             ``should_exit`` — True when the caller should break the
             input loop.
-            ``zeroed`` — True if this keystroke triggered a successful
-            zeroing (Enter). Callers use it to choose the exit message.
+            ``zeroed`` — True if this keystroke committed a successful
+            zeroing. Callers use it to choose the exit message.
+
+        Zeroing is two-step: Enter *arms* a confirmation
+        (``pending_zero`` becomes True) but does not zero. While armed,
+        a deliberate ``y``/``Y`` commits the zero (and exits); any other
+        key cancels back to jogging. This guards an accidental Enter
+        from redefining scan home.
         """
         if ch == -1:
+            # No keypress this tick — leave any armed prompt intact so a
+            # ~100ms idle getch() doesn't silently cancel it.
             return deg_state, False, False
+        if self._pending_zero:
+            return self._confirm_zero(ch, deg_state)
         if ch == _KEY_ENTER:
             if not self.is_available:
                 return deg_state, False, False
-            try:
-                self.zero()
-            except (RuntimeError, TimeoutError) as exc:
-                self.logger.warning("zero failed: %s", exc)
-                return deg_state, False, False
-            return deg_state, True, True
+            # Arm the confirmation; the real zero happens in
+            # _confirm_zero once the operator presses 'y'.
+            self._pending_zero = True
+            return deg_state, False, False
         if not (0 <= ch < 256):
             return deg_state, False, False
         key = chr(ch).lower()
@@ -208,3 +226,25 @@ class MotorZeroer:
             except (RuntimeError, TimeoutError) as exc:
                 self.logger.warning("jog %s failed: %s", key, exc)
         return deg_state, False, False
+
+    def _confirm_zero(self, ch, deg_state):
+        """Resolve an armed zero prompt for one keystroke.
+
+        ``y``/``Y`` commits the zero and signals exit; any other key
+        cancels back to jogging. The prompt clears either way (callers
+        keep it armed only across ``-1`` no-input ticks, handled in
+        :meth:`handle_key`). A cancelling key is swallowed here — it is
+        not re-interpreted as a jog or step-size change.
+        """
+        key = chr(ch).lower() if 0 <= ch < 256 else None
+        self._pending_zero = False
+        if key != "y":
+            return deg_state, False, False
+        if not self.is_available:
+            return deg_state, False, False
+        try:
+            self.zero()
+        except (RuntimeError, TimeoutError) as exc:
+            self.logger.warning("zero failed: %s", exc)
+            return deg_state, False, False
+        return deg_state, True, True

--- a/tests/test_motor_scripts.py
+++ b/tests/test_motor_scripts.py
@@ -10,12 +10,14 @@ the dummy transport used everywhere else.
 
 import importlib.util
 import json
+import sys
 import threading
 import time
 from argparse import Namespace
 from pathlib import Path
 
 import numpy as np
+import pytest
 import yaml
 
 from eigsep_observing import run_tag
@@ -40,22 +42,89 @@ def _load(name):
     raise FileNotFoundError(f"{name}.py not found in {SCRIPT_DIRS}")
 
 
-def test_motor_control_main_runs_short_scan(client, monkeypatch):
-    """``motor_control.main`` runs a full scan to completion against
-    the dummy manager. Patch the hard-coded linspace to a small grid
-    so the test finishes quickly."""
-    mc = _load("motor_control")
-    small = np.array([-1.0, 0.0, 1.0])
-    orig_linspace = mc.np.linspace
-    monkeypatch.setattr(
-        mc.np,
-        "linspace",
-        lambda *a, **kw: (
-            small if a and a[0] == -180.0 else orig_linspace(*a, **kw)
-        ),
+def _scan_args(**overrides):
+    """A small-grid arg namespace for driving ``motor_control.main``
+    quickly. Grid bounds default to a 3-point az/el sweep."""
+    base = dict(
+        el_first=False,
+        count=1,
+        pause_s=None,
+        sleep_s=None,
+        az_start=-1.0,
+        az_stop=1.0,
+        az_step=1.0,
+        el_start=-1.0,
+        el_stop=1.0,
+        el_step=1.0,
     )
-    args = Namespace(el_first=False, count=1, pause_s=None, sleep_s=None)
-    mc.main(client.transport, args)
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_motor_control_main_runs_short_scan(client):
+    """``motor_control.main`` runs a full scan to completion against the
+    dummy manager, building the grid from CLI args (no numpy patching)."""
+    mc = _load("motor_control")
+    mc.main(client.transport, _scan_args())
+
+
+def test_motor_control_axis_range_inclusive_endpoint():
+    """``_axis_range`` includes the stop endpoint when it lands on the
+    step grid, so ``0 -> 180`` actually reaches 180."""
+    mc = _load("motor_control")
+    rng = mc._axis_range(0.0, 180.0, 5.0)
+    assert rng[0] == 0.0
+    assert rng[-1] == 180.0
+    assert len(rng) == 37
+    np.testing.assert_allclose(np.diff(rng), 5.0)
+
+
+def test_motor_control_axis_range_offgrid_stop_does_not_overshoot():
+    """A stop that doesn't land on the grid stops at the last point
+    <= stop rather than overshooting the boundary."""
+    mc = _load("motor_control")
+    rng = mc._axis_range(0.0, 10.0, 3.0)
+    np.testing.assert_allclose(rng, [0.0, 3.0, 6.0, 9.0])
+
+
+def test_motor_control_axis_range_rejects_nonpositive_step():
+    mc = _load("motor_control")
+    with pytest.raises(ValueError):
+        mc._axis_range(0.0, 10.0, 0.0)
+
+
+def test_motor_control_axis_range_rejects_inverted_bounds():
+    mc = _load("motor_control")
+    with pytest.raises(ValueError):
+        mc._axis_range(180.0, 0.0, 5.0)
+
+
+def test_motor_control_parse_args_accepts_scan_bounds(monkeypatch):
+    """The new per-axis bound/step flags parse as floats into the
+    underscore namespace ``main`` consumes."""
+    mc = _load("motor_control")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "motor_control",
+            "--az_start",
+            "0",
+            "--az_stop",
+            "180",
+            "--az_step",
+            "10",
+            "--el_start",
+            "-45",
+            "--el_stop",
+            "45",
+            "--el_step",
+            "15",
+        ],
+    )
+    args = mc._parse_args()
+    assert (args.az_start, args.az_stop, args.az_step) == (0.0, 180.0, 10.0)
+    assert (args.el_start, args.el_stop, args.el_step) == (-45.0, 45.0, 15.0)
 
 
 def test_motor_manual_helpers_exist():

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -167,7 +167,13 @@ def test_handle_key_plus_recovers_integer_steps_from_floor(client):
     assert deg == 2.0
 
 
-def test_handle_key_enter_zeroes(client):
+def test_handle_key_enter_arms_confirmation_without_zeroing(client):
+    """A single Enter must NOT zero — it arms a confirmation prompt.
+
+    Zeroing redefines scan home, so an accidental Enter (or a new
+    operator who doesn't know what Enter does) must not be able to
+    trigger it in one keystroke.
+    """
     zeroer = _zeroer(client.transport)
     motor = client._manager.picos["motor"]
     zeroer.jog_az(2.0)
@@ -178,14 +184,82 @@ def test_handle_key_enter_zeroes(client):
         ),
         timeout=3.0,
     )
+    offset = motor._emulator.azimuth.target_pos
+    assert offset != 0  # precondition: we are off-home
     _, should_exit, zeroed = zeroer.handle_key(_KEY_ENTER, 1.0)
+    assert zeroer.pending_zero is True
+    assert should_exit is False
+    assert zeroed is False
+    # No reset happened — position is untouched.
+    assert motor._emulator.azimuth.target_pos == offset
+
+
+def test_handle_key_confirm_y_zeroes_and_exits(client):
+    zeroer = _zeroer(client.transport)
+    motor = client._manager.picos["motor"]
+    zeroer.jog_az(2.0)
+    assert _wait_until(
+        lambda: (
+            motor._emulator.azimuth.position
+            == motor._emulator.azimuth.target_pos
+        ),
+        timeout=3.0,
+    )
+    zeroer.handle_key(_KEY_ENTER, 1.0)  # arm
+    _, should_exit, zeroed = zeroer.handle_key(ord("y"), 1.0)
     assert should_exit is True
     assert zeroed is True
+    assert zeroer.pending_zero is False
     assert _wait_until(
         lambda: motor._emulator.azimuth.position == 0,
         timeout=2.0,
     )
     assert motor._emulator.azimuth.target_pos == 0
+
+
+def test_handle_key_confirm_uppercase_y_also_zeroes(client):
+    zeroer = _zeroer(client.transport)
+    zeroer.handle_key(_KEY_ENTER, 1.0)  # arm
+    _, should_exit, zeroed = zeroer.handle_key(ord("Y"), 1.0)
+    assert should_exit is True
+    assert zeroed is True
+
+
+def test_handle_key_pending_other_key_cancels_without_zeroing(client):
+    """While the prompt is armed, any non-'y' key cancels it and is
+    otherwise swallowed — it must neither zero nor execute as a jog.
+    """
+    zeroer = _zeroer(client.transport)
+    motor = client._manager.picos["motor"]
+    zeroer.jog_az(2.0)
+    assert _wait_until(
+        lambda: (
+            motor._emulator.azimuth.position
+            == motor._emulator.azimuth.target_pos
+        ),
+        timeout=3.0,
+    )
+    offset = motor._emulator.azimuth.target_pos
+    zeroer.handle_key(_KEY_ENTER, 1.0)  # arm
+    # 'l' is normally a jog-left; while armed it must only cancel.
+    _, should_exit, zeroed = zeroer.handle_key(ord("l"), 1.0)
+    assert zeroer.pending_zero is False
+    assert should_exit is False
+    assert zeroed is False
+    # Unchanged target proves neither a zero nor a jog fired.
+    assert motor._emulator.azimuth.target_pos == offset
+
+
+def test_handle_key_pending_no_input_preserves_prompt(client):
+    """``getch()`` returns -1 every ~100ms when idle; that must keep the
+    confirmation prompt armed rather than silently cancelling it.
+    """
+    zeroer = _zeroer(client.transport)
+    zeroer.handle_key(_KEY_ENTER, 1.0)  # arm
+    _, should_exit, zeroed = zeroer.handle_key(-1, 1.0)
+    assert zeroer.pending_zero is True
+    assert should_exit is False
+    assert zeroed is False
 
 
 def test_handle_key_directional_jogs(client):


### PR DESCRIPTION
Two operator-facing motor bring-up improvements, surfaced while debugging the motor on hardware.

## 1. `motor_manual.py` — confirm before zeroing
Pressing Enter used to immediately zero the step counters, which redefines scan home. A stray or doubled Enter (or a new operator) could redefine home in a single keystroke — potentially catastrophic, since the scan then sweeps relative to the wrong origin.

Now zeroing is **two-step**:
- **Enter** arms a confirmation: `>>> ZERO HERE? 'y' to confirm, any other key to cancel <<<`
- **`y`/`Y`** commits the zero and exits; **any other key** cancels back to jogging (and is swallowed — a cancel keypress won't also jog).
- An idle no-input tick (`getch()` → -1 every ~100 ms) keeps the prompt armed rather than silently dismissing it.

The two-step guard lives entirely in `MotorZeroer.handle_key` / `_confirm_zero` (the unit-testable state machine); the curses frame only renders the prompt via the new `pending_zero` property.

## 2. `motor_control.py` — configurable per-axis scan grid
Replaced the hard-coded `np.linspace(-180, 180, 10)` grid with per-axis CLI flags so the scan range and resolution are easy to change:

```bash
# az sweeps 0,5,...,180 (inclusive of 180); el keeps its ±180/5 default
python scripts/motor_control.py --az_start 0 --az_stop 180 --az_step 5

# pin one axis by setting start == stop (single-point axis)
python scripts/motor_control.py --az_start 0 --az_stop 180 --az_step 5 \
    --el_start 0 --el_stop 0
```

- `--az_start/--az_stop/--az_step` + `--el_*` equivalents, all in degrees.
- Stop endpoint is **inclusive** when it lands on the grid (`0 -> 180` reaches 180); an off-grid stop stops at the last point `<= stop` rather than overshooting the mechanical boundary.
- The `_axis_range` helper validates `step > 0` and `stop >= start`, failing fast with a clear `ValueError` before any hardware is touched. The chosen grid is logged at startup.
- Defaults reproduce a full ±180 sweep at 5°.

## Test plan
- `tests/test_motor_zeroer.py` — **18 passed** (5 new: arm-without-zeroing, `y` commits, uppercase `Y`, non-`y` cancels-without-jog, no-input preserves prompt). New tests watched fail first (`AttributeError: pending_zero`) before implementing.
- `tests/test_motor_scripts.py` — **15 passed** (5 new for `_axis_range` inclusivity/overshoot/validation + the parse-args wiring; the existing run-scan smoke test now drives the grid from args instead of monkeypatching numpy).
- `ruff check` + `ruff format --check` clean.

Both changes are bring-up tooling under `scripts/` and follow the `scripts/CLAUDE.md` contract (no `PandaClient`, no heartbeat, command through `PicoProxy`). Kept jointly since they're closely related motor bring-up improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)