### PR TITLE
fix(live_status): drain-time age semantics + poll-don't-wait ticks

### DIFF
--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -14,10 +14,15 @@ Design notes
   surfaces. It holds no ``Writer`` of any kind. Enforced by
   ``tests/test_redis.py::test_consumer_role_surfaces_are_structural``.
 
-- **Blocking reads use finite timeouts.** Redis ``XREAD block=0`` means
-  "block forever"; a drain thread that parked inside Redis would ignore
-  ``stop_event.set()`` and never join on shutdown. Every blocking reader
-  call here passes a finite timeout and loops on the stop event.
+- **Tick-loop reads poll, they don't wait.** The drain loops already
+  pace themselves on ``snap_tick_s`` / ``panda_tick_s``; a stream read
+  inside a tick only needs to consume what's already in Redis, so every
+  tick-loop read passes :data:`_POLL_TIMEOUT_S` (~1 ms — the smallest
+  finite block this API can express; ``timeout=None`` maps to ``XREAD
+  block=0``, which is "block forever" and would ignore
+  ``stop_event.set()``). The one deliberate blocker is the dedicated
+  VNA thread (:data:`_VNA_BLOCK_S`), which parks inside Redis between
+  ~1/hour sweeps and wakes for the stop check on each timeout.
 
 - **Threshold recompute.** When ``corr_header["integration_time"]``
   changes (re-sync), :meth:`_recompute_thresholds` rebuilds
@@ -82,6 +87,14 @@ _ADC_STATS_STREAM = f"stream:{_ADC_STATS_KEY}"
 # ~1/hour producer.
 _VNA_BLOCK_S = 1.0
 
+# Effective "don't wait" timeout for stream reads inside the tick
+# loops. The reader API maps ``timeout=None`` to ``XREAD block=0``
+# (block forever), so a 1 ms block is the closest expressible thing to
+# a non-blocking read: it consumes entries already in Redis and
+# returns immediately when a stream is quiet, keeping the tick period
+# pinned to snap_tick_s / panda_tick_s.
+_POLL_TIMEOUT_S = 0.001
+
 
 @dataclass
 class StateSnapshot:
@@ -130,6 +143,14 @@ class StateSnapshot:
     metadata_latest: dict[str, dict] = field(default_factory=dict)
     metadata_last_stream_unix: dict[str, float] = field(default_factory=dict)
     metadata_snapshot: dict[str, Any] = field(default_factory=dict)
+    # Wallclock of the last *successful* snapshot-hash read. The
+    # /api/metadata age computation is ``read_unix - {key}_ts`` —
+    # producer age at drain time — so the dashboard's own cache
+    # staleness never inflates a healthy sensor's displayed age. Does
+    # not advance on failed reads: a downed panda bus freezes the
+    # cached ages (last-known values) and is surfaced via
+    # ``panda_connected``, not by aging every tile.
+    metadata_snapshot_read_unix: Optional[float] = None
 
     # Wallclock at which the current rfswitch ``sw_state_name`` first
     # appeared. Distinct from ``metadata_last_stream_unix["rfswitch"]``
@@ -268,10 +289,10 @@ class LiveStatusAggregator:
         Optional pre-built :class:`Thresholds`. If ``None``, one is
         built from the bundled YAML and the first corr header seen.
     snap_tick_s, panda_tick_s
-        Loop cadence for the drain threads.
-    read_timeout_s
-        Finite timeout for blocking stream reads (``CorrReader``,
-        ``AdcSnapshotReader``, ``StatusReader``). Must be > 0.
+        Loop cadence for the drain threads. Stream reads inside a tick
+        are ~1 ms polls (see :data:`_POLL_TIMEOUT_S`), so the tick
+        cadence is the single knob controlling how stale the cached
+        state can be.
     stop_event
         External stop event; one is created if not supplied.
     """
@@ -283,24 +304,17 @@ class LiveStatusAggregator:
         obs_cfg: dict,
         *,
         thresholds: Optional[Thresholds] = None,
-        snap_tick_s: float = 0.5,
-        panda_tick_s: float = 0.5,
-        read_timeout_s: float = 0.2,
+        snap_tick_s: float = 0.25,
+        panda_tick_s: float = 0.25,
         snap_fpga_probe_interval_s: float = 5.0,
         snap_fpga_host_override: Optional[str] = None,
         stop_event: Optional[threading.Event] = None,
     ):
-        if read_timeout_s <= 0:
-            raise ValueError(
-                "read_timeout_s must be > 0; "
-                "zero means block-forever in Redis semantics"
-            )
         self.transport_snap = transport_snap
         self.transport_panda = transport_panda
         self.obs_cfg = dict(obs_cfg)
         self._snap_tick_s = snap_tick_s
         self._panda_tick_s = panda_tick_s
-        self._read_timeout_s = read_timeout_s
         self._snap_fpga_probe_interval_s = snap_fpga_probe_interval_s
         self._snap_fpga_host_override = snap_fpga_host_override
         self._stop_event = stop_event or threading.Event()
@@ -649,14 +663,15 @@ class LiveStatusAggregator:
     def _read_corr(self) -> tuple[Optional[tuple], bool]:
         """Drain the corr stream to the latest entry; reshape the tail.
 
-        ``CorrReader.read`` consumes one stream entry per call. The
-        producer publishes at the integration cadence (~4 Hz at the
-        default ``corr_acc_len``); this drain ticks at
-        ``1/snap_tick_s`` (~2 Hz). Reading one entry per tick falls
-        behind by ~2 entries/sec, which surfaces as a growing display
-        lag — the legacy ``live_plotter`` polls faster than the
-        producer (FuncAnimation at 20 Hz) and therefore never lags.
-        Drain to the tail so the plot always reflects the most recent
+        ``CorrReader.read`` consumes one stream entry per call, and
+        the producer publishes at the integration cadence (~4 Hz at
+        the default ``corr_acc_len``) — comparable to the drain's
+        ``1/snap_tick_s``. Reading one entry per tick would therefore
+        fall behind whenever the producer outpaces the drain, which
+        surfaces as a growing display lag — the legacy
+        ``live_plotter`` polls faster than the producer
+        (FuncAnimation at 20 Hz) and therefore never lags. Drain to
+        the tail so the plot always reflects the most recent
         integration; intermediate entries are discarded because the
         dashboard renders current state, not history.
 
@@ -669,16 +684,16 @@ class LiveStatusAggregator:
         """
         last_acc_cnt: Optional[int] = None
         last_pairs: Optional[dict] = None
-        # First read waits up to read_timeout_s for *any* new entry;
-        # subsequent reads use a tiny timeout so the drain only consumes
-        # entries already in Redis at this moment and never blocks
-        # waiting for the producer's next push (which would let a
-        # fast producer starve _snap_tick from ever returning).
-        timeout = self._read_timeout_s
+        # Poll, don't wait: the drain only consumes entries already in
+        # Redis at this moment and never blocks waiting for the
+        # producer's next push (which would let a fast producer starve
+        # _snap_tick from ever returning, and a quiet one inflate the
+        # tick period). A new integration is picked up at worst one
+        # snap_tick_s later.
         while True:
             try:
                 acc_cnt, pairs_data = self.corr_reader.read(
-                    timeout=timeout, unpack=True
+                    timeout=_POLL_TIMEOUT_S, unpack=True
                 )
             except TimeoutError:
                 break
@@ -692,7 +707,6 @@ class LiveStatusAggregator:
                 break
             last_acc_cnt = acc_cnt
             last_pairs = pairs_data
-            timeout = 0.001
         if last_acc_cnt is None:
             return None, True
         try:
@@ -703,13 +717,14 @@ class LiveStatusAggregator:
         return (last_acc_cnt, reshaped), True
 
     def _read_adc_snapshot(self) -> tuple[Optional[tuple], bool]:
-        """One AdcSnapshotReader.read call with a finite timeout.
+        """One AdcSnapshotReader.read poll (no waiting; ~1 Hz producer
+        entries are picked up at worst one snap_tick_s after arrival).
 
         Returns ``(result, ok)`` — see :meth:`_read_corr` for semantics.
         """
         try:
             data, sidecar = self.adc_snapshot_reader.read(
-                timeout=self._read_timeout_s
+                timeout=_POLL_TIMEOUT_S
             )
         except TimeoutError:
             return None, True
@@ -897,6 +912,7 @@ class LiveStatusAggregator:
 
             if snap is not None:
                 s.metadata_snapshot = snap
+                s.metadata_snapshot_read_unix = now
 
             if hb is not None:
                 s.panda_heartbeat = bool(hb)
@@ -930,22 +946,23 @@ class LiveStatusAggregator:
                     s.panda_config_upload_unix = None
 
     def _drain_status(self) -> tuple[list[tuple[int, str]], bool]:
-        """Drain StatusReader until the next call times out.
+        """Drain StatusReader until the next poll comes back empty.
 
-        Each read is capped at :attr:`_read_timeout_s` so shutdown is
-        prompt. Returns ``(entries, ok)`` where ``ok`` is True unless a
-        transport-level exception fired; a clean timeout (``level is
-        None`` on the first read) is treated as a successful empty
-        drain because the round-trip to Redis completed.
+        Each read is a :data:`_POLL_TIMEOUT_S` poll — the loop-exit
+        read must not wait for the producer, or every steady-state
+        tick (status stream quiet) carries the full timeout as a
+        hidden tail-block on the tick period. Returns ``(entries,
+        ok)`` where ``ok`` is True unless a transport-level exception
+        fired; an empty poll (``level is None`` on the first read) is
+        treated as a successful empty drain because the round-trip to
+        Redis completed.
         """
         out: list[tuple[int, str]] = []
         # Safety bound: never loop more than N times per tick in
         # case the producer is hosing the stream.
         for _ in range(100):
             try:
-                level, msg = self.status_reader.read(
-                    timeout=self._read_timeout_s
-                )
+                level, msg = self.status_reader.read(timeout=_POLL_TIMEOUT_S)
             except Exception as exc:
                 logger.error("status_reader.read failed: %s", exc)
                 return out, False

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -305,18 +305,28 @@ def _corr_payload(
     return payload
 
 
-def _metadata_payload(
-    state: StateSnapshot, thresholds: Thresholds, now: float
-) -> dict:
+def _metadata_payload(state: StateSnapshot, thresholds: Thresholds) -> dict:
     """Return per-sensor ``{value, ts_unix, age_s, status, classify}``.
 
     ``classify`` is the tile color tag. It uses the panda ``_ts``
     stamps that :class:`MetadataSnapshotReader` returns alongside each
     sensor's value; a stale _ts is rendered as ``"stale"`` regardless
     of the value-based band.
+
+    ``age_s`` is the producer's age *at the moment the drain read the
+    snapshot* (``metadata_snapshot_read_unix - {key}_ts``), not at the
+    moment of this request — computing against the request wallclock
+    folded the aggregator's cache staleness (up to a full tick period)
+    into every sensor's age, making healthy 200 ms picos read as ~1 s
+    old. A dead sensor still ages: successful drains keep advancing
+    the read stamp while its ``_ts`` freezes. A dead panda *bus*
+    freezes both (last-known values); that state is surfaced by
+    ``panda_connected``, not here. Clamped at zero because ``_ts`` is
+    panda-clock and the read stamp is ground-clock.
     """
     out: dict[str, dict] = {}
     snapshot = state.metadata_snapshot or {}
+    read_unix = state.metadata_snapshot_read_unix
     for sensor, value in snapshot.items():
         if sensor.endswith("_ts"):
             continue
@@ -325,7 +335,10 @@ def _metadata_payload(
             ts_unix = float(ts_unix) if ts_unix is not None else None
         except (TypeError, ValueError):
             ts_unix = None
-        age_s = (now - ts_unix) if ts_unix is not None else None
+        if ts_unix is not None and read_unix is not None:
+            age_s = max(0.0, read_unix - ts_unix)
+        else:
+            age_s = None
         status = value.get("status") if isinstance(value, dict) else None
         classify_by_sig: dict[str, str] = {}
         # For every registered signal whose "domain" matches this
@@ -649,9 +662,7 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
     def api_metadata():
         state = aggregator.snapshot()
         return jsonify(
-            _envelope(
-                _metadata_payload(state, aggregator.thresholds, time.time())
-            )
+            _envelope(_metadata_payload(state, aggregator.thresholds))
         )
 
     @app.route("/api/adc")

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -1,6 +1,9 @@
 "use strict";
 
-const POLL_MS = 1000;
+// 2 Hz repaint matches the aggregator's 0.25 s drain ticks closely
+// enough that lab operators see sensor wiggles near-live; field
+// operation tolerates anything slower, so this is sized for the lab.
+const POLL_MS = 500;
 // Per-pico heartbeat staleness threshold. Healthy picos push at ~0.2 s;
 // an age past this means the heartbeat has effectively stopped, so the
 // pane flags amber rather than implying the sensor is still live.

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -108,7 +108,6 @@ def agg(seeded):
         obs_cfg=OBS_CFG,
         snap_tick_s=0.01,
         panda_tick_s=0.01,
-        read_timeout_s=0.05,
     )
     yield a
     a.stop(timeout=1.0)
@@ -159,17 +158,6 @@ def test_aggregator_double_start_raises(agg):
             agg.start()
     finally:
         agg.stop()
-
-
-def test_aggregator_rejects_zero_timeout(seeded):
-    snap, panda = seeded
-    with pytest.raises(ValueError):
-        LiveStatusAggregator(
-            transport_snap=snap,
-            transport_panda=panda,
-            obs_cfg=OBS_CFG,
-            read_timeout_s=0,
-        )
 
 
 # ---------------------------------------------------------------------
@@ -359,13 +347,15 @@ def test_snap_tick_ingests_adc_snapshot_and_computes_clipping(agg, seeded):
 
 def test_snap_tick_no_corr_data_yet_does_not_block(agg):
     """A freshly-started aggregator with no corr publisher should
-    complete its tick quickly (finite timeout) and record
-    snap_connected=True thanks to get_header/config succeeding."""
+    complete its tick quickly (never-registered streams short-circuit
+    to the absent-sentinel) and record snap_connected=True thanks to
+    get_header/config succeeding."""
     t0 = time.time()
     agg._snap_tick()
     dt = time.time() - t0
-    # read_timeout_s=0.05, so the tick shouldn't take more than ~0.3 s
-    # even with both corr and adc_snapshot reads timing out.
+    # Generous bound: fakeredis pays a one-off setup cost on the first
+    # read; the registered-but-quiet timing contract is pinned tightly
+    # by test_snap_tick_completes_quickly_when_streams_quiet.
     assert dt < 1.0
     state = agg.snapshot()
     # Header + config were seeded; snap_connected should still flip True.
@@ -426,6 +416,130 @@ def test_panda_tick_captures_snapshot_hash(agg, seeded):
     assert state.metadata_snapshot["lidar"]["distance_m"] == 1.5
     # _ts bookkeeping key is included in the raw snapshot.
     assert "lidar_ts" in state.metadata_snapshot
+
+
+def test_panda_tick_stamps_snapshot_read_unix(agg, seeded):
+    """Each successful snapshot-hash read stamps the wallclock it
+    happened at. The /api/metadata age computation uses this stamp
+    (drain-time semantics) so a healthy 200 ms producer doesn't get
+    the dashboard's own cache staleness folded into its displayed
+    age."""
+    _, panda = seeded
+    MetadataWriter(panda).add(
+        "lidar",
+        {
+            "sensor_name": "lidar",
+            "app_id": 5,
+            "status": "update",
+            "distance_m": 1.5,
+        },
+    )
+
+    t0 = time.time()
+    agg._panda_tick()
+    t1 = time.time()
+
+    state = agg.snapshot()
+    assert state.metadata_snapshot_read_unix is not None
+    assert t0 <= state.metadata_snapshot_read_unix <= t1
+
+
+def test_panda_tick_read_stamp_frozen_when_snapshot_read_fails(
+    agg, seeded, monkeypatch
+):
+    """When the snapshot read fails (panda bus down), the read stamp
+    must not advance — the cached ages freeze at their last-known
+    values and the bus-down state is surfaced by ``panda_connected``,
+    not by artificially aging every sensor tile."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    _, panda = seeded
+    MetadataWriter(panda).add(
+        "lidar",
+        {
+            "sensor_name": "lidar",
+            "app_id": 5,
+            "status": "update",
+            "distance_m": 1.5,
+        },
+    )
+    agg._panda_tick()
+    stamp = agg.snapshot().metadata_snapshot_read_unix
+    assert stamp is not None
+
+    def _down(*args, **kwargs):
+        raise RedisConnectionError("panda unreachable")
+
+    monkeypatch.setattr(agg.metadata_snapshot, "get", _down)
+    agg._panda_tick()
+
+    state = agg.snapshot()
+    assert state.metadata_snapshot_read_unix == stamp
+    # The cached snapshot itself is also retained (last-known values).
+    assert "lidar" in state.metadata_snapshot
+
+
+def test_panda_tick_completes_quickly_with_empty_streams(seeded):
+    """Regression: the status drain used to exit its loop only via a
+    blocking ``XREAD block=200ms`` timing out, so every steady-state
+    tick (status stream quiet) carried a hidden +0.2 s — inflating the
+    effective tick period ~40% past ``panda_tick_s`` and with it the
+    metadata cache staleness. Tick-loop reads must poll, not wait."""
+    snap, panda = seeded
+    a = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+    )
+    try:
+        # Warm-up tick: fakeredis pays a one-off ~300 ms setup cost on
+        # the first blocking read, which would swamp the measurement.
+        a._panda_tick()
+        t0 = time.time()
+        a._panda_tick()
+        dt = time.time() - t0
+        assert dt < 0.15, f"panda tick took {dt:.3f} s on empty streams"
+    finally:
+        a.stop(timeout=1.0)
+
+
+def test_snap_tick_completes_quickly_when_streams_quiet(seeded):
+    """Same poll-don't-wait contract for the SNAP tick.
+
+    The corr and adc_snapshot streams must exist (be registered) but
+    have no pending entries — that's the steady state between
+    integrations, and the one where the reads used to block
+    ``read_timeout_s`` each (0.4 s combined per tick). A
+    never-registered stream short-circuits to the absent-sentinel
+    without blocking, which would not exercise the regression."""
+    snap, panda = seeded
+    CorrWriter(snap).add(
+        _make_corr_row(), cnt=1, sync_time=1000.0, dtype=DTYPE
+    )
+    AdcSnapshotWriter(snap).add(
+        np.zeros((2, 2, 100), dtype=np.int8),
+        unix_ts=time.time(),
+        sync_time=1000.0,
+        corr_acc_cnt=1,
+        wiring={"ants": {}},
+    )
+    _rewind_streams(snap, ["stream:corr", "stream:adc_snapshot"])
+    a = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+    )
+    try:
+        # Warm-up tick consumes the seeded entries (and absorbs the
+        # one-off fakeredis setup cost); the measured tick then sees
+        # registered-but-quiet streams.
+        a._snap_tick()
+        t0 = time.time()
+        a._snap_tick()
+        dt = time.time() - t0
+        assert dt < 0.15, f"snap tick took {dt:.3f} s with quiet streams"
+    finally:
+        a.stop(timeout=1.0)
 
 
 def test_panda_tick_reads_status_log(agg, seeded):

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -231,7 +231,6 @@ def agg_primed():
         transport_snap=snap,
         transport_panda=panda,
         obs_cfg=OBS_CFG,
-        read_timeout_s=0.05,
     )
     agg._snap_tick()
     agg._panda_tick()
@@ -462,7 +461,6 @@ def test_corr_and_adc_routes_use_wiring_labels_when_published():
         transport_snap=snap,
         transport_panda=panda,
         obs_cfg=OBS_CFG,
-        read_timeout_s=0.05,
     )
     try:
         agg._snap_tick()
@@ -494,6 +492,88 @@ def test_metadata_route_includes_classify(client):
     lna = data["tempctrl_lna"]
     # tempctrl_lna.T_now = 25.1 is inside healthy (24.0, 26.0).
     assert lna["classify"]["tempctrl_lna.T_now"] == "ok"
+
+
+# ---------------------------------------------------------------------
+# Metadata age semantics: producer age measured at drain time.
+#
+# The displayed age answers "how long before the drain's snapshot read
+# did the producer last write" — i.e. producer health. Computing it
+# against the *request* wallclock folded the aggregator's own cache
+# staleness (up to a full tick period) into every sensor's age, making
+# healthy 200 ms picos read as ~1 s old on the dashboard.
+# ---------------------------------------------------------------------
+
+
+def _payload_thresholds():
+    from eigsep_observing.live_status import Thresholds
+
+    return Thresholds.from_yaml(OBS_CFG, corr_header=None)
+
+
+def _lidar_state(ts_unix, read_unix):
+    """StateSnapshot with one lidar entry whose ``_ts`` and drain-read
+    stamp are pinned to known values. ``ts_unix`` is set deep in the
+    past so any age computed against the live wallclock (the old,
+    wrong semantics) is unmistakably huge."""
+    from eigsep_observing.live_status.aggregator import StateSnapshot
+
+    state = StateSnapshot()
+    state.metadata_snapshot = {
+        "lidar": {
+            "sensor_name": "lidar",
+            "app_id": 5,
+            "status": "update",
+            "distance_m": 1.5,
+        },
+        "lidar_ts": ts_unix,
+    }
+    state.metadata_snapshot_read_unix = read_unix
+    return state
+
+
+def test_metadata_age_measured_at_drain_time_not_request_time():
+    from eigsep_observing.live_status.app import _metadata_payload
+
+    ts = time.time() - 3600.0
+    state = _lidar_state(ts, read_unix=ts + 0.1)
+    payload = _metadata_payload(state, _payload_thresholds())
+    assert payload["lidar"]["age_s"] == pytest.approx(0.1, abs=1e-3)
+
+
+def test_metadata_age_grows_when_producer_stops():
+    """A dead pico stops bumping ``_ts`` while successful drains keep
+    advancing the read stamp — the age must keep growing so the stale
+    relabel still fires."""
+    from eigsep_observing.live_status.app import _metadata_payload
+
+    ts = time.time() - 3600.0
+    state = _lidar_state(ts, read_unix=ts + 45.0)
+    payload = _metadata_payload(state, _payload_thresholds())
+    assert payload["lidar"]["age_s"] == pytest.approx(45.0, abs=1e-3)
+
+
+def test_metadata_age_clamped_at_zero_on_clock_skew():
+    """``_ts`` is panda-clock, the read stamp is ground-clock; modest
+    skew must not render a negative age."""
+    from eigsep_observing.live_status.app import _metadata_payload
+
+    ts = time.time() - 3600.0
+    state = _lidar_state(ts, read_unix=ts - 0.05)
+    payload = _metadata_payload(state, _payload_thresholds())
+    assert payload["lidar"]["age_s"] == 0.0
+
+
+def test_metadata_age_none_without_read_stamp():
+    """A snapshot with no recorded drain read (only possible by direct
+    state seeding) has an unknown age, not one invented from the
+    request wallclock."""
+    from eigsep_observing.live_status.app import _metadata_payload
+
+    ts = time.time() - 3600.0
+    state = _lidar_state(ts, read_unix=None)
+    payload = _metadata_payload(state, _payload_thresholds())
+    assert payload["lidar"]["age_s"] is None
 
 
 def test_adc_route_lists_per_input_with_clip_frac(client):
@@ -637,7 +717,6 @@ def test_rfswitch_payload_no_countdown_without_observed_transition():
         transport_snap=snap,
         transport_panda=panda,
         obs_cfg=OBS_CFG,
-        read_timeout_s=0.05,
     )
     try:
         agg._panda_tick()
@@ -686,7 +765,6 @@ def test_rfswitch_payload_no_countdown_without_schedule_in_redis():
         transport_snap=snap,
         transport_panda=panda,
         obs_cfg=OBS_CFG,
-        read_timeout_s=0.05,
     )
     try:
         # First tick: drain seeds metadata_latest["rfswitch"] = RFNOFF,
@@ -773,7 +851,6 @@ def test_config_route_schedule_empty_when_no_config_in_redis():
         transport_snap=snap,
         transport_panda=panda,
         obs_cfg=OBS_CFG,
-        read_timeout_s=0.05,
     )
     try:
         agg._panda_tick()


### PR DESCRIPTION
## Problem

Healthy 200 ms picos read as ~1 s old on the live-status dashboard (while `imu_manual.py` against the same Redis updates near-instantly). Root cause was three latency stages stacking inside the app, not Redis:

1. `/api/metadata` computed `age_s = request_now - {key}_ts` against a **cached** snapshot, folding the aggregator's cache staleness (up to a full tick period) into every sensor's displayed age.
2. `_drain_status` exited its loop only via a blocking `XREAD block=200ms` timing out, so every steady-state tick (status stream quiet) carried a hidden +0.2 s tail-block — inflating the effective panda tick period ~40 % past the documented `panda_tick_s=0.5`. The corr/adc reads on the SNAP tick had the same shape.
3. Front-end repainted at 1 Hz.

## Changes

- **Drain-time age semantics.** The panda drain stamps `metadata_snapshot_read_unix` on each successful snapshot read; `age_s = read_unix - {key}_ts` now reports producer health at drain time (~0.1 s for a healthy pico). A dead pico still ages — successful drains keep advancing the stamp while its `_ts` freezes — so the stale relabel still fires. A dead panda *bus* freezes the cached ages (last-known values); that state is surfaced by `panda_connected` ("Backend Redis: down" tile), not by artificially aging every sensor tile. Clamped at zero for panda↔ground clock skew.
- **Poll, don't wait.** All tick-loop stream reads use a ~1 ms block (`_POLL_TIMEOUT_S`, the smallest finite block the reader API can express — `timeout=None` maps to block-forever). The tick cadence becomes the single staleness knob; the now-meaningless `read_timeout_s` constructor param is removed. The dedicated VNA thread keeps its deliberate 1 s block.
- **Snappier for lab bring-up:** drain tick defaults 0.5 s → 0.25 s, front-end `POLL_MS` 1000 → 500. Net: sensor panes track at ~2 Hz with honest ~0.1 s ages, vs ~1 Hz with ~0.5–1 s reported ages before. Field operation tolerates anything slower.

## Tests

- `test_panda_tick_stamps_snapshot_read_unix`, `test_panda_tick_read_stamp_frozen_when_snapshot_read_fails` — read-stamp lifecycle on success/failure.
- `test_metadata_age_*` (×4) — drain-time age, dead-producer growth, skew clamp, missing-stamp → `None`.
- `test_panda_tick_completes_quickly_with_empty_streams`, `test_snap_tick_completes_quickly_when_streams_quiet` — pin the no-tail-block timing contract (the snap twin seeds + consumes entries first: never-registered streams short-circuit without blocking and wouldn't exercise the regression).
- All written red-first; `test_aggregator_rejects_zero_timeout` removed with the parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)