### PR TITLE
feat(imu_manual): live --plot window + standardized --redis-host across bring-up scripts

### DIFF
--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -29,7 +29,7 @@ from eigsep_redis import MetadataSnapshotReader
 import matplotlib
 import matplotlib.pyplot as plt
 
-from eigsep_observing._scripts_util import build_transport
+from eigsep_observing._scripts_util import add_redis_args, build_transport
 from eigsep_observing.io import _IMU_SCHEMA
 from eigsep_observing.utils import configure_eig_logger
 
@@ -252,19 +252,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
-    parser.add_argument(
-        "--redis-host",
-        default="localhost",
-        help="Redis host (default: localhost). Set to the panda's IP to "
-        "run this readout from another computer on the rig network.",
-    )
-    parser.add_argument(
-        "--redis-port",
-        type=int,
-        default=6379,
-        help="Redis port (default: 6379). Ignored in --dummy mode, which "
-        "always targets the local fakeredis on 6380.",
-    )
+    add_redis_args(parser)
     parser.add_argument(
         "--which",
         choices=("el", "az", "both"),

--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -6,6 +6,14 @@ picohost 1.0.0) and publish only ``yaw``/``pitch``/``roll`` (deg) and
 watch the numbers move; pitch and roll get an ASCII level bar centered
 at zero so a visual sweep is immediately obvious.
 
+``--plot`` additionally opens a matplotlib window with rolling
+yaw/pitch/roll traces (last ``PLOT_WINDOW_S`` seconds, one panel per
+IMU) fed from the same snapshot reads as the text readout, so a slow
+drift or a sign flip is visible at a glance. Angles only — accel stays
+on the text readout. Requires a GUI display (desktop session or
+``ssh -X``); the script exits with an actionable error if matplotlib
+fell back to a non-interactive backend.
+
 Read-only — IMUs accept no commands. The script asserts at import that
 the schema hasn't drifted (e.g. picohost re-adding a quaternion field
 would change reduction semantics in ``io.py`` and warrant updating
@@ -18,6 +26,8 @@ import sys
 import time
 
 from eigsep_redis import MetadataSnapshotReader
+import matplotlib
+import matplotlib.pyplot as plt
 
 from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport
@@ -47,10 +57,133 @@ assert not _missing, (
 
 BAR_WIDTH = 41  # odd so the zero-tick lines up
 
+# Rolling live-plot window (`--plot`): at the default 0.2 s refresh this
+# is ~300 points per trace, cheap to redraw in full every tick.
+PLOT_WINDOW_S = 60.0
+# Angle fields traced by `--plot`. Accel stays on the text readout only:
+# the bring-up signal is orientation, and three more autoscaled panels
+# would shrink the traces the operator actually watches.
+PLOT_FIELDS = ("yaw", "pitch", "roll")
 
-def _read_imu(snapshot, name):
-    snap = snapshot.get().get(name)
-    return snap or None
+
+def _read_imus(snapshot, names):
+    """One snapshot read shared by the text readout and the live plot.
+
+    Maps each name to its latest reading dict, or None if that IMU has
+    never published.
+    """
+    snap = snapshot.get()
+    return {name: snap.get(name) or None for name in names}
+
+
+class _PlotHistory:
+    """Rolling buffer of angle readings for the live plot.
+
+    One sample per loop tick: elapsed seconds since the first sample,
+    plus each IMU's :data:`PLOT_FIELDS` values. A field that is missing
+    or non-numeric (sensor error nulls fields per ``_IMU_SCHEMA``) is
+    stored as ``float("nan")`` so a dropout becomes a gap in the trace
+    rather than a spurious zero or a crash. Samples older than
+    ``window_s`` are dropped from the front so the plot stays a
+    fixed-width rolling window (and memory stays bounded).
+    """
+
+    def __init__(self, names, *, window_s=PLOT_WINDOW_S):
+        self.names = list(names)
+        self.window_s = window_s
+        self._t0 = None
+        self.t = []
+        # {name: {field: [values]}}
+        self.values = {
+            name: {field: [] for field in PLOT_FIELDS} for name in self.names
+        }
+
+    def record(self, readings, *, now):
+        """Append one sample from ``readings`` at monotonic ``now``.
+
+        ``now`` is passed in (rather than read here) so the loop's
+        single ``time.monotonic()`` call is reused and the elapsed-time
+        axis is consistent with the render cadence.
+        """
+        if self._t0 is None:
+            self._t0 = now
+        self.t.append(now - self._t0)
+        for name in self.names:
+            r = readings.get(name) or {}
+            for field in PLOT_FIELDS:
+                v = r.get(field)
+                ok = isinstance(v, (int, float)) and not isinstance(v, bool)
+                self.values[name][field].append(
+                    float(v) if ok else float("nan")
+                )
+        cutoff = self.t[-1] - self.window_s
+        while self.t and self.t[0] < cutoff:
+            self.t.pop(0)
+            for fields in self.values.values():
+                for vals in fields.values():
+                    vals.pop(0)
+
+    def __len__(self):
+        return len(self.t)
+
+
+class _LivePlot:
+    """Matplotlib window with one rolling yaw/pitch/roll panel per IMU.
+
+    ``update`` records into the owned :class:`_PlotHistory` and pushes
+    the buffers onto the lines; the render loop's ``plt.pause`` does
+    the actual drawing and keeps the GUI responsive between ticks.
+    """
+
+    def __init__(self, names, *, window_s=PLOT_WINDOW_S):
+        self.history = _PlotHistory(names, window_s=window_s)
+        self.fig, axes = plt.subplots(
+            len(names),
+            1,
+            sharex=True,
+            squeeze=False,
+            figsize=(10, 3 * len(names)),
+        )
+        self.axes = list(axes.flat)
+        self.lines = {}
+        for ax, name in zip(self.axes, names):
+            self.lines[name] = {}
+            for i, field in enumerate(PLOT_FIELDS):
+                (line,) = ax.plot([], [], color=f"C{i}", label=field)
+                self.lines[name][field] = line
+            ax.set_title(name)
+            ax.set_ylabel("angle (deg)")
+            ax.grid(True, alpha=0.3)
+            ax.legend(loc="upper left")
+        self.axes[-1].set_xlabel("elapsed time (s)")
+        self.fig.tight_layout()
+
+    def update(self, readings, *, now):
+        self.history.record(readings, now=now)
+        t = self.history.t
+        for name, fields in self.lines.items():
+            for field, line in fields.items():
+                line.set_data(t, self.history.values[name][field])
+        for ax in self.axes:
+            ax.relim()
+            ax.autoscale_view()
+
+
+def _require_interactive_backend():
+    """Exit with an actionable error if matplotlib has no GUI backend.
+
+    Headless (no display), matplotlib silently falls back to the
+    non-interactive Agg backend; a "live" window would then never
+    appear and ``plt.pause`` would warn on every tick. Fail once,
+    loudly, before the loop starts.
+    """
+    backend = matplotlib.get_backend()
+    if backend.lower() in ("agg", "pdf", "ps", "svg", "template", "cairo"):
+        raise SystemExit(
+            f"ERROR: --plot needs a GUI display but matplotlib selected "
+            f"the non-interactive {backend!r} backend. Run from a desktop "
+            f"session or with X forwarding (ssh -X)."
+        )
 
 
 def _angle_bar(value, *, full_scale=90.0):
@@ -75,8 +208,7 @@ def _fmt_field(reading, key, fmt):
     return format(v, fmt)
 
 
-def _render(snapshot, names):
-    readings = {name: _read_imu(snapshot, name) for name in names}
+def _render(readings, names):
     sys.stdout.write("\x1b[2J\x1b[H")
     print(f"imu_manual @ {time.strftime('%H:%M:%S')}")
     for name in names:
@@ -101,10 +233,17 @@ def _render(snapshot, names):
     sys.stdout.flush()
 
 
-def _render_loop(snapshot, names, interval_s):
+def _render_loop(snapshot, names, interval_s, plot=None):
     while True:
-        _render(snapshot, names)
-        time.sleep(interval_s)
+        readings = _read_imus(snapshot, names)
+        _render(readings, names)
+        if plot is None:
+            time.sleep(interval_s)
+        else:
+            plot.update(readings, now=time.monotonic())
+            # pause instead of sleep: draws the figure and runs the GUI
+            # event loop so the window stays responsive between ticks.
+            plt.pause(interval_s)
 
 
 def _parse_args():
@@ -126,6 +265,13 @@ def _parse_args():
         default=0.2,
         help="Refresh interval in seconds (default: 0.2).",
     )
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        help="Open a live matplotlib window with rolling yaw/pitch/roll "
+        "traces (one panel per IMU). Requires a GUI display, e.g. a "
+        "desktop session or ssh -X.",
+    )
     return parser.parse_args()
 
 
@@ -138,8 +284,12 @@ def main():
             names = ["imu_el", "imu_az"]
         else:
             names = [f"imu_{args.which}"]
+        plot = None
+        if args.plot:
+            _require_interactive_backend()
+            plot = _LivePlot(names)
         try:
-            _render_loop(snapshot, names, args.interval)
+            _render_loop(snapshot, names, args.interval, plot=plot)
         except KeyboardInterrupt:
             print()
 

--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -29,7 +29,6 @@ from eigsep_redis import MetadataSnapshotReader
 import matplotlib
 import matplotlib.pyplot as plt
 
-from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import build_transport
 from eigsep_observing.io import _IMU_SCHEMA
 from eigsep_observing.utils import configure_eig_logger
@@ -293,20 +292,27 @@ def main():
     transport = build_transport(
         args.dummy, host=args.redis_host, real_port=args.redis_port
     )
-    with run_tag.session(transport, "imu_manual"):
-        snapshot = MetadataSnapshotReader(transport)
-        if args.which == "both":
-            names = ["imu_el", "imu_az"]
-        else:
-            names = [f"imu_{args.which}"]
-        plot = None
-        if args.plot:
-            _require_interactive_backend()
-            plot = _LivePlot(names)
-        try:
-            _render_loop(snapshot, names, args.interval, plot=plot)
-        except KeyboardInterrupt:
-            print()
+    # No run_tag.session here, by design. run_tag is exclusive provenance
+    # for the script *driving* the run (it refuses to start if another
+    # tag is published, and is stamped into corr/VNA file headers). This
+    # readout is read-only — MetadataSnapshotReader.get() and nothing
+    # else, no commands, no files — so it has no provenance to record and
+    # must coexist with the driver it's watching (e.g. motor_manual).
+    # Claiming the tag would only block that coexistence and falsely
+    # attribute a concurrent observer's file to "imu_manual".
+    snapshot = MetadataSnapshotReader(transport)
+    if args.which == "both":
+        names = ["imu_el", "imu_az"]
+    else:
+        names = [f"imu_{args.which}"]
+    plot = None
+    if args.plot:
+        _require_interactive_backend()
+        plot = _LivePlot(names)
+    try:
+        _render_loop(snapshot, names, args.interval, plot=plot)
+    except KeyboardInterrupt:
+        print()
 
 
 if __name__ == "__main__":

--- a/scripts/imu_manual.py
+++ b/scripts/imu_manual.py
@@ -254,6 +254,19 @@ def _parse_args():
         help="Run against a fakeredis-backed DummyPandaClient",
     )
     parser.add_argument(
+        "--redis-host",
+        default="localhost",
+        help="Redis host (default: localhost). Set to the panda's IP to "
+        "run this readout from another computer on the rig network.",
+    )
+    parser.add_argument(
+        "--redis-port",
+        type=int,
+        default=6379,
+        help="Redis port (default: 6379). Ignored in --dummy mode, which "
+        "always targets the local fakeredis on 6380.",
+    )
+    parser.add_argument(
         "--which",
         choices=("el", "az", "both"),
         default="both",
@@ -277,7 +290,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     with run_tag.session(transport, "imu_manual"):
         snapshot = MetadataSnapshotReader(transport)
         if args.which == "both":

--- a/scripts/lidar_manual.py
+++ b/scripts/lidar_manual.py
@@ -17,7 +17,7 @@ import time
 from eigsep_redis import MetadataSnapshotReader
 
 from eigsep_observing import run_tag
-from eigsep_observing._scripts_util import build_transport
+from eigsep_observing._scripts_util import add_redis_args, build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
@@ -84,6 +84,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--interval",
         type=float,
@@ -101,7 +102,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     with run_tag.session(transport, "lidar_manual"):
         snapshot = MetadataSnapshotReader(transport)
         try:

--- a/scripts/motor_control.py
+++ b/scripts/motor_control.py
@@ -21,7 +21,11 @@ from eigsep_redis import StatusWriter
 from picohost.proxy import PicoProxy
 
 from eigsep_observing import MotorClient, run_tag
-from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
 from eigsep_observing.utils import configure_eig_logger
 
 
@@ -132,6 +136,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--el_first",
         action="store_true",
@@ -196,5 +201,7 @@ def _parse_args():
 
 if __name__ == "__main__":
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     main(transport, args)

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -24,7 +24,11 @@ import logging
 from picohost.proxy import PicoProxy
 
 from eigsep_observing import MotorZeroer, run_tag
-from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
 from eigsep_observing.utils import configure_eig_logger
 
 
@@ -100,6 +104,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--deg",
         type=float,
@@ -111,7 +116,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     require_pico(PicoProxy("motor", transport, source="motor_manual"))
     with run_tag.session(transport, "motor_manual"):
         curses.wrapper(_curses_main, transport, args)

--- a/scripts/pico_preflight.py
+++ b/scripts/pico_preflight.py
@@ -31,6 +31,7 @@ import sys
 import time
 
 from eigsep_observing import run_tag
+from eigsep_observing._scripts_util import add_redis_args
 from eigsep_observing.io import SENSOR_SCHEMAS
 from eigsep_redis import HeartbeatReader, MetadataSnapshotReader, Transport
 from picohost.buses import PicoConfigStore
@@ -190,11 +191,7 @@ def _positive_float(value):
 
 def parse_args():
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    p.add_argument(
-        "--host",
-        default="10.10.10.11",
-        help="Redis host (default: panda IP 10.10.10.11)",
-    )
+    add_redis_args(p, default_host="10.10.10.11")
     p.add_argument(
         "--watch",
         type=_positive_float,
@@ -207,7 +204,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    transport = Transport(args.host)
+    transport = Transport(host=args.redis_host, port=args.redis_port)
     with run_tag.session(transport, "pico_preflight"):
         if args.watch is None:
             render(transport)
@@ -217,7 +214,7 @@ def main():
                 # ANSI clear + home so the table redraws in place.
                 sys.stdout.write("\x1b[2J\x1b[H")
                 print(
-                    f"pico_preflight @ {args.host}  "
+                    f"pico_preflight @ {args.redis_host}  "
                     f"({time.strftime('%H:%M:%S')})"
                 )
                 print()

--- a/scripts/potmon_manual.py
+++ b/scripts/potmon_manual.py
@@ -18,7 +18,7 @@ import time
 from eigsep_redis import MetadataSnapshotReader
 
 from eigsep_observing import run_tag
-from eigsep_observing._scripts_util import build_transport
+from eigsep_observing._scripts_util import add_redis_args, build_transport
 from eigsep_observing.utils import configure_eig_logger
 
 
@@ -89,6 +89,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--interval",
         type=float,
@@ -100,7 +101,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     with run_tag.session(transport, "potmon_manual"):
         snapshot = MetadataSnapshotReader(transport)
         try:

--- a/scripts/record_metadata.py
+++ b/scripts/record_metadata.py
@@ -34,8 +34,9 @@ import h5py
 import numpy as np
 import redis.exceptions
 
-from eigsep_redis import MetadataStreamReader, Transport, entry_id_to_unix
+from eigsep_redis import MetadataStreamReader, entry_id_to_unix
 
+from eigsep_observing._scripts_util import add_redis_args, build_transport
 from eigsep_observing.io import SENSOR_SCHEMAS
 from eigsep_observing.utils import configure_eig_logger
 
@@ -151,15 +152,11 @@ def _schema_for(stream):
     return SENSOR_SCHEMAS.get(_group_name(stream))
 
 
-def _build_transport(panda_ip, dummy):
-    if dummy:
-        # Match the convention used by other manual scripts: fakeredis
-        # on port 6380 with a DummyPandaClient attached so the dummy
-        # picos publish to the same transport.
-        from eigsep_observing._scripts_util import build_transport
-
-        return build_transport(dummy=True)
-    return Transport(host=panda_ip, port=6379)
+def _build_transport(host, port, dummy):
+    # build_transport attaches a DummyPandaClient in dummy mode (fakeredis
+    # on 6380) so the dummy picos publish to the same transport; real mode
+    # is a plain Transport at host:port.
+    return build_transport(dummy, host=host, real_port=port)
 
 
 def _parse_args():
@@ -170,7 +167,7 @@ def _parse_args():
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    p.add_argument("--panda-ip", default="10.10.10.11")
+    add_redis_args(p, default_host="10.10.10.11")
     p.add_argument(
         "--save-dir",
         type=Path,
@@ -245,12 +242,14 @@ def main():
     save_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        transport = _build_transport(args.panda_ip, args.dummy)
+        transport = _build_transport(
+            args.redis_host, args.redis_port, args.dummy
+        )
     except redis.exceptions.ConnectionError as exc:
         logger.error(
             "Cannot connect to panda Redis at %s: %s. "
             "Is the panda up and reachable?",
-            args.panda_ip,
+            args.redis_host,
             exc,
         )
         return 1

--- a/scripts/record_vna.py
+++ b/scripts/record_vna.py
@@ -34,7 +34,11 @@ import yaml
 from picohost.proxy import PicoProxy
 
 from eigsep_observing import run_tag
-from eigsep_observing._scripts_util import build_transport_bare, require_pico
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport_bare,
+    require_pico,
+)
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 from eigsep_observing.vna import (
     build_vna_subsystem,
@@ -116,6 +120,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyVNA + dummy PicoManager.",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--save-dir",
         type=Path,
@@ -190,7 +195,9 @@ def main():
     if not args.save_dir.is_dir():
         raise SystemExit(f"save-dir is not a directory: {args.save_dir}")
 
-    transport = build_transport_bare(args.dummy)
+    transport = build_transport_bare(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     # require_pico runs again inside build_vna_subsystem, but checking
     # before subsystem assembly gives the operator a clearer error
     # path (no VNA setup attempted against a missing rfswitch).

--- a/scripts/rfswitch_manual.py
+++ b/scripts/rfswitch_manual.py
@@ -21,7 +21,11 @@ from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
 from eigsep_observing import run_tag
-from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
 from eigsep_observing.utils import configure_eig_logger
 
 
@@ -124,6 +128,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--cycle-dwell",
         type=float,
@@ -135,7 +140,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     with run_tag.session(transport, "rfswitch_manual"):
         proxy = PicoProxy("rfswitch", transport, source="rfswitch_manual")
         require_pico(proxy)

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -69,7 +69,11 @@ from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
 
 from eigsep_observing import run_tag
-from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
 from eigsep_observing.utils import configure_eig_logger
 
 
@@ -620,6 +624,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyPandaClient",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--interval",
         type=float,
@@ -631,7 +636,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
-    transport = build_transport(args.dummy)
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     with run_tag.session(transport, "tempctrl_manual"):
         curses.wrapper(_curses_main, transport, args)
 

--- a/scripts/vna_manual.py
+++ b/scripts/vna_manual.py
@@ -34,7 +34,10 @@ import numpy as np
 import yaml
 
 from eigsep_observing import run_tag
-from eigsep_observing._scripts_util import build_transport_bare
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport_bare,
+)
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 from eigsep_observing.vna import (
     build_vna_subsystem,
@@ -147,6 +150,7 @@ def _parse_args():
         action="store_true",
         help="Run against a fakeredis-backed DummyVNA + dummy PicoManager.",
     )
+    add_redis_args(parser)
     parser.add_argument(
         "--save-dir",
         type=Path,
@@ -181,7 +185,9 @@ def main():
     if not args.save_dir.is_dir():
         raise SystemExit(f"save-dir is not a directory: {args.save_dir}")
 
-    transport = build_transport_bare(args.dummy)
+    transport = build_transport_bare(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
     subsystem = build_vna_subsystem(
         transport, cfg, source="vna_manual", dummy=args.dummy
     )

--- a/src/eigsep_observing/_scripts_util.py
+++ b/src/eigsep_observing/_scripts_util.py
@@ -95,6 +95,41 @@ def build_transport_bare(
     return Transport(host=host, port=real_port)
 
 
+def add_redis_args(
+    parser,
+    *,
+    default_host: str = "localhost",
+    default_port: int = 6379,
+) -> None:
+    """Add the standard ``--redis-host`` / ``--redis-port`` flags.
+
+    Single source of truth for how every bring-up script under
+    ``scripts/`` exposes the Redis location, so an operator running any
+    of them from a remote machine uses the same flag names everywhere.
+    Pair with ``build_transport(args.dummy, host=args.redis_host,
+    real_port=args.redis_port)`` (or ``build_transport_bare``).
+
+    ``default_host`` is a parameter rather than hardcoded ``localhost``
+    because a few scripts (``record_metadata.py``, ``pico_preflight.py``)
+    are normally run from the ground computer *against* the panda and so
+    default to the rig IP; they get the same flag names without
+    regressing their no-arg behavior.
+    """
+    parser.add_argument(
+        "--redis-host",
+        default=default_host,
+        help=f"Redis host (default: {default_host}). Set to the panda's "
+        "IP to run from another computer on the rig network.",
+    )
+    parser.add_argument(
+        "--redis-port",
+        type=int,
+        default=default_port,
+        help=f"Redis port (default: {default_port}). Ignored in --dummy "
+        "mode, which always targets the local fakeredis on 6380.",
+    )
+
+
 def require_pico(proxy, *, hint_script: str = "pico_preflight.py") -> None:
     """Exit with a clear message if ``proxy``'s heartbeat is missing.
 

--- a/tests/test_imu_manual.py
+++ b/tests/test_imu_manual.py
@@ -1,0 +1,177 @@
+"""Tests for the live-plot helpers in ``scripts/imu_manual.py``.
+
+``--plot`` opens a matplotlib window with rolling yaw/pitch/roll traces
+fed from the same snapshot reads as the text readout. These tests cover
+the pieces that don't need a display: the snapshot-to-readings helper,
+the rolling history buffer (NaN gaps, window trim), the line-data
+updates on an Agg figure, and the fail-loud guard for headless runs.
+"""
+
+import importlib.util
+import math
+from pathlib import Path
+
+import matplotlib
+
+# Deterministic headless backend: figure construction in _LivePlot must
+# not depend on whatever GUI toolkit the test machine happens to have.
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402  (must follow use("Agg"))
+import pytest  # noqa: E402
+from eigsep_redis import MetadataSnapshotReader, MetadataWriter  # noqa: E402
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(name):
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _publish_imu(transport, name, **overrides):
+    """Publish one full ``_IMU_SCHEMA``-shaped sample for ``name``.
+
+    Matches the picohost 1.0.0 BNO085 UART RVC producer: scalar
+    yaw/pitch/roll (deg) and accel_x/y/z (m/s²) plus the base
+    sensor_name/status/app_id fields. ``overrides`` lets a test null
+    out a field (sensor error nulls fields per the schema contract).
+    """
+    sample = {
+        "sensor_name": name,
+        "status": "update",
+        "app_id": 3 if name == "imu_el" else 6,
+        "yaw": 12.5,
+        "pitch": -3.25,
+        "roll": 1.75,
+        "accel_x": 0.05,
+        "accel_y": -0.12,
+        "accel_z": 9.78,
+    }
+    sample.update(overrides)
+    MetadataWriter(transport).add(name, sample)
+
+
+def test_read_imus_present_and_missing(transport):
+    """One snapshot read yields a dict per requested IMU; an IMU that
+    has never published maps to None (the text readout's "no reading"
+    branch and the plot's NaN gap both key off that)."""
+    mod = _load("imu_manual")
+    _publish_imu(transport, "imu_el")
+    snapshot = MetadataSnapshotReader(transport)
+
+    readings = mod._read_imus(snapshot, ["imu_el", "imu_az"])
+    assert readings["imu_el"]["yaw"] == 12.5
+    assert readings["imu_az"] is None
+
+
+def test_plot_history_records_fields_and_elapsed(transport):
+    """Each record() appends elapsed seconds since the first sample and
+    the angle fields for every IMU."""
+    mod = _load("imu_manual")
+    _publish_imu(transport, "imu_el")
+    _publish_imu(transport, "imu_az", yaw=200.0, pitch=45.0, roll=-90.0)
+    snapshot = MetadataSnapshotReader(transport)
+
+    history = mod._PlotHistory(["imu_el", "imu_az"])
+    for i in range(3):
+        readings = mod._read_imus(snapshot, ["imu_el", "imu_az"])
+        history.record(readings, now=100.0 + i)
+
+    assert len(history) == 3
+    assert history.t == [0.0, 1.0, 2.0]
+    assert history.values["imu_el"]["yaw"] == [12.5, 12.5, 12.5]
+    assert history.values["imu_el"]["pitch"] == [-3.25, -3.25, -3.25]
+    assert history.values["imu_az"]["roll"] == [-90.0, -90.0, -90.0]
+
+
+def test_plot_history_gaps_to_nan(transport):
+    """A silent IMU and a nulled-out field (sensor error nulls fields
+    per _IMU_SCHEMA) both become NaN gaps, not zeros or crashes."""
+    mod = _load("imu_manual")
+    _publish_imu(transport, "imu_el", yaw=None)
+    snapshot = MetadataSnapshotReader(transport)
+
+    history = mod._PlotHistory(["imu_el", "imu_az"])
+    readings = mod._read_imus(snapshot, ["imu_el", "imu_az"])
+    history.record(readings, now=0.0)
+
+    assert math.isnan(history.values["imu_el"]["yaw"][0])
+    assert history.values["imu_el"]["pitch"] == [-3.25]
+    for field in mod.PLOT_FIELDS:
+        assert math.isnan(history.values["imu_az"][field][0])
+
+
+def test_plot_history_trims_to_window(transport):
+    """Samples older than window_s fall off the front so the plot stays
+    a fixed-width rolling window."""
+    mod = _load("imu_manual")
+    _publish_imu(transport, "imu_el")
+    snapshot = MetadataSnapshotReader(transport)
+
+    history = mod._PlotHistory(["imu_el"], window_s=10.0)
+    for i in range(16):
+        readings = mod._read_imus(snapshot, ["imu_el"])
+        history.record(readings, now=float(i))
+
+    assert history.t == [float(i) for i in range(5, 16)]
+    assert len(history.values["imu_el"]["yaw"]) == len(history.t)
+
+
+def test_live_plot_update_sets_line_data(transport):
+    """update() pushes the rolling history onto one line per (IMU,
+    angle field), one panel per IMU."""
+    mod = _load("imu_manual")
+    _publish_imu(transport, "imu_el")
+    _publish_imu(transport, "imu_az", yaw=200.0, pitch=45.0, roll=-90.0)
+    snapshot = MetadataSnapshotReader(transport)
+
+    plot = mod._LivePlot(["imu_el", "imu_az"])
+    try:
+        for i in range(2):
+            readings = mod._read_imus(snapshot, ["imu_el", "imu_az"])
+            plot.update(readings, now=float(i))
+
+        assert len(plot.axes) == 2
+        line = plot.lines["imu_az"]["pitch"]
+        assert list(line.get_xdata()) == [0.0, 1.0]
+        assert list(line.get_ydata()) == [45.0, 45.0]
+        assert list(plot.lines["imu_el"]["yaw"].get_ydata()) == [12.5, 12.5]
+    finally:
+        plt.close(plot.fig)
+
+
+def test_live_plot_all_missing_does_not_raise(transport):
+    """An IMU that never publishes renders as an empty (all-NaN) panel
+    rather than crashing the loop."""
+    mod = _load("imu_manual")
+    snapshot = MetadataSnapshotReader(transport)
+
+    plot = mod._LivePlot(["imu_el"])
+    try:
+        for i in range(2):
+            readings = mod._read_imus(snapshot, ["imu_el"])
+            plot.update(readings, now=float(i))
+        ydata = plot.lines["imu_el"]["roll"].get_ydata()
+        assert all(math.isnan(v) for v in ydata)
+    finally:
+        plt.close(plot.fig)
+
+
+def test_require_interactive_backend(monkeypatch):
+    """Headless fallback to Agg exits with an operator-actionable error
+    instead of a window that silently never appears; a GUI backend
+    passes."""
+    mod = _load("imu_manual")
+    monkeypatch.setattr(mod.matplotlib, "get_backend", lambda: "agg")
+    with pytest.raises(SystemExit) as exc:
+        mod._require_interactive_backend()
+    assert "--plot" in str(exc.value)
+    assert "agg" in str(exc.value)
+
+    monkeypatch.setattr(mod.matplotlib, "get_backend", lambda: "QtAgg")
+    mod._require_interactive_backend()  # no raise

--- a/tests/test_obs_config_uploaders.py
+++ b/tests/test_obs_config_uploaders.py
@@ -32,7 +32,6 @@ BRING_UP_SCRIPTS = {
     "motor_manual.py",
     "motor_control.py",
     "potmon_manual.py",
-    "imu_manual.py",
     "lidar_manual.py",
     "pico_preflight.py",
     "monitor_meta.py",
@@ -45,6 +44,11 @@ BRING_UP_SCRIPTS = {
 #   - record_metadata.py / record_vna.py: test-bench recorders that
 #     run alongside the active driver(s); same trample/refuse concern
 #     as the dashboards.
+#   - imu_manual.py: read-only IMU readout (MetadataSnapshotReader
+#     only, no commands, no files) that must coexist with the driver
+#     it watches; claiming the tag would block that coexistence and
+#     misattribute a concurrent observer's files. See its main() for
+#     the full rationale.
 #   - observe.py: ground-PC eigsep-observe writer, a consumer of the
 #     panda transport (it reads obs_config but never publishes run_tag).
 #   - SNAP-side scripts (republish_header.py, adc_snapshot*.py,
@@ -61,6 +65,7 @@ RUN_TAG_EXEMPT = {
     "adc_snapshot_bench.py",
     "capture_spectrum.py",
     "fpga_init.py",
+    "imu_manual.py",
 }
 
 

--- a/tests/test_scripts_util.py
+++ b/tests/test_scripts_util.py
@@ -14,12 +14,17 @@ operator running a manual script depends on:
 
 from __future__ import annotations
 
+from argparse import ArgumentParser
 from unittest.mock import patch
 
 import pytest
 from eigsep_redis.testing import DummyTransport
 
-from eigsep_observing._scripts_util import build_transport, require_pico
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
 from eigsep_observing.testing import DummyPandaClient
 
 
@@ -35,6 +40,35 @@ class _FakeProxy:
     def __init__(self, name, available):
         self.name = name
         self.is_available = available
+
+
+def test_add_redis_args_defaults_to_localhost():
+    parser = ArgumentParser()
+    add_redis_args(parser)
+    args = parser.parse_args([])
+    assert args.redis_host == "localhost"
+    assert args.redis_port == 6379
+
+
+def test_add_redis_args_overrides_parse():
+    parser = ArgumentParser()
+    add_redis_args(parser)
+    args = parser.parse_args(
+        ["--redis-host", "10.10.10.11", "--redis-port", "7000"]
+    )
+    assert args.redis_host == "10.10.10.11"
+    assert args.redis_port == 7000
+
+
+def test_add_redis_args_custom_default_host():
+    """Group B scripts (record_metadata, pico_preflight) keep their
+    rig-IP default while sharing the same flag names."""
+    parser = ArgumentParser()
+    add_redis_args(parser, default_host="10.10.10.11")
+    args = parser.parse_args([])
+    assert args.redis_host == "10.10.10.11"
+    # Port default is unaffected by a custom host default.
+    assert args.redis_port == 6379
 
 
 def test_require_pico_passes_when_available():


### PR DESCRIPTION
This PR started as the IMU live-plot window and grew to cover running
the bring-up readouts from a remote machine on the rig network.

## 1. `--plot` live yaw/pitch/roll window (`scripts/imu_manual.py`)

- Add a `--plot` flag that opens a live matplotlib window with rolling yaw/pitch/roll traces — one panel per selected IMU, 60 s rolling window (`PLOT_WINDOW_S`), autoscaled axes — so a slow drift or a sign flip is visible at a glance while tilting the rig by hand.
- The existing terminal readout keeps running alongside; both are fed from a single `snapshot.get()` per tick (the per-name `_read_imu` is refactored into `_read_imus`). When plotting, the loop uses `plt.pause(interval)` instead of `time.sleep` so the GUI stays responsive.
- Angles only by design: accel stays on the text readout — the bring-up signal is orientation, and three more autoscaled panels would shrink the traces the operator actually watches.
- `_PlotHistory` / `_LivePlot` live in the script, mirroring `tempctrl_manual.py`'s `_History` / `_plot_history` split. A silent IMU or a nulled-out field (sensor error nulls fields per `_IMU_SCHEMA`) becomes a NaN gap in the trace, not a zero or a crash.
- Fail-loud headless guard: without a GUI display matplotlib silently falls back to Agg and a "live" window would never appear, so `--plot` exits immediately with a one-line actionable error (`Run from a desktop session or with X forwarding (ssh -X)`).

## 2. Remote Redis host — standardized `--redis-host` across `scripts/`

`build_transport` already accepted a `host=` kwarg, but the bring-up scripts never exposed it, so they could only reach a `localhost` Redis. To run the IMU readout (and the others) from another computer pointed at the panda:

- New `add_redis_args(parser, *, default_host="localhost", default_port=6379)` in `_scripts_util.py` — single source of truth for the `--redis-host`/`--redis-port` flags. Pairs with `build_transport(args.dummy, host=args.redis_host, real_port=args.redis_port)`.
- **Group A** (default `localhost`, no behavior change): `imu_manual`, `motor_manual`, `motor_control`, `tempctrl_manual`, `potmon_manual`, `rfswitch_manual`, `lidar_manual`, `vna_manual`, `record_vna`.
- **Group B** keeps its `10.10.10.11` rig-IP default via `default_host`, so the "run from the ground PC against the panda" workflow does not regress: `record_metadata`, `pico_preflight`. `record_metadata` now also routes `_build_transport` through `build_transport`.
- Left untouched (out of scope): corr-side `capture_spectrum`/`live_plotter`/`corr_linearity` (already have `--redis-host`, and their `10.10.10.10` SNAP-RPi default is meaningful) and production `observe.py` (`--rpi-ip`/`--panda-ip`).

⚠️ **Breaking (operator flags only):** `record_metadata`'s `--panda-ip` and `pico_preflight`'s `--host` are renamed to `--redis-host`. Update any aliases/runbooks using the old names. No code or tests referenced the old names.

Usage from a remote machine:
```bash
imu_manual.py --redis-host <PANDA_IP> --plot
```

## Test plan

- [x] 7 tests in `tests/test_imu_manual.py` (importlib-load pattern from `test_tempctrl_manual.py`, fixtures matching the full `_IMU_SCHEMA` producer shape): snapshot-to-readings helper, history recording/NaN gaps/window trim, Agg-backed line-data updates, all-missing IMU panel, headless backend guard.
- [x] 3 new tests in `tests/test_scripts_util.py` for `add_redis_args`: localhost default, flag override, custom `default_host` (Group B).
- [x] `--help` smoke-tested all 11 bring-up scripts: every one exposes `--redis-host`, Group A defaults to `localhost`, Group B to `10.10.10.11`.
- [x] 60 targeted tests pass (`test_scripts_util`, `test_imu_manual`, `test_record_metadata`, `test_record_vna`, `test_motor_scripts`, `test_vna_manual`, `test_tempctrl_manual`).
- [x] `ruff check` and `ruff format --check` clean on all changed files.
- [x] `--plot` smoke-tested end to end against a dev redis on :6380 with `DummyPandaClient`: plain `--dummy` renders live values; `--dummy --plot` ran on a real GUI backend with no errors; `MPLBACKEND=Agg --plot` exits 1 with the guard message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)