### PR TITLE
refactor(redis-kv): extract _redis_json_kv helper for the five K/V siblings

### DIFF
--- a/src/eigsep_observing/_redis_json_kv.py
+++ b/src/eigsep_observing/_redis_json_kv.py
@@ -1,0 +1,74 @@
+"""Shared publish/read shape for the single-key Redis JSON K/V modules.
+
+Five sibling modules ride this shape — :mod:`~eigsep_observing.run_tag`,
+:mod:`~eigsep_observing.obs_config_owner`,
+:mod:`~eigsep_observing.file_heartbeat`,
+:mod:`~eigsep_observing.snap_reinit`,
+:mod:`~eigsep_observing.corr_health`: a single Redis key holds a small
+JSON blob, overwritten on each publish via ``transport.add_raw`` /
+``transport.get_raw`` — consumers only ever care about the most recent
+value. This module is the single home for the serialize/deserialize
+path so a parsing fix propagates to all siblings at once (issue #149).
+
+What stays per-module: the ``*_KEY`` constant, the ``_EMPTY`` sentinel,
+lifecycle semantics (``run_tag``'s ``clear``/``session``,
+``obs_config_owner``'s deliberate lack of ``clear``, ``snap_reinit``'s
+read-modify-write counter), derived fields (``seconds_since_*``), and
+publish failure policy — :func:`publish_json` always raises, and each
+sibling decides whether to swallow+WARN (four do) or propagate to the
+caller (``corr_health``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional
+
+
+def publish_json(transport, key: str, payload: dict) -> None:
+    """Serialize ``payload`` and overwrite ``key``.
+
+    Raises on serialization or transport error — the caller owns the
+    failure policy (swallow+WARN for provenance/heartbeat keys, raise
+    for ``corr_health`` whose caller disables on first failure).
+    """
+    transport.add_raw(key, json.dumps(payload))
+
+
+def read_json(
+    transport,
+    key: str,
+    *,
+    label: str,
+    logger,
+    parse: Callable[[Any], Any],
+) -> Optional[Any]:
+    """Fetch ``key``, decode, ``json.loads``, and apply ``parse``.
+
+    Returns ``parse``'s result, or ``None`` for every failure mode so
+    each sibling maps it to its own ``_EMPTY`` sentinel: missing key
+    (silent), transport error (``"failed to read {label}"`` WARNING),
+    malformed JSON or a ``parse`` raising ``ValueError`` / ``TypeError``
+    / ``KeyError`` (``"malformed {label} payload"`` WARNING with the
+    raw payload).
+
+    ``parse`` must do all field extraction and type coercion — running
+    it inside the try-block is what guarantees a junk payload degrades
+    to the sentinel instead of raising out of the sibling's ``read``.
+    Warnings go to the caller's ``logger`` so per-module log
+    provenance survives the extraction.
+    """
+    try:
+        raw = transport.get_raw(key)
+    except Exception as exc:
+        logger.warning("failed to read %s: %s", label, exc)
+        return None
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode()
+    try:
+        return parse(json.loads(raw))
+    except (ValueError, TypeError, KeyError) as exc:
+        logger.warning("malformed %s payload %r: %s", label, raw, exc)
+        return None

--- a/src/eigsep_observing/corr_health.py
+++ b/src/eigsep_observing/corr_health.py
@@ -26,10 +26,11 @@ consumers only ever care about the most recent write.
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from typing import Optional
+
+from ._redis_json_kv import publish_json, read_json
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,15 @@ _EMPTY = {
     "published_unix": None,
     "seconds_since_publish": None,
 }
+
+
+def _parse(obj) -> dict:
+    readout = obj["readout_time_ms"]
+    return {
+        "dropped_integrations": int(obj["dropped_integrations"]),
+        "readout_time_ms": float(readout) if readout is not None else None,
+        "published_unix": float(obj["published_unix"]),
+    }
 
 
 def publish(
@@ -57,16 +67,14 @@ def publish(
     Redis would warn-spam the journal. The caller (``EigsepFpga``) owns
     the failure policy — disable-on-first-failure with a single ERROR.
     """
-    payload = json.dumps(
-        {
-            "dropped_integrations": int(dropped_integrations),
-            "readout_time_ms": (
-                float(readout_time_ms) if readout_time_ms is not None else None
-            ),
-            "published_unix": time.time() if now is None else now,
-        }
-    )
-    transport.add_raw(CORR_HEALTH_KEY, payload)
+    payload = {
+        "dropped_integrations": int(dropped_integrations),
+        "readout_time_ms": (
+            float(readout_time_ms) if readout_time_ms is not None else None
+        ),
+        "published_unix": time.time() if now is None else now,
+    }
+    publish_json(transport, CORR_HEALTH_KEY, payload)
 
 
 def read(transport, *, now: Optional[float] = None) -> dict:
@@ -77,27 +85,14 @@ def read(transport, *, now: Optional[float] = None) -> dict:
     corr-loop tile (no drop/readout suffixes) rather than failing.
     """
     t_now = time.time() if now is None else now
-    try:
-        raw = transport.get_raw(CORR_HEALTH_KEY)
-    except Exception as exc:
-        logger.warning("failed to read corr health: %s", exc)
+    out = read_json(
+        transport,
+        CORR_HEALTH_KEY,
+        label="corr health",
+        logger=logger,
+        parse=_parse,
+    )
+    if out is None:
         return dict(_EMPTY)
-    if raw is None:
-        return dict(_EMPTY)
-    if isinstance(raw, (bytes, bytearray)):
-        raw = raw.decode()
-    try:
-        obj = json.loads(raw)
-        dropped = int(obj["dropped_integrations"])
-        readout = obj["readout_time_ms"]
-        readout = float(readout) if readout is not None else None
-        pub = float(obj["published_unix"])
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
-        logger.warning("malformed corr health payload %r: %s", raw, exc)
-        return dict(_EMPTY)
-    return {
-        "dropped_integrations": dropped,
-        "readout_time_ms": readout,
-        "published_unix": pub,
-        "seconds_since_publish": max(0.0, t_now - pub),
-    }
+    out["seconds_since_publish"] = max(0.0, t_now - out["published_unix"])
+    return out

--- a/src/eigsep_observing/file_heartbeat.py
+++ b/src/eigsep_observing/file_heartbeat.py
@@ -16,11 +16,12 @@ publish — consumers only ever care about the most recent write.
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from pathlib import Path
 from typing import Optional, Union
+
+from ._redis_json_kv import publish_json, read_json
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,10 @@ _EMPTY = {
 }
 
 
+def _parse(obj) -> dict:
+    return {"path": obj["path"], "mtime_unix": float(obj["mtime_unix"])}
+
+
 def publish(transport, path: Union[str, Path], mtime_unix: float) -> None:
     """Stamp a file-write heartbeat into Redis.
 
@@ -41,9 +46,9 @@ def publish(transport, path: Union[str, Path], mtime_unix: float) -> None:
     landed on disk by the time this runs; losing a heartbeat only
     costs a dashboard tile for one cycle.
     """
-    payload = json.dumps({"path": str(path), "mtime_unix": float(mtime_unix)})
+    payload = {"path": str(path), "mtime_unix": float(mtime_unix)}
     try:
-        transport.add_raw(FILE_HEARTBEAT_KEY, payload)
+        publish_json(transport, FILE_HEARTBEAT_KEY, payload)
     except Exception as exc:
         logger.warning("failed to publish file heartbeat: %s", exc)
 
@@ -59,24 +64,17 @@ def read(transport, *, now: Optional[float] = None) -> dict:
     failing.
     """
     t_now = time.time() if now is None else now
-    try:
-        raw = transport.get_raw(FILE_HEARTBEAT_KEY)
-    except Exception as exc:
-        logger.warning("failed to read file heartbeat: %s", exc)
-        return dict(_EMPTY)
-    if raw is None:
-        return dict(_EMPTY)
-    if isinstance(raw, (bytes, bytearray)):
-        raw = raw.decode()
-    try:
-        obj = json.loads(raw)
-        path = obj["path"]
-        mtime = float(obj["mtime_unix"])
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
-        logger.warning("malformed file heartbeat payload %r: %s", raw, exc)
+    out = read_json(
+        transport,
+        FILE_HEARTBEAT_KEY,
+        label="file heartbeat",
+        logger=logger,
+        parse=_parse,
+    )
+    if out is None:
         return dict(_EMPTY)
     return {
-        "newest_h5_path": path,
-        "mtime_unix": mtime,
-        "seconds_since_write": max(0.0, t_now - mtime),
+        "newest_h5_path": out["path"],
+        "mtime_unix": out["mtime_unix"],
+        "seconds_since_write": max(0.0, t_now - out["mtime_unix"]),
     }

--- a/src/eigsep_observing/obs_config_owner.py
+++ b/src/eigsep_observing/obs_config_owner.py
@@ -28,10 +28,11 @@ Downstream trust checks:
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from typing import Optional
+
+from ._redis_json_kv import publish_json, read_json
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,17 @@ _EMPTY = {
     "owner": None,
     "uploaded_at_unix": None,
 }
+
+
+def _parse(obj) -> dict:
+    owner = obj["owner"]
+    uploaded = obj["uploaded_at_unix"]
+    return {
+        "owner": str(owner) if owner is not None else None,
+        "uploaded_at_unix": (
+            float(uploaded) if uploaded is not None else None
+        ),
+    }
 
 
 def publish_owner(
@@ -64,8 +76,8 @@ def publish_owner(
                 f"obs_config_owner {owner!r}: {exc}; using 0.0."
             )
     try:
-        payload = json.dumps({"owner": str(owner), "uploaded_at_unix": t})
-        transport.add_raw(OBS_CONFIG_OWNER_KEY, payload)
+        payload = {"owner": str(owner), "uploaded_at_unix": t}
+        publish_json(transport, OBS_CONFIG_OWNER_KEY, payload)
     except Exception as exc:
         logger.warning("failed to publish obs_config_owner: %s", exc)
 
@@ -79,22 +91,17 @@ def read_owner(transport) -> dict:
     None`` as a misconfiguration signal (no authorized uploader has
     seeded Redis yet), not the steady-state default.
     """
-    try:
-        raw = transport.get_raw(OBS_CONFIG_OWNER_KEY)
-    except Exception as exc:
-        logger.warning("failed to read obs_config_owner: %s", exc)
+    out = read_json(
+        transport,
+        OBS_CONFIG_OWNER_KEY,
+        label="obs_config_owner",
+        logger=logger,
+        parse=_parse,
+    )
+    if out is None:
         return dict(_EMPTY)
-    if raw is None:
-        return dict(_EMPTY)
-    if isinstance(raw, (bytes, bytearray)):
-        raw = raw.decode()
-    try:
-        obj = json.loads(raw)
-        owner = obj["owner"]
-        uploaded = obj["uploaded_at_unix"]
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
-        logger.warning("malformed obs_config_owner payload %r: %s", raw, exc)
-        return dict(_EMPTY)
+    owner = out["owner"]
+    uploaded = out["uploaded_at_unix"]
     if owner is None and uploaded is None:
         return dict(_EMPTY)
     if owner is None or uploaded is None:
@@ -105,4 +112,4 @@ def read_owner(transport) -> dict:
             uploaded,
         )
         return dict(_EMPTY)
-    return {"owner": str(owner), "uploaded_at_unix": float(uploaded)}
+    return out

--- a/src/eigsep_observing/run_tag.py
+++ b/src/eigsep_observing/run_tag.py
@@ -24,11 +24,12 @@ the default for normal operations.
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from contextlib import contextmanager
 from typing import Optional
+
+from ._redis_json_kv import publish_json, read_json
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,15 @@ _EMPTY = {
     "run_tag": None,
     "run_started_at_unix": None,
 }
+
+
+def _parse(obj) -> dict:
+    tag = obj["run_tag"]
+    started = obj["run_started_at_unix"]
+    return {
+        "run_tag": str(tag) if tag is not None else None,
+        "run_started_at_unix": float(started) if started is not None else None,
+    }
 
 
 def publish(transport, tag: str, started_unix: Optional[float] = None) -> None:
@@ -73,8 +83,8 @@ def publish(transport, tag: str, started_unix: Optional[float] = None) -> None:
                 f"{exc}; using 0.0."
             )
     try:
-        payload = json.dumps({"run_tag": str(tag), "run_started_at_unix": t})
-        transport.add_raw(RUN_TAG_KEY, payload)
+        payload = {"run_tag": str(tag), "run_started_at_unix": t}
+        publish_json(transport, RUN_TAG_KEY, payload)
     except Exception as exc:
         logger.warning("failed to publish run_tag: %s", exc)
 
@@ -86,9 +96,8 @@ def clear(transport) -> None:
     same shape as ``read``'s empty sentinel. ``read`` handles both
     "key absent" and "null payload" identically.
     """
-    payload = json.dumps(dict(_EMPTY))
     try:
-        transport.add_raw(RUN_TAG_KEY, payload)
+        publish_json(transport, RUN_TAG_KEY, dict(_EMPTY))
     except Exception as exc:
         logger.warning("failed to clear run_tag: %s", exc)
 
@@ -102,22 +111,13 @@ def read(transport) -> dict:
     ``run_tag is None`` as a misconfiguration signal, not the
     steady-state default.
     """
-    try:
-        raw = transport.get_raw(RUN_TAG_KEY)
-    except Exception as exc:
-        logger.warning("failed to read run_tag: %s", exc)
+    out = read_json(
+        transport, RUN_TAG_KEY, label="run_tag", logger=logger, parse=_parse
+    )
+    if out is None:
         return dict(_EMPTY)
-    if raw is None:
-        return dict(_EMPTY)
-    if isinstance(raw, (bytes, bytearray)):
-        raw = raw.decode()
-    try:
-        obj = json.loads(raw)
-        tag = obj["run_tag"]
-        started = obj["run_started_at_unix"]
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
-        logger.warning("malformed run_tag payload %r: %s", raw, exc)
-        return dict(_EMPTY)
+    tag = out["run_tag"]
+    started = out["run_started_at_unix"]
     if tag is None and started is None:
         return dict(_EMPTY)
     if tag is None or started is None:
@@ -127,7 +127,7 @@ def read(transport) -> dict:
             started,
         )
         return dict(_EMPTY)
-    return {"run_tag": str(tag), "run_started_at_unix": float(started)}
+    return out
 
 
 @contextmanager

--- a/src/eigsep_observing/snap_reinit.py
+++ b/src/eigsep_observing/snap_reinit.py
@@ -17,10 +17,11 @@ glance whether the SNAP has been thermal-cycling without checking
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from typing import Optional
+
+from ._redis_json_kv import publish_json, read_json
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,13 @@ _EMPTY = {
     "last_reinit_unix": None,
     "seconds_since_reinit": None,
 }
+
+
+def _parse(obj) -> dict:
+    return {
+        "count": int(obj["count"]),
+        "last_reinit_unix": float(obj["last_reinit_unix"]),
+    }
 
 
 def publish(transport) -> None:
@@ -45,29 +53,20 @@ def publish(transport) -> None:
     practice; concurrent publishers would only lose a count or two.
     """
     try:
-        raw = transport.get_raw(REINIT_KEY)
-        count = 0
-        if raw is not None:
-            if isinstance(raw, (bytes, bytearray)):
-                raw = raw.decode()
-            try:
-                count = int(json.loads(raw).get("count", 0))
-            except (
-                ValueError,
-                TypeError,
-                KeyError,
-                json.JSONDecodeError,
-            ) as exc:
-                logger.warning(
-                    "malformed snap reinit payload %r: %s; resetting count",
-                    raw,
-                    exc,
-                )
-                count = 0
-        payload = json.dumps(
-            {"count": count + 1, "last_reinit_unix": time.time()}
+        count = read_json(
+            transport,
+            REINIT_KEY,
+            label="snap reinit heartbeat",
+            logger=logger,
+            parse=lambda obj: int(obj.get("count", 0)),
         )
-        transport.add_raw(REINIT_KEY, payload)
+        if count is None:
+            count = 0  # absent or malformed payload: reset the count
+        publish_json(
+            transport,
+            REINIT_KEY,
+            {"count": count + 1, "last_reinit_unix": time.time()},
+        )
     except Exception as exc:
         logger.warning("failed to publish snap reinit heartbeat: %s", exc)
 
@@ -81,24 +80,17 @@ def read(transport, *, now: Optional[float] = None) -> dict:
     rather than failing.
     """
     t_now = time.time() if now is None else now
-    try:
-        raw = transport.get_raw(REINIT_KEY)
-    except Exception as exc:
-        logger.warning("failed to read snap reinit heartbeat: %s", exc)
-        return dict(_EMPTY)
-    if raw is None:
-        return dict(_EMPTY)
-    if isinstance(raw, (bytes, bytearray)):
-        raw = raw.decode()
-    try:
-        obj = json.loads(raw)
-        count = int(obj["count"])
-        last_unix = float(obj["last_reinit_unix"])
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
-        logger.warning("malformed snap reinit payload %r: %s", raw, exc)
+    out = read_json(
+        transport,
+        REINIT_KEY,
+        label="snap reinit heartbeat",
+        logger=logger,
+        parse=_parse,
+    )
+    if out is None:
         return dict(_EMPTY)
     return {
-        "count": count,
-        "last_reinit_unix": last_unix,
-        "seconds_since_reinit": max(0.0, t_now - last_unix),
+        "count": out["count"],
+        "last_reinit_unix": out["last_reinit_unix"],
+        "seconds_since_reinit": max(0.0, t_now - out["last_reinit_unix"]),
     }

--- a/tests/test_obs_config_owner.py
+++ b/tests/test_obs_config_owner.py
@@ -82,6 +82,23 @@ def test_read_malformed_payload_returns_empty(caplog):
     )
 
 
+def test_read_non_numeric_uploaded_unix_returns_empty(caplog):
+    """Regression: float coercion used to live outside the parse
+    try-block, so a junk timestamp raised an uncaught ValueError out
+    of read_owner() (issue #149)."""
+    t = DummyTransport()
+    t.add_raw(
+        OBS_CONFIG_OWNER_KEY,
+        json.dumps({"owner": "panda_observe", "uploaded_at_unix": "abc"}),
+    )
+    with caplog.at_level("WARNING"):
+        out = read_owner(t)
+    assert out == {"owner": None, "uploaded_at_unix": None}
+    assert any(
+        "malformed obs_config_owner" in rec.message for rec in caplog.records
+    )
+
+
 def test_read_partial_null_payload_warns(caplog):
     t = DummyTransport()
     t.add_raw(

--- a/tests/test_redis_json_kv.py
+++ b/tests/test_redis_json_kv.py
@@ -1,0 +1,116 @@
+"""Tests for eigsep_observing._redis_json_kv (shared K/V helper).
+
+The five sibling K/V modules (``run_tag``, ``obs_config_owner``,
+``file_heartbeat``, ``snap_reinit``, ``corr_health``) share one
+publish/read shape; this module is the single home for it. Behavior
+differences (swallow-vs-raise publish, lifecycle, derived fields)
+stay in the sibling modules — see issue #149.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from eigsep_redis.testing import DummyTransport
+
+from eigsep_observing._redis_json_kv import publish_json, read_json
+
+logger = logging.getLogger("test_redis_json_kv")
+
+KEY = "eigsep:test_kv"
+
+
+def _parse(obj):
+    return {"name": str(obj["name"]), "value": float(obj["value"])}
+
+
+def test_publish_then_read_roundtrip():
+    t = DummyTransport()
+    publish_json(t, KEY, {"name": "x", "value": 1.5})
+    out = read_json(t, KEY, label="test kv", logger=logger, parse=_parse)
+    assert out == {"name": "x", "value": 1.5}
+
+
+def test_read_missing_key_returns_none_without_warning(caplog):
+    t = DummyTransport()
+    with caplog.at_level("WARNING"):
+        out = read_json(t, KEY, label="test kv", logger=logger, parse=_parse)
+    assert out is None
+    assert not caplog.records
+
+
+def test_read_transport_error_returns_none_and_warns(caplog):
+    class BoomTransport:
+        def get_raw(self, key):
+            raise RuntimeError("redis down")
+
+    with caplog.at_level("WARNING"):
+        out = read_json(
+            BoomTransport(), KEY, label="test kv", logger=logger, parse=_parse
+        )
+    assert out is None
+    assert any(
+        "failed to read test kv" in rec.message for rec in caplog.records
+    )
+
+
+def test_read_malformed_json_returns_none_and_warns(caplog):
+    t = DummyTransport()
+    t.add_raw(KEY, b"not-json-at-all")
+    with caplog.at_level("WARNING"):
+        out = read_json(t, KEY, label="test kv", logger=logger, parse=_parse)
+    assert out is None
+    assert any(
+        "malformed test kv payload" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"value": 1.0},  # missing field -> KeyError
+        {"name": "x", "value": "abc"},  # non-numeric -> ValueError
+        {"name": "x", "value": None},  # None -> TypeError
+        ["not", "a", "dict"],  # list indexing by str -> TypeError
+    ],
+)
+def test_read_parse_failure_returns_none_and_warns(payload, caplog):
+    t = DummyTransport()
+    t.add_raw(KEY, json.dumps(payload))
+    with caplog.at_level("WARNING"):
+        out = read_json(t, KEY, label="test kv", logger=logger, parse=_parse)
+    assert out is None
+    assert any(
+        "malformed test kv payload" in rec.message for rec in caplog.records
+    )
+
+
+def test_read_warns_on_caller_logger(caplog):
+    """Warnings carry the caller's logger name, so per-module log
+    provenance (eigsep_observing.run_tag etc.) survives the extraction."""
+    t = DummyTransport()
+    t.add_raw(KEY, b"not-json-at-all")
+    with caplog.at_level("WARNING"):
+        read_json(t, KEY, label="test kv", logger=logger, parse=_parse)
+    assert caplog.records[0].name == "test_redis_json_kv"
+
+
+def test_read_decodes_bytes_payload():
+    t = DummyTransport()
+    t.add_raw(KEY, json.dumps({"name": "x", "value": 2.0}).encode())
+    out = read_json(t, KEY, label="test kv", logger=logger, parse=_parse)
+    assert out == {"name": "x", "value": 2.0}
+
+
+def test_publish_raises_on_transport_error():
+    """publish_json does NOT swallow — each sibling owns its failure
+    policy (four swallow+WARN, corr_health raises to its caller)."""
+
+    class BoomTransport:
+        def add_raw(self, key, value, ex=None):
+            raise RuntimeError("redis down")
+
+    with pytest.raises(RuntimeError, match="redis down"):
+        publish_json(BoomTransport(), KEY, {"name": "x", "value": 1.0})

--- a/tests/test_run_tag.py
+++ b/tests/test_run_tag.py
@@ -121,6 +121,22 @@ def test_read_missing_required_field_returns_empty(missing_key):
     assert out == {"run_tag": None, "run_started_at_unix": None}
 
 
+def test_read_non_numeric_started_unix_returns_empty(caplog):
+    """Regression: float coercion used to live outside the parse
+    try-block, so a junk timestamp raised an uncaught ValueError out
+    of read() — and through publish()/session(), crashing the driver
+    script (issue #149)."""
+    t = DummyTransport()
+    t.add_raw(
+        RUN_TAG_KEY,
+        json.dumps({"run_tag": "panda_observe", "run_started_at_unix": "abc"}),
+    )
+    with caplog.at_level("WARNING"):
+        out = read(t)
+    assert out == {"run_tag": None, "run_started_at_unix": None}
+    assert any("malformed run_tag" in rec.message for rec in caplog.records)
+
+
 def test_read_partial_null_payload_warns(caplog):
     t = DummyTransport()
     t.add_raw(


### PR DESCRIPTION
Closes #149.

## What

Extracts the shared serialize/deserialize path of the five single-key JSON K/V modules (`run_tag`, `obs_config_owner`, `file_heartbeat`, `snap_reinit`, `corr_health`) into `src/eigsep_observing/_redis_json_kv.py`:

- `publish_json(transport, key, payload)` — `json.dumps` + `add_raw`. **Always raises**; each sibling owns its failure policy (four wrap it in their own swallow+WARN, `corr_health` propagates to `EigsepFpga` per its disable-on-first-failure contract).
- `read_json(transport, key, *, label, logger, parse)` — `get_raw` + bytes decode + `json.loads` + `parse(obj)`, returning `None` on missing key / transport error / malformed payload so each sibling maps it to its own `_EMPTY` sentinel.

Two refinements over the issue's sketch:

1. **`parse` callback instead of returning the raw dict.** Field extraction and type coercion currently live inside the same try-block as `json.loads`, and the malformed-payload WARNING logs the raw string. Running the per-module `parse` inside the helper's try preserves both, instead of duplicating the except tuple per module.
2. **Caller passes `logger` and `label`.** All five modules already used the exact templates `"failed to read {label}: %s"` / `"malformed {label} payload %r: %s"`, so warnings keep their per-module logger names and text.

What stays per-module (per the issue): `*_KEY`, `_EMPTY`, module docstrings, `run_tag`'s `clear`/`session` + overwrite WARNING, `obs_config_owner`'s deliberate lack of `clear`, `snap_reinit`'s read-modify-write counter, `file_heartbeat`/`corr_health`'s derived `seconds_since_*` with caller-supplied `now` clamped at 0.

## Bug fixed (the one intentional behavior change)

In `run_tag.read` and `obs_config_owner.read_owner`, the `float()` coercion sat **outside** the parse try-block, so a junk payload like `{"run_tag": "x", "run_started_at_unix": "abc"}` raised an uncaught `ValueError` out of `read()` — and since `run_tag.publish`/`session` call `read()` outside their own try-blocks, it could crash a driver script, violating the module's "losing it must never block the script's main work" contract. The coercion now runs inside the helper's try via `parse`, degrading to the empty sentinel + WARNING. Regression tests added in `tests/test_run_tag.py` and `tests/test_obs_config_owner.py` (verified to fail with `ValueError` on `main`).

Two cosmetic log-text normalizations in `snap_reinit.publish`: the malformed-existing-payload WARNING is now `"malformed snap reinit heartbeat payload %r: %s"` (was `"malformed snap reinit payload %r: %s; resetting count"` — the reset is now a code comment), and a transport read error WARNs `"failed to read snap reinit heartbeat"` before the publish-failure WARNING. All existing assertions are substring matches and pass unchanged.

## Testing

- New `tests/test_redis_json_kv.py` (11 tests) covering roundtrip, missing-key silence, transport-error/malformed/parse-failure warnings, caller-logger provenance, bytes decode, and publish raise-through.
- All 5 sibling test suites pass **unchanged** (except the 2 new regression tests) — that's the behavior-preservation proof: 106 passed across the affected suites including `test_live_status_aggregator.py`.
- `ruff check` and `ruff format --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)