### PR TITLE
feat(motor): go-home control in motor_manual + Ctrl-C home prompt in scan

### DIFF
--- a/scripts/motor_control.py
+++ b/scripts/motor_control.py
@@ -48,6 +48,33 @@ def _axis_range(start, stop, step):
     return np.arange(start, stop + step / 2.0, step)
 
 
+def _prompt_go_home(motor):
+    """On a Ctrl-C interrupt, offer to drive back to (0, 0).
+
+    Defaults to *No* so an interrupt leaves the motors halted in place
+    (the safe abort) unless the operator explicitly opts in. A
+    non-interactive stdin (``EOFError``) or a second Ctrl-C
+    (``KeyboardInterrupt``) is treated as No. When confirmed, the same
+    ``MotorClient.home`` primitive ``motor_manual.py`` uses drives the
+    return; a Ctrl-C during that move aborts it.
+    """
+    try:
+        answer = input("Go home (0,0)? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        logger.info("Leaving motors in place.")
+        return
+    if answer not in ("y", "yes"):
+        logger.info("Leaving motors in place.")
+        return
+    logger.info("Returning to home (0, 0)...")
+    try:
+        motor.home()
+    except KeyboardInterrupt:
+        logger.info("Home move aborted.")
+    except (TimeoutError, RuntimeError) as exc:
+        logger.error("Home move failed: %s", exc)
+
+
 def main(transport, args):
     # Build (and validate) the grid before touching hardware so bad
     # bounds fail fast without opening a run_tag session.
@@ -87,6 +114,7 @@ def main(transport, args):
             )
         except KeyboardInterrupt:
             logger.info("Scan interrupted by user")
+            _prompt_go_home(motor)
         except (TimeoutError, RuntimeError) as exc:
             logger.error("Motor scan aborted: %s", exc)
         finally:

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -11,6 +11,7 @@ Controls:
     u / d  - jog elevation up / down
     l / r  - jog azimuth left / right
     + / -  - increase / decrease jog step size
+    h      - go home: drive both axes to step 0 (any key cancels)
     Enter  - arm zero confirmation
     y      - confirm and zero (after Enter); any other key cancels
     q      - quit without zeroing
@@ -43,9 +44,15 @@ def _render(screen, zeroer, deg):
         screen.addstr(3, 0, "AZ pos: DISCONNECTED (waiting for reconnect)")
         screen.addstr(4, 0, "EL pos: ---")
     screen.addstr(6, 0, "u/d = jog EL | l/r = jog AZ")
-    screen.addstr(7, 0, "+/- = change step size")
+    screen.addstr(7, 0, "+/- = change step size | h = go home (0,0)")
     screen.addstr(8, 0, "Enter = zero (asks to confirm) | q = quit")
-    if zeroer.pending_zero:
+    if zeroer.is_homing:
+        screen.addstr(
+            10,
+            0,
+            ">>> HOMING to (0,0)... press any key to cancel <<<",
+        )
+    elif zeroer.pending_zero:
         screen.addstr(
             10,
             0,
@@ -75,6 +82,7 @@ def _curses_main(screen, transport, args):
     except KeyboardInterrupt:
         pass
     finally:
+        zeroer.cancel_home()  # stop any in-flight background home
         zeroer.halt()
 
     if zeroed:

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -108,18 +108,27 @@ class MotorClient:
         except KeyError:
             return None
 
-    def _wait_for_stop(self, timeout=None):
+    def _wait_for_stop(self, timeout=None, stop_event=None):
         """Block until the motor's position equals its target on both axes.
 
         Mirrors the progress-reset stall detection in
         ``picohost.motor.PicoMotor.wait_for_stop``: the timer resets
         whenever ``(az_pos, el_pos)`` changes, so a slow move never
         trips the stall guard.
+
+        If ``stop_event`` is supplied and set, the wait halts the motor
+        and returns mid-move — cooperative cancellation for callers that
+        drive ``home`` from a background thread (``motor_manual.py``).
+        ``scan`` does not pass an event here (it cancels between moves),
+        so its semantics are unchanged.
         """
         timeout = self.stall_timeout_s if timeout is None else timeout
         t = time.monotonic()
         last_pos = None
         while True:
+            if stop_event is not None and stop_event.is_set():
+                self.halt()
+                return
             status = self._motor_status()
             if status is None:
                 if time.monotonic() - t >= timeout:
@@ -166,18 +175,22 @@ class MotorClient:
             "is PicoManager running and the motor pico registered?"
         )
 
-    def _send_and_wait(self, action, *, label, timeout=None, **kwargs):
+    def _send_and_wait(
+        self, action, *, label, timeout=None, stop_event=None, **kwargs
+    ):
         """Send a single move command and block until the motor stops.
 
         The whole send-then-wait window is wrapped in
         ``coord.motion_section`` so per-move serialization (when
         enabled) is enforced at the lowest level — every public mover
         on this class composes from this helper, so neither callers
-        nor subclasses have to remember to take the lock.
+        nor subclasses have to remember to take the lock. ``stop_event``
+        is forwarded to :meth:`_wait_for_stop` for cooperative
+        cancellation.
         """
         with self._coord.motion_section(label=label):
             self._proxy.send_command(action, **kwargs)
-            self._wait_for_stop(timeout=timeout)
+            self._wait_for_stop(timeout=timeout, stop_event=stop_event)
 
     def move_to(
         self,
@@ -224,16 +237,32 @@ class MotorClient:
                 target_deg=target_deg,
             )
 
-    def home(self):
+    def home(self, stop_event=None):
         """Drive both axes to step position 0, one at a time.
 
         Only one motor moves at once: az homes first, then el. Running
         both simultaneously is a mechanical-safety hazard on the rig
         and matches the historical ``picohost`` script behavior.
+
+        ``stop_event`` (optional) enables cooperative cancellation: a
+        set event halts the in-flight axis and skips the next one, so a
+        background home (``motor_manual.py``) can be aborted mid-move.
         """
         self._await_initial_status()
-        self._send_and_wait("az_target_steps", label="home az", target_steps=0)
-        self._send_and_wait("el_target_steps", label="home el", target_steps=0)
+        self._send_and_wait(
+            "az_target_steps",
+            label="home az",
+            target_steps=0,
+            stop_event=stop_event,
+        )
+        if stop_event is not None and stop_event.is_set():
+            return
+        self._send_and_wait(
+            "el_target_steps",
+            label="home el",
+            target_steps=0,
+            stop_event=stop_event,
+        )
 
     def scan(
         self,

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -9,11 +9,14 @@ terminal.
 
 import inspect
 import logging
+import threading
 import time
 
 from eigsep_redis import MetadataSnapshotReader
 from picohost.motor import PicoMotor
 from picohost.proxy import PicoProxy
+
+from .motor_client import MotorClient
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +78,7 @@ class MotorZeroer:
         el_up_delay_us=2400,
         el_dn_delay_us=600,
         source="motor_zeroer",
+        motor_client=None,
     ):
         self.transport = transport
         self._proxy = PicoProxy("motor", transport, source=source)
@@ -88,10 +92,28 @@ class MotorZeroer:
         self.logger = logger
         # Two-step zero guard: Enter arms this, a deliberate 'y' commits.
         self._pending_zero = False
+        # "Go home" drives both axes to step 0 via the same
+        # MotorClient.home primitive motor_control.py uses. It runs in a
+        # background thread so the curses loop keeps rendering live
+        # position; injectable for tests.
+        if motor_client is None:
+            motor_client = MotorClient(transport, source="motor_manual_home")
+        self._motor_client = motor_client
+        self._homing = False
+        self._home_thread = None
+        self._home_stop = None
 
     @property
     def is_available(self):
         return self._proxy.is_available
+
+    @property
+    def is_homing(self):
+        """True while a background "go home" move is in flight. The
+        curses layer reads this to render the homing banner and to know
+        that jog/zero keys are currently inert.
+        """
+        return self._homing
 
     @property
     def pending_zero(self):
@@ -137,6 +159,42 @@ class MotorZeroer:
         """
         self._proxy.send_command("halt")
         self._proxy.send_command("reset_step_position", az_step=0, el_step=0)
+
+    def start_home(self):
+        """Begin driving both axes back to step 0 in a background thread.
+
+        No-op if a home is already in flight or the manager is
+        unreachable. The thread runs the shared
+        :meth:`MotorClient.home` (mechanically-safe az-then-el) and
+        clears :attr:`is_homing` when it returns — normally, on a
+        :meth:`cancel_home`, or after a logged error.
+        """
+        if self._homing or not self.is_available:
+            return
+        self._home_stop = threading.Event()
+        self._homing = True
+
+        def _run():
+            try:
+                self._motor_client.home(stop_event=self._home_stop)
+            except (RuntimeError, TimeoutError) as exc:
+                self.logger.warning("home failed: %s", exc)
+            finally:
+                self._homing = False
+
+        self._home_thread = threading.Thread(
+            target=_run, name="motor-home", daemon=True
+        )
+        self._home_thread.start()
+
+    def cancel_home(self):
+        """Stop an in-flight background home: signal the thread and halt
+        the motor. :attr:`is_homing` clears once the thread unwinds.
+        Safe to call when not homing (just a best-effort halt).
+        """
+        if self._home_stop is not None:
+            self._home_stop.set()
+        self.halt()
 
     def status_text(self):
         """Return ``(az_str, el_str, connected)`` for the UI.
@@ -186,7 +244,14 @@ class MotorZeroer:
         """
         if ch == -1:
             # No keypress this tick — leave any armed prompt intact so a
-            # ~100ms idle getch() doesn't silently cancel it.
+            # ~100ms idle getch() doesn't silently cancel it, and leave a
+            # background home running.
+            return deg_state, False, False
+        if self._homing:
+            # While a background home is in flight, any real keystroke
+            # cancels it and is otherwise swallowed (it does not jog,
+            # zero, or quit). Idle (-1) ticks were handled above.
+            self.cancel_home()
             return deg_state, False, False
         if self._pending_zero:
             return self._confirm_zero(ch, deg_state)
@@ -211,6 +276,11 @@ class MotorZeroer:
             return deg_state + 1, False, False
         if key == "-":
             return max(0.1, deg_state - 1), False, False
+        if key == "h":
+            # Start driving back to step 0 in the background; start_home
+            # no-ops if the manager is unreachable.
+            self.start_home()
+            return deg_state, False, False
         if key in ("u", "d", "l", "r"):
             if not self.is_available:
                 return deg_state, False, False

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -363,6 +363,32 @@ def test_move_to_does_not_block_switch_when_serialize_off(client):
     t.join(timeout=1.0)
 
 
+def test_home_stop_event_bails_without_raising(client):
+    """A set ``stop_event`` makes ``home()`` halt and return promptly
+    even when the motor can't reach step 0 — mirrors ``scan()``'s
+    cooperative cancellation. Without the event this same frozen-emulator
+    state raises ``TimeoutError`` (see ``test_wait_for_stop_timeout``);
+    with it, ``home()`` must return cleanly so the manual UI's background
+    home thread can be cancelled mid-move.
+    """
+    motor = MotorClient(
+        client.transport, poll_interval_s=0.02, stall_timeout_s=5.0
+    )
+    assert _wait_until_motor_status_available(motor)
+    # Drive az off zero, then freeze mid-move so home()'s subsequent
+    # drive to step 0 can never complete on its own.
+    motor._proxy.send_command("az_target_deg", target_deg=100.0)
+    assert _wait_until_metadata_target_non_zero(motor)
+    client._manager.picos["motor"]._emulator.stop()
+
+    stop_event = threading.Event()
+    stop_event.set()
+
+    started = time.monotonic()
+    motor.home(stop_event=stop_event)  # must return, not raise or block
+    assert time.monotonic() - started < 1.0
+
+
 def test_scan_uses_send_and_wait_helper(client):
     """Sanity-check the refactor: scan() calls ``_send_and_wait``
     rather than the inline send + wait pattern. A regression that

--- a/tests/test_motor_scripts.py
+++ b/tests/test_motor_scripts.py
@@ -127,6 +127,69 @@ def test_motor_control_parse_args_accepts_scan_bounds(monkeypatch):
     assert (args.el_start, args.el_stop, args.el_step) == (-45.0, 45.0, 15.0)
 
 
+def _patch_scan_to_interrupt(mc, monkeypatch):
+    """Make ``MotorClient.scan`` raise KeyboardInterrupt and spy on
+    ``home``. Returns the call counter dict."""
+    home_calls = {"n": 0}
+
+    def fake_scan(self, **kwargs):
+        raise KeyboardInterrupt
+
+    def fake_home(self, *a, **kw):
+        home_calls["n"] += 1
+
+    monkeypatch.setattr(mc.MotorClient, "scan", fake_scan)
+    monkeypatch.setattr(mc.MotorClient, "home", fake_home)
+    return home_calls
+
+
+def test_motor_control_interrupt_prompt_yes_homes(client, monkeypatch):
+    """A Ctrl-C during the scan prompts the operator; answering 'y'
+    drives back to (0,0) via ``MotorClient.home``."""
+    mc = _load("motor_control")
+    home_calls = _patch_scan_to_interrupt(mc, monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda *_a: "y")
+    mc.main(client.transport, _scan_args())
+    assert home_calls["n"] == 1
+
+
+def test_motor_control_interrupt_prompt_no_skips_home(client, monkeypatch):
+    """The prompt defaults to No — an empty answer leaves the motors
+    halted in place rather than homing."""
+    mc = _load("motor_control")
+    home_calls = _patch_scan_to_interrupt(mc, monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda *_a: "")
+    mc.main(client.transport, _scan_args())
+    assert home_calls["n"] == 0
+
+
+def test_motor_control_interrupt_prompt_eof_skips_home(client, monkeypatch):
+    """A non-interactive stdin (EOFError on input) is treated as No and
+    must not crash the exit path."""
+    mc = _load("motor_control")
+    home_calls = _patch_scan_to_interrupt(mc, monkeypatch)
+
+    def raise_eof(*_a):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+    mc.main(client.transport, _scan_args())
+    assert home_calls["n"] == 0
+
+
+def test_motor_control_second_interrupt_skips_home(client, monkeypatch):
+    """A second Ctrl-C at the prompt declines the home cleanly."""
+    mc = _load("motor_control")
+    home_calls = _patch_scan_to_interrupt(mc, monkeypatch)
+
+    def raise_interrupt(*_a):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", raise_interrupt)
+    mc.main(client.transport, _scan_args())
+    assert home_calls["n"] == 0
+
+
 def test_motor_manual_helpers_exist():
     """``motor_manual`` should expose the curses frame and arg parser."""
     mm = _load("motor_manual")

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -16,6 +16,26 @@ def _zeroer(transport):
     return MotorZeroer(transport)
 
 
+class _BlockingHomeClient:
+    """Stand-in ``MotorClient`` whose ``home`` blocks on the stop event.
+
+    Lets a test observe ``is_homing == True`` deterministically (the
+    real emulator reaches step 0 too fast to catch the flag) and proves
+    the cancel path: ``home`` only returns once the ``stop_event`` is
+    set, so ``cancel_home`` unwinding the thread is observable.
+    """
+
+    def __init__(self):
+        self.home_calls = 0
+        self.last_stop_event = None
+
+    def home(self, stop_event=None):
+        self.home_calls += 1
+        self.last_stop_event = stop_event
+        if stop_event is not None:
+            stop_event.wait(timeout=2.0)
+
+
 def _wait_until(pred, timeout=2.0, interval=0.05):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -275,6 +295,84 @@ def test_handle_key_directional_jogs(client):
         zeroer.handle_key(ord(key), 1.0)
         after = getter()
         assert after - before == factor * motor.deg_to_steps(1.0)
+
+
+def test_handle_key_h_drives_to_home(client):
+    """Pressing 'h' drives both axes back to step 0 via the real
+    ``MotorClient.home`` path (background thread), and clears
+    ``is_homing`` when the move completes."""
+    zeroer = _zeroer(client.transport)
+    motor = client._manager.picos["motor"]
+    zeroer.jog_az(2.0)
+    zeroer.jog_el(2.0)
+    assert _wait_until(
+        lambda: (
+            motor._emulator.azimuth.position
+            == motor._emulator.azimuth.target_pos
+            and motor._emulator.elevation.position
+            == motor._emulator.elevation.target_pos
+        ),
+        timeout=3.0,
+    )
+    assert motor._emulator.azimuth.target_pos != 0  # precondition
+
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(
+        lambda: (
+            motor._emulator.azimuth.position == 0
+            and motor._emulator.elevation.position == 0
+        ),
+        timeout=5.0,
+    )
+    assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
+
+
+def test_handle_key_h_sets_homing_and_any_key_cancels(client):
+    """'h' starts a background home (``is_homing`` True); while homing,
+    any subsequent key cancels it (stops the motor, unwinds the thread)
+    and must NOT execute as a jog."""
+    fake = _BlockingHomeClient()
+    zeroer = MotorZeroer(client.transport, motor_client=fake)
+
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: zeroer.is_homing, timeout=1.0)
+    assert fake.home_calls == 1
+
+    motor = client._manager.picos["motor"]
+    before = motor._emulator.azimuth.target_pos
+    # 'l' is normally jog-left; while homing it must only cancel.
+    _, should_exit, zeroed = zeroer.handle_key(ord("l"), 1.0)
+    assert should_exit is False
+    assert zeroed is False
+    assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
+    assert motor._emulator.azimuth.target_pos == before
+
+
+def test_handle_key_h_ignored_when_unavailable(client, monkeypatch):
+    """When the manager is unreachable, 'h' is a no-op — no home thread
+    is spawned."""
+    fake = _BlockingHomeClient()
+    zeroer = MotorZeroer(client.transport, motor_client=fake)
+    monkeypatch.setattr(
+        MotorZeroer, "is_available", property(lambda self: False)
+    )
+    zeroer.handle_key(ord("h"), 1.0)
+    assert zeroer.is_homing is False
+    assert fake.home_calls == 0
+
+
+def test_handle_key_noop_during_homing_preserves_state(client):
+    """A ``-1`` idle tick (getch timeout) while homing must keep the
+    home running rather than silently cancelling it."""
+    fake = _BlockingHomeClient()
+    zeroer = MotorZeroer(client.transport, motor_client=fake)
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: zeroer.is_homing, timeout=1.0)
+    _, should_exit, zeroed = zeroer.handle_key(-1, 1.0)
+    assert zeroer.is_homing is True
+    assert should_exit is False
+    assert zeroed is False
+    zeroer.cancel_home()  # cleanup
 
 
 def test_format_pos_renders_axis_degrees():


### PR DESCRIPTION
Two operator-UX improvements found while testing the motor scripts.

## 1. `motor_manual.py` — `h` = go home
Press **`h`** to drive both axes back to step 0. The move runs in a background thread, so the live AZ/EL position keeps rendering as the motors approach zero, under a `>>> HOMING to (0,0)... press any key to cancel <<<` banner.

- Fires immediately (no confirmation) — homing to a known-safe origin is far less destructive than redefining home, and cancel is one keypress away.
- **Any key cancels** the in-flight home (halts + stays in the UI); jog/zero keys are inert while homing. Quitting mid-home stops the thread cleanly.

## 2. `motor_control.py` — prompt-to-home on Ctrl-C
The scan previously only auto-homed on the **counted-completion** path (`--count N` finishing); the default run-until-Ctrl-C path just halts in place (auto-driving across the sky during an abort is the wrong default).

Ctrl-C now prompts `Go home (0,0)? [y/N]` — **default No** (empty / `n` / non-interactive stdin / a second Ctrl-C all decline cleanly). On `y` it returns to home, abortable with another Ctrl-C. Stall/error aborts stay halt-in-place, unchanged.

## Shared primitive
Both paths call the same mechanically-safe az→el `MotorClient.home()`. It gains an optional `stop_event` threaded through `_send_and_wait`/`_wait_for_stop` (a set event halts and returns mid-move), mirroring the existing `scan(stop_event=...)`. `scan()` passes no event, so its behavior is byte-for-byte unchanged.

## Tests (TDD, against the dummy `PicoManager`)
- `MotorClient`: `home(stop_event)` bails promptly even with a frozen emulator (vs. the existing `TimeoutError` without it).
- `MotorZeroer`: `h` drives targets to 0 via the real path; `h` sets `is_homing` and any key cancels without jogging; `h` is a no-op when disconnected; `-1` idle ticks preserve homing.
- `motor_control`: interrupt + `input→"y"` homes; `""`/EOF/second-Ctrl-C do not.

Full changed-surface suite green: **58 passed** (`test_motor_client` + `test_motor_zeroer` + `test_motor_scripts`); ruff check + format clean.

> Base is `feat/motor-zero-confirm` (about to merge); this auto-retargets to `main` once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)