### PR TITLE
feat(tempctrl_manual): step clamp up/down with c/C instead of cycling

### DIFF
--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -488,7 +488,9 @@ def _render(screen, snapshot, state):
     )
     screen.addstr(13, 0, "l/L enable LNA on/off       o/O enable LOAD on/off")
     screen.addstr(14, 0, "n/N LNA cooling on/off      m/M LOAD cooling on/off")
-    screen.addstr(15, 0, "+/- LNA setpoint  ][ LOAD setpoint  c/C clamp up/down")
+    screen.addstr(
+        15, 0, "+/- LNA setpoint  ][ LOAD setpoint  c/C clamp up/down"
+    )
     screen.addstr(16, 0, "g/G LNA Kp  h/H LOAD Kp  i/I LNA Ki  k/K LOAD Ki")
     screen.addstr(17, 0, "z/Z reset LNA/LOAD integral")
     screen.addstr(

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -15,7 +15,9 @@ Controls:
   m / M    LOAD cooling (negative drive) allow / forbid
   + / -    LNA setpoint +/- 0.5 deg C
   ] / [    LOAD setpoint +/- 0.5 deg C
-  c        cycle clamp through (0.1, 0.3, 0.5, 1.0) on both channels
+  c / C    clamp one step up / down through (0.1, 0.2, 0.3, 0.5, 1.0)
+           on both channels (no wraparound, so the clamp can be lowered
+           without passing through the higher values first)
   g / G    LNA Kp +/- 0.05
   h / H    LOAD Kp +/- 0.05
   i / I    LNA Ki +/- 0.005
@@ -74,7 +76,7 @@ from eigsep_observing.utils import configure_eig_logger
 configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
-CLAMPS = (0.1, 0.3, 0.5, 1.0)
+CLAMPS = (0.1, 0.2, 0.3, 0.5, 1.0)
 SETPOINT_STEP_C = 0.5
 KP_STEP = 0.05
 KI_STEP = 0.005  # smaller — integral accumulates over many ticks
@@ -133,7 +135,7 @@ class _State:
         # never disagrees with what the firmware is enforcing.
         self.lna_cooling_enabled = lna_cooling_enabled
         self.load_cooling_enabled = load_cooling_enabled
-        self.clamp_idx = 2  # default 0.5
+        self.clamp_idx = CLAMPS.index(0.2)  # firmware default clamp
         self.last_message = ""
 
 
@@ -486,7 +488,7 @@ def _render(screen, snapshot, state):
     )
     screen.addstr(13, 0, "l/L enable LNA on/off       o/O enable LOAD on/off")
     screen.addstr(14, 0, "n/N LNA cooling on/off      m/M LOAD cooling on/off")
-    screen.addstr(15, 0, "+/- LNA setpoint  ][ LOAD setpoint  c cycle clamp")
+    screen.addstr(15, 0, "+/- LNA setpoint  ][ LOAD setpoint  c/C clamp up/down")
     screen.addstr(16, 0, "g/G LNA Kp  h/H LOAD Kp  i/I LNA Ki  k/K LOAD Ki")
     screen.addstr(17, 0, "z/Z reset LNA/LOAD integral")
     screen.addstr(
@@ -537,7 +539,10 @@ def _handle_key(ch, proxy, state, history=None, outdir="."):
         state.load_setpoint -= SETPOINT_STEP_C
         _push_temperatures(proxy, state)
     elif ch == ord("c"):
-        state.clamp_idx = (state.clamp_idx + 1) % len(CLAMPS)
+        state.clamp_idx = min(state.clamp_idx + 1, len(CLAMPS) - 1)
+        _push_clamp(proxy, state)
+    elif ch == ord("C"):
+        state.clamp_idx = max(state.clamp_idx - 1, 0)
         _push_clamp(proxy, state)
     elif ch == ord("g"):
         state.lna_Kp = max(0.0, state.lna_Kp + KP_STEP)

--- a/tests/test_tempctrl_manual.py
+++ b/tests/test_tempctrl_manual.py
@@ -323,6 +323,74 @@ def test_handle_p_key_plots_and_continues(transport, tmp_path):
     assert len(list(tmp_path.glob("tempctrl_*.png"))) == 1
 
 
+class _FakeProxy:
+    """Records send_command calls; returns a truthy result like a
+    successful PicoProxy round-trip."""
+
+    def __init__(self):
+        self.sent = []
+
+    def send_command(self, action, **kwargs):
+        self.sent.append((action, kwargs))
+        return {"action": action}
+
+
+def _make_state(mod):
+    return mod._State(
+        lna_setpoint=30.0,
+        load_setpoint=30.0,
+        lna_enabled=False,
+        load_enabled=False,
+        lna_Kp=0.2,
+        lna_Ki=0.0,
+        load_Kp=0.2,
+        load_Ki=0.0,
+        lna_cooling_enabled=True,
+        load_cooling_enabled=True,
+    )
+
+
+def test_clamp_defaults_to_firmware_default(transport):
+    """The client-side clamp starts at the firmware default (0.2), so
+    the first push is relative to what the firmware is enforcing."""
+    mod = _load("tempctrl_manual")
+    state = _make_state(mod)
+    assert mod.CLAMPS[state.clamp_idx] == 0.2
+
+
+def test_clamp_steps_down_without_wraparound(transport):
+    """`C` lowers the clamp directly — the operator never has to pass
+    through higher (higher-current) values to reach a lower one."""
+    mod = _load("tempctrl_manual")
+    proxy = _FakeProxy()
+    state = _make_state(mod)
+
+    assert mod._handle_key(ord("C"), proxy, state) is True
+    assert mod.CLAMPS[state.clamp_idx] == 0.1
+    assert proxy.sent == [("set_clamp", {"LNA": 0.1, "LOAD": 0.1})]
+
+    # At the bottom of the table, another `C` stays put (no wrap to 1.0).
+    mod._handle_key(ord("C"), proxy, state)
+    assert mod.CLAMPS[state.clamp_idx] == 0.1
+    assert proxy.sent[-1] == ("set_clamp", {"LNA": 0.1, "LOAD": 0.1})
+
+
+def test_clamp_steps_up_and_saturates_at_max(transport):
+    """`c` raises the clamp one step at a time and saturates at the top
+    of the table instead of wrapping back to the minimum."""
+    mod = _load("tempctrl_manual")
+    proxy = _FakeProxy()
+    state = _make_state(mod)
+
+    mod._handle_key(ord("c"), proxy, state)
+    assert mod.CLAMPS[state.clamp_idx] == 0.3
+    assert proxy.sent[-1] == ("set_clamp", {"LNA": 0.3, "LOAD": 0.3})
+
+    for _ in range(10):
+        mod._handle_key(ord("c"), proxy, state)
+    assert mod.CLAMPS[state.clamp_idx] == 1.0
+
+
 def test_handle_p_key_no_data(transport, tmp_path):
     """Pressing `p` before any sample is buffered reports 'no data'."""
     mod = _load("tempctrl_manual")


### PR DESCRIPTION
## Summary
- `c` cycling the clamp forced the operator through every higher (higher-current) value before reaching a lower one; `c` now steps up one entry and `C` steps down, saturating at the table ends with no wraparound
- Add 0.2 to the clamp table and seed the client-side index there to match the new firmware default (pico-firmware lowers the default clamp 0.6 → 0.2 in a companion PR)
- Add tests for the default index, step-down-without-wrap, and step-up saturation

## Test plan
- [x] `pytest tests/test_tempctrl_manual.py`: 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)