### PR TITLE
feat(io): metadata recorder read/write pair, aligned with corr metadata format

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -48,7 +48,10 @@ eigsep-observe --dummy        # terminal 2
 # Test-bench data collection (no SNAP): save pico metadata while you
 # exercise actuators with motor_manual / tempctrl_manual / etc. The
 # panda's PicoManager service must already be running; record_metadata
-# is a consumer that drains the streams to its own HDF5 file.
+# is a consumer that drains the streams to its own HDF5 file (same JSON
+# metadata format as a corr file's sidecar). Read it back with
+# eigsep_observing.io.read_metadata_hdf5(fname), which returns
+# {stream: [sample_dict, ...]} (each dict carries _ts_unix for joining).
 python scripts/record_metadata.py --save-dir /tmp/runs
 
 # Same idea for VNA: loop ant/rec bundles at a fixed interval and

--- a/scripts/record_metadata.py
+++ b/scripts/record_metadata.py
@@ -1,20 +1,27 @@
 """Standalone metadata recorder.
 
-Drains all registered panda metadata streams and writes raw entries
-(no averaging) to an HDF5 file. Designed for hardware tests where the
-SNAP correlator is not in the loop, so the corr-side metadata-to-disk
-pipeline (``EigObserver.record_corr_data``) is unavailable.
+Drains all registered panda metadata streams and writes the raw entries
+(no averaging) to an HDF5 file, using the *same* on-disk format as a corr
+file's metadata sidecar (:func:`eigsep_observing.io.write_metadata_hdf5`):
+one JSON list-of-dicts per stream under a ``metadata`` group. Designed for
+hardware tests where the SNAP correlator is not in the loop, so the
+corr-side metadata-to-disk pipeline (``EigObserver.record_corr_data``) is
+unavailable.
 
-Each Redis stream becomes one HDF5 group named after the metadata key
-(e.g. ``imu_el``, ``tempctrl_lna``). Inside the group:
+Each drained Redis entry becomes one dict in its stream's list — the raw
+payload plus a folded-in ``_ts_unix`` (float unix seconds, from the Redis
+stream entry ID's millisecond prefix, the most accurate per-sample
+timestamp available since the picos do not embed wall-clock timestamps in
+their payloads). Because the format matches io.py's JSON serialization, a
+``None`` field (a nulled sensor reading) round-trips as ``None`` rather
+than a zero/empty sentinel. Read it back with
+:func:`eigsep_observing.io.read_metadata_hdf5`.
 
-- one 1-D resizable dataset per payload field, typed via
-  :data:`eigsep_observing.io.SENSOR_SCHEMAS` where the key is known
-  (with lazy per-sample inference for fields outside the schema), and
-- a ``_ts_unix`` dataset (float64) populated from the Redis stream
-  entry ID's millisecond prefix — the most accurate per-sample
-  timestamp available, since the picos do not embed wall-clock
-  timestamps in their payloads.
+Samples accumulate in memory and the file is written once on exit; the
+SIGINT/SIGTERM handlers stop the loop so a normal Ctrl-C still saves. A
+hard crash (SIGKILL / power loss) loses the run — acceptable for the
+attended bring-up runs this tool is for, and it keeps the format identical
+to the corr sidecar so the two can be changed together later.
 
 Coexists safely with ``eigsep-observe``: each consumer has its own
 ``Transport`` with an independent local read pointer (same pattern
@@ -23,119 +30,21 @@ Coexists safely with ``eigsep-observe``: each consumer has its own
 
 import argparse
 import datetime as dt
-import json
 import logging
 import signal
 import sys
 import threading
 from pathlib import Path
 
-import h5py
-import numpy as np
 import redis.exceptions
 
 from eigsep_redis import MetadataStreamReader, entry_id_to_unix
 
 from eigsep_observing._scripts_util import add_redis_args, build_transport
-from eigsep_observing.io import SENSOR_SCHEMAS
+from eigsep_observing.io import write_metadata_hdf5
 from eigsep_observing.utils import configure_eig_logger
 
 logger = logging.getLogger(__name__)
-
-
-_SCHEMA_DTYPES = {
-    str: h5py.string_dtype(encoding="utf-8"),
-    bool: np.dtype(np.uint8),
-    int: np.dtype(np.int64),
-    float: np.dtype(np.float64),
-}
-
-
-def _dtype_for_value(value):
-    """Lazy dtype pick for a single sample value (used for fields not
-    declared in :data:`SENSOR_SCHEMAS`). Booleans must be checked
-    before ints — Python ``bool`` is a subclass of ``int``."""
-    if isinstance(value, bool):
-        return _SCHEMA_DTYPES[bool]
-    if isinstance(value, int):
-        return _SCHEMA_DTYPES[int]
-    if isinstance(value, float):
-        return _SCHEMA_DTYPES[float]
-    if isinstance(value, str):
-        return _SCHEMA_DTYPES[str]
-    return _SCHEMA_DTYPES[str]
-
-
-class _StreamWriter:
-    """Per-stream HDF5 group with per-field resizable datasets.
-
-    Pre-creates datasets for every field in ``schema`` so a stream
-    with declared fields produces a uniform file even if some samples
-    omit a field. Unknown fields encountered later are added lazily
-    with a per-sample dtype inference and back-filled with default
-    sentinels for prior rows.
-    """
-
-    _CHUNK = 256
-
-    def __init__(self, h5file, group_name, schema=None):
-        self.group = h5file.create_group(group_name)
-        self.count = 0
-        self._dsets = {}
-        self._make_dset("_ts_unix", np.dtype(np.float64))
-        if schema:
-            for field, py_type in schema.items():
-                dtype = _SCHEMA_DTYPES.get(py_type, _SCHEMA_DTYPES[str])
-                self._make_dset(field, dtype)
-
-    def _make_dset(self, name, dtype):
-        dset = self.group.create_dataset(
-            name,
-            shape=(self.count,),
-            maxshape=(None,),
-            dtype=dtype,
-            chunks=(self._CHUNK,),
-        )
-        self._dsets[name] = dset
-
-    def _ensure_dset(self, name, value):
-        if name in self._dsets:
-            return self._dsets[name]
-        self._make_dset(name, _dtype_for_value(value))
-        return self._dsets[name]
-
-    def append(self, ts_unix, payload):
-        new_count = self.count + 1
-        for dset in self._dsets.values():
-            dset.resize((new_count,))
-        self._dsets["_ts_unix"][self.count] = ts_unix
-        for field, value in payload.items():
-            dset = self._ensure_dset(field, value)
-            # Re-resize in case _ensure_dset just created a dataset
-            # that was sized at the pre-append count.
-            if dset.shape[0] < new_count:
-                dset.resize((new_count,))
-            if value is None:
-                continue  # leave default sentinel (0 / "")
-            try:
-                if h5py.check_string_dtype(dset.dtype):
-                    dset[self.count] = (
-                        value if isinstance(value, str) else json.dumps(value)
-                    )
-                elif dset.dtype == np.uint8:
-                    dset[self.count] = np.uint8(bool(value))
-                else:
-                    dset[self.count] = value
-            except (TypeError, ValueError) as exc:
-                logger.warning(
-                    "Cannot write %s=%r (dtype=%s) to %s: %s",
-                    field,
-                    value,
-                    dset.dtype,
-                    self.group.name,
-                    exc,
-                )
-        self.count = new_count
 
 
 def _group_name(stream):
@@ -147,9 +56,40 @@ def _group_name(stream):
     )
 
 
-def _schema_for(stream):
-    """Return the SENSOR_SCHEMAS entry matching this stream, or None."""
-    return SENSOR_SCHEMAS.get(_group_name(stream))
+def _drain_into(reader, collected):
+    """Drain all registered streams once, accumulating into ``collected``.
+
+    Each Redis entry becomes one dict appended to ``collected[stream]``:
+    the raw payload plus a folded-in ``_ts_unix`` (from the entry ID).
+    The ``stream:`` prefix is stripped. Non-dict payloads are logged at
+    ERROR and skipped — the producer is at fault, not the recorder.
+    """
+    drained = reader.drain(with_ids=True)
+    for stream, entries in drained.items():
+        bucket = collected.setdefault(_group_name(stream), [])
+        for entry_id, payload in entries:
+            if not isinstance(payload, dict):
+                logger.error(
+                    "Skipping non-dict payload on %s: %r", stream, payload
+                )
+                continue
+            bucket.append({"_ts_unix": entry_id_to_unix(entry_id), **payload})
+
+
+def _collect(transport, collected, interval, stop_event):
+    """Drain into ``collected`` until ``stop_event`` is set.
+
+    ``drain`` is non-blocking, so the loop is paced by ``stop_event.wait``
+    (which also keeps SIGINT responsive). Picos publish at ~5 Hz; a 1 s
+    default batches ~5 entries per drain.
+    """
+    reader = MetadataStreamReader(transport)
+    while not stop_event.is_set():
+        try:
+            _drain_into(reader, collected)
+        except redis.exceptions.ConnectionError as exc:
+            logger.warning("drain failed: %s", exc)
+        stop_event.wait(interval)
 
 
 def _build_transport(host, port, dummy):
@@ -163,7 +103,8 @@ def _parse_args():
     p = argparse.ArgumentParser(
         description=(
             "Record panda metadata streams to HDF5. No averaging — "
-            "every Redis stream entry becomes one HDF5 row."
+            "every Redis stream entry becomes one row, in the same "
+            "format as a corr file's metadata sidecar."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -179,9 +120,9 @@ def _parse_args():
         type=float,
         default=1.0,
         help=(
-            "Drain block timeout, in seconds. The recorder will return "
-            "from xread as soon as any entry arrives, so this is the "
-            "maximum stall between SIGINT and exit."
+            "Drain pacing, in seconds — the maximum stall between SIGINT "
+            "and exit. Samples accumulate between drains and are written "
+            "once on exit."
         ),
     )
     p.add_argument(
@@ -190,48 +131,6 @@ def _parse_args():
         help="Connect to fakeredis on localhost:6380 with dummy picos.",
     )
     return p.parse_args()
-
-
-def _run(transport, out_path, interval, stop_event):
-    reader = MetadataStreamReader(transport)
-    writers = {}  # stream_name -> _StreamWriter
-
-    with h5py.File(out_path, "w") as h5file:
-        while not stop_event.is_set():
-            try:
-                drained = reader.drain(with_ids=True)
-            except redis.exceptions.ConnectionError as exc:
-                logger.warning("drain failed: %s", exc)
-                stop_event.wait(interval)
-                continue
-
-            for stream, entries in drained.items():
-                writer = writers.get(stream)
-                if writer is None:
-                    writer = _StreamWriter(
-                        h5file,
-                        _group_name(stream),
-                        schema=_schema_for(stream),
-                    )
-                    writers[stream] = writer
-
-                for entry_id, payload in entries:
-                    if not isinstance(payload, dict):
-                        logger.error(
-                            "Skipping non-dict payload on %s: %r",
-                            stream,
-                            payload,
-                        )
-                        continue
-                    writer.append(entry_id_to_unix(entry_id), payload)
-
-            h5file.flush()
-            # drain() is non-blocking, so pace the loop here. Picos
-            # publish at ~5 Hz; a 1 s default batches ~5 entries per
-            # drain. stop_event.wait keeps SIGINT responsiveness.
-            stop_event.wait(interval)
-
-    return writers
 
 
 def main():
@@ -269,12 +168,15 @@ def main():
     signal.signal(signal.SIGINT, _handle)
     signal.signal(signal.SIGTERM, _handle)
 
+    collected = {}
     try:
-        writers = _run(transport, out_path, args.interval, stop_event)
+        _collect(transport, collected, args.interval, stop_event)
     except KeyboardInterrupt:
         logger.info("KeyboardInterrupt, stopping.")
-        writers = {}
     finally:
+        # Write whatever we captured, even on an uncaught exit, so a run
+        # is never lost to a missed signal.
+        write_metadata_hdf5(out_path, collected)
         if args.dummy:
             dummy_client = getattr(transport, "_dummy_client", None)
             if dummy_client is not None:
@@ -284,7 +186,7 @@ def main():
     logger.info(
         "Closed %s with %d stream(s).",
         out_path,
-        len(writers),
+        len(collected),
     )
     return 0
 

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -370,6 +370,45 @@ def write_hdf5(fname, data, header, metadata=None):
                     )
 
 
+def write_metadata_hdf5(fname, metadata):
+    """
+    Write standalone metadata streams to HDF5.
+
+    Produces the *same* on-disk shape as the ``metadata`` group of a corr
+    file (see :func:`write_hdf5`): each stream's value — a list of
+    per-sample dicts — is JSON-encoded under a top-level ``metadata``
+    group via the shared :func:`_write_header_item` path, so a ``None``
+    field survives as JSON ``null`` rather than a typed zero/empty
+    sentinel.
+
+    Used by ``scripts/record_metadata.py`` to save pico metadata when no
+    correlator loop is running (the corr-side
+    ``EigObserver.record_corr_data`` path is unavailable). Read it back
+    with :func:`read_metadata_hdf5`.
+
+    Parameters
+    ----------
+    fname : str or Path
+        Output filename.
+    metadata : dict
+        ``{stream_name: [sample_dict, ...]}``. Each sample dict is one
+        Redis stream entry (raw payload plus a folded-in ``_ts_unix``).
+        A per-stream safety net mirrors :func:`write_hdf5`: a contract
+        violation on one stream is logged at ERROR and skipped.
+    """
+    with h5py.File(fname, "w") as f:
+        metadata_grp = f.create_group("metadata")
+        for key, value in metadata.items():
+            try:
+                _write_header_item(metadata_grp, key, value)
+            except (TypeError, ValueError) as e:
+                logger.error(
+                    f"Metadata contract violation: failed to write key "
+                    f"'{key}' ({type(e).__name__}: {e}). Skipping this "
+                    f"stream. Producer must be fixed."
+                )
+
+
 def read_hdf5(fname):
     """
     Read data from an HDF5 file.
@@ -423,6 +462,38 @@ def read_hdf5(fname):
                 else:
                     metadata[name] = _read_dataset(obj)
     return data, header, metadata
+
+
+def read_metadata_hdf5(fname):
+    """
+    Read a metadata file written by :func:`write_metadata_hdf5` (e.g. by
+    ``scripts/record_metadata.py``).
+
+    Returns ``{stream_name: [sample_dict, ...]}`` — the same shape and
+    None-faithful JSON decoding :func:`read_hdf5` returns for a corr
+    file's ``metadata`` group, so a dropped reading reads back as ``None``
+    rather than a zero/empty sentinel. Each recorder sample dict carries a
+    folded-in ``_ts_unix`` (float unix seconds) for joining across streams,
+    e.g. ``np.array([d["_ts_unix"] for d in rows])``.
+
+    Parameters
+    ----------
+    fname : str or Path
+        Path to a ``metadata_*.h5`` file produced by the recorder.
+
+    Returns
+    -------
+    dict
+        ``{stream_name: [sample_dict, ...]}``; empty if the file holds no
+        ``metadata`` group.
+    """
+    out = {}
+    with h5py.File(fname, "r") as f:
+        if "metadata" not in f:
+            return out
+        for name, obj in f["metadata"].items():
+            out[name] = _read_dataset(obj)
+    return out
 
 
 def write_s11_file(

--- a/tests/test_read_metadata.py
+++ b/tests/test_read_metadata.py
@@ -1,0 +1,112 @@
+"""Round-trip + format-match tests for the io.py metadata pair.
+
+``write_metadata_hdf5`` writes standalone pico metadata the *same* way a
+corr file's sidecar is written: one JSON list-of-dicts per stream under a
+``metadata`` group, so a ``None`` field (a nulled sensor reading) survives
+as ``None`` rather than a zero/empty sentinel. ``read_metadata_hdf5``
+inverts it to ``{stream: [dict, ...]}`` — the same shape and None-faithful
+JSON decoding ``read_hdf5`` returns for a corr file's ``metadata`` group.
+
+The format-match test asserts a standalone metadata file and a corr file
+written from identical metadata read back equal, so the two
+representations can't drift. (The recorder script that produces these
+files is exercised in ``test_record_metadata.py``.)
+"""
+
+import numpy as np
+import pytest
+
+from eigsep_observing.io import (
+    read_hdf5,
+    read_metadata_hdf5,
+    write_hdf5,
+    write_metadata_hdf5,
+)
+
+
+# Production-shaped raw samples, each carrying the ``_ts_unix`` the
+# recorder folds in from the Redis stream entry ID. The ``None`` fields
+# are real (a sensor error nulls fields per SENSOR_SCHEMAS) and are the
+# reason for matching io.py's None-faithful JSON over a typed-column
+# sentinel: a dropped reading must read back as None, not 0.0.
+SAMPLES = {
+    "motor": [
+        {
+            "_ts_unix": 1000.0,
+            "sensor_name": "motor",
+            "status": "update",
+            "app_id": 5,
+            "az_pos": 1.5,
+            "az_target_pos": 2.0,
+            "el_pos": -3.0,
+            "el_target_pos": -3.0,
+        },
+        {
+            "_ts_unix": 1000.5,
+            "sensor_name": "motor",
+            "status": "error",
+            "app_id": 5,
+            "az_pos": None,
+            "az_target_pos": 2.0,
+            "el_pos": None,
+            "el_target_pos": -3.0,
+        },
+    ],
+    "imu_el": [
+        {
+            "_ts_unix": 1000.1,
+            "sensor_name": "imu_el",
+            "status": "update",
+            "app_id": 3,
+            "yaw": 12.5,
+            "pitch": -3.25,
+            "roll": 1.75,
+            "accel_x": 0.05,
+            "accel_y": -0.12,
+            "accel_z": 9.78,
+        },
+    ],
+}
+
+
+@pytest.fixture
+def recorder_file(tmp_path):
+    """A metadata file written through the recorder's file-I/O path."""
+    out = tmp_path / "metadata_test.h5"
+    write_metadata_hdf5(out, SAMPLES)
+    return out
+
+
+def test_round_trips_streams_as_lists_of_dicts(recorder_file):
+    assert read_metadata_hdf5(recorder_file) == SAMPLES
+
+
+def test_none_fields_survive_as_none(recorder_file):
+    motor = read_metadata_hdf5(recorder_file)["motor"]
+    assert motor[1]["az_pos"] is None
+    assert motor[1]["el_pos"] is None
+    # ints/floats/strings on the same row are untouched.
+    assert motor[1]["app_id"] == 5
+    assert motor[1]["el_target_pos"] == -3.0
+    assert motor[1]["status"] == "error"
+
+
+def test_matches_io_corr_metadata_serialization(tmp_path, recorder_file):
+    """Identical metadata written through the corr file writer reads back
+    equal — the recorder format *is* the corr sidecar format."""
+    corr = tmp_path / "corr.h5"
+    write_hdf5(
+        corr,
+        data={"auto0": np.zeros((1, 2), dtype=np.int32)},
+        header={"nchan": 1},
+        metadata=SAMPLES,
+    )
+    _, _, corr_meta = read_hdf5(corr)
+    assert read_metadata_hdf5(recorder_file) == corr_meta
+
+
+def test_missing_metadata_group_reads_empty(tmp_path):
+    """A file with no streams (recorder saw nothing) reads as empty."""
+    empty = tmp_path / "empty.h5"
+    write_metadata_hdf5(empty, {})
+    assert read_metadata_hdf5(empty) == {}

--- a/tests/test_record_metadata.py
+++ b/tests/test_record_metadata.py
@@ -1,13 +1,14 @@
-"""Smoke tests for scripts/record_metadata.py.
+"""Tests for scripts/record_metadata.py.
 
 The script lives under ``scripts/`` (not on the package path) so we
-import it by file location, same pattern as test_motor_scripts.py.
+import it by file location, same pattern as test_imu_manual.py.
 
-We drive ``_run`` against a ``DummyTransport`` with an active
-``DummyPandaClient`` publishing pico metadata, then inspect the
-resulting HDF5 file. The picos publish at the picohost cadence
-(``STATUS_CADENCE_MS = 200``), so a short window already yields
-several rows per stream.
+The recorder accumulates raw stream entries in memory and writes them
+once, in the same JSON list-of-dicts format as a corr file's metadata
+sidecar (see test_read_metadata.py for the io.py round-trip). Here we
+cover the script's own pieces: the per-drain capture (``_drain_into``),
+the end-to-end ``_collect`` loop against live dummy picos, and the
+stream-name helper.
 """
 
 import importlib.util
@@ -15,10 +16,9 @@ import threading
 import time
 from pathlib import Path
 
-import h5py
-import numpy as np
+from eigsep_redis import MetadataStreamReader, MetadataWriter
 
-from eigsep_observing.io import SENSOR_SCHEMAS
+from eigsep_observing.io import read_metadata_hdf5, write_metadata_hdf5
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
@@ -35,8 +35,6 @@ def _load_record_metadata():
 def _wait_for_streams(transport, expected_count, timeout=5.0):
     """Block until at least ``expected_count`` metadata streams are
     registered, or ``timeout`` elapses."""
-    from eigsep_redis import MetadataStreamReader
-
     reader = MetadataStreamReader(transport)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -47,107 +45,88 @@ def _wait_for_streams(transport, expected_count, timeout=5.0):
     return reader.streams
 
 
-def test_record_metadata_captures_dummy_pico_streams(client, tmp_path):
-    """End-to-end: the dummy picos publish, ``_run`` drains, and the
-    HDF5 file carries one group per stream with monotonic timestamps."""
+def _motor_sample(**overrides):
+    sample = {
+        "sensor_name": "motor",
+        "status": "update",
+        "app_id": 5,
+        "az_pos": 1.5,
+        "az_target_pos": 2.0,
+        "el_pos": -3.0,
+        "el_target_pos": -3.0,
+    }
+    sample.update(overrides)
+    return sample
+
+
+def test_drain_folds_in_ts_unix_and_payload(transport):
+    """``_drain_into`` appends one dict per Redis entry, stripping the
+    ``stream:`` prefix and folding in a float ``_ts_unix`` alongside the
+    raw payload.
+
+    The first publish + drain only establishes the stream's read position
+    at the tail (the reader skips pre-existing backlog, exactly as the
+    live recorder does); the entry published after that is captured.
+    """
+    rm = _load_record_metadata()
+    writer = MetadataWriter(transport)
+    reader = MetadataStreamReader(transport)
+    collected = {}
+
+    writer.add("motor", _motor_sample())
+    rm._drain_into(reader, collected)  # prime position
+
+    writer.add("motor", _motor_sample(az_pos=2.5))
+    rm._drain_into(reader, collected)  # capture this one
+
+    assert list(collected) == ["motor"]
+    (row,) = collected["motor"]
+    assert row["az_pos"] == 2.5
+    assert row["sensor_name"] == "motor"
+    assert isinstance(row["_ts_unix"], float)
+    assert row["_ts_unix"] > 0
+
+
+def test_collect_captures_dummy_pico_streams(client, tmp_path):
+    """End-to-end: dummy picos publish, ``_collect`` drains into memory,
+    and the round-tripped file carries a list of sample dicts per stream
+    with monotonic ``_ts_unix`` timestamps."""
     rm = _load_record_metadata()
     transport = client.transport
 
-    # Give the embedded PicoManager a moment to register heartbeats
-    # and have its devices publish a first round of status updates.
+    # Give the embedded PicoManager a moment to register heartbeats and
+    # have its devices publish a first round of status updates.
     streams = _wait_for_streams(transport, expected_count=3, timeout=5.0)
     assert streams, "dummy picos never registered metadata streams"
 
-    out_path = tmp_path / "metadata_test.h5"
+    collected = {}
     stop_event = threading.Event()
-
-    def _runner():
-        rm._run(transport, out_path, interval=0.2, stop_event=stop_event)
-
-    t = threading.Thread(target=_runner)
+    t = threading.Thread(
+        target=rm._collect, args=(transport, collected, 0.2, stop_event)
+    )
     t.start()
-    # 2s is enough for several rows per stream at 200 ms producer cadence.
+    # 2s is enough for several rows per stream at 200 ms producer cadence
+    # (the first drain only primes read positions).
     time.sleep(2.0)
     stop_event.set()
     t.join(timeout=5.0)
     assert not t.is_alive(), "record_metadata thread did not stop"
 
-    # File should be readable and contain at least the IMU + one tempctrl
-    # group, with non-empty datasets and strictly monotonic timestamps.
-    with h5py.File(out_path, "r") as f:
-        group_names = list(f.keys())
-        assert "imu_el" in group_names
-        assert "imu_az" in group_names
-        assert any(g.startswith("tempctrl_") for g in group_names)
+    out_path = tmp_path / "metadata_test.h5"
+    write_metadata_hdf5(out_path, collected)
+    data = read_metadata_hdf5(out_path)
 
-        for stream_name in group_names:
-            grp = f[stream_name]
-            assert "_ts_unix" in grp, f"{stream_name} missing _ts_unix"
-            ts = grp["_ts_unix"][:]
-            assert ts.size > 0, f"{stream_name} has no samples"
-            assert ts.dtype == np.float64
-            assert np.all(np.diff(ts) >= 0), (
-                f"{stream_name} timestamps not monotonic: {ts}"
-            )
+    assert "imu_el" in data
+    assert "imu_az" in data
+    assert any(name.startswith("tempctrl_") for name in data)
 
-
-def test_record_metadata_uses_sensor_schema_dtypes(client, tmp_path):
-    """Schema-driven dtypes: ``imu_el`` declares all floats + a few
-    str/int fields, so the resulting datasets should match."""
-    rm = _load_record_metadata()
-    transport = client.transport
-
-    _wait_for_streams(transport, expected_count=3, timeout=5.0)
-
-    out_path = tmp_path / "metadata_schema.h5"
-    stop_event = threading.Event()
-
-    def _runner():
-        rm._run(transport, out_path, interval=0.2, stop_event=stop_event)
-
-    t = threading.Thread(target=_runner)
-    t.start()
-    time.sleep(2.0)
-    stop_event.set()
-    t.join(timeout=5.0)
-
-    schema = SENSOR_SCHEMAS["imu_el"]
-    with h5py.File(out_path, "r") as f:
-        grp = f["imu_el"]
-        for field, py_type in schema.items():
-            assert field in grp, f"imu_el missing schema field {field!r}"
-            dset = grp[field]
-            if py_type is float:
-                assert dset.dtype == np.float64
-            elif py_type is int:
-                assert dset.dtype == np.int64
-            elif py_type is bool:
-                assert dset.dtype == np.uint8
-            elif py_type is str:
-                assert h5py.check_string_dtype(dset.dtype) is not None
-
-
-def test_stream_writer_handles_lazy_field(tmp_path):
-    """A field that wasn't in the schema appears mid-stream; back-fill
-    rows should carry sentinels so per-row indices align with _ts_unix."""
-    rm = _load_record_metadata()
-    out = tmp_path / "lazy.h5"
-    with h5py.File(out, "w") as f:
-        w = rm._StreamWriter(f, "stream_a", schema={"x": float})
-        w.append(1000.0, {"x": 1.0})
-        w.append(1001.0, {"x": 2.0, "y": "hello"})  # 'y' is new
-        w.append(1002.0, {"x": 3.0, "y": "world"})
-
-        grp = f["stream_a"]
-        assert grp["_ts_unix"].shape == (3,)
-        assert grp["x"].shape == (3,)
-        assert grp["y"].shape == (3,)
-        # Row 0 had no 'y'; should be sentinel (empty string for str dtype).
-        y_vals = grp["y"][:]
-        # h5py returns variable-length strings as bytes by default.
-        assert y_vals[0] in (b"", "")
-        assert y_vals[1] in (b"hello", "hello")
-        assert y_vals[2] in (b"world", "world")
+    for stream_name, rows in data.items():
+        assert rows, f"{stream_name} captured no samples"
+        ts = [r["_ts_unix"] for r in rows]
+        assert all(isinstance(x, float) for x in ts)
+        assert all(b >= a for a, b in zip(ts, ts[1:])), (
+            f"{stream_name} timestamps not monotonic: {ts}"
+        )
 
 
 def test_group_name_strips_stream_prefix():


### PR DESCRIPTION
## What

Adds a standalone metadata file pair to `io.py`, next to `write_hdf5`/`read_hdf5` and reusing the same serialization helpers:

- **`write_metadata_hdf5(fname, metadata)`** — writes `{stream: [sample_dict, ...]}` as one JSON dataset per stream under a `metadata` group (via the shared `_write_header_item` path). Same per-key safety net as `write_hdf5`.
- **`read_metadata_hdf5(fname)`** — inverts it to `{stream: [sample_dict, ...]}`, the same shape and `None`-faithful JSON decoding `read_hdf5` returns for a corr file's `metadata` group.

`scripts/record_metadata.py` is rewritten onto this pair: it drops the columnar `_StreamWriter`/dtype machinery, accumulates `{stream: [payload + _ts_unix]}` in memory (`_drain_into`/`_collect`), and writes once on exit via `write_metadata_hdf5`.

## Why

The recorder previously stored metadata as typed per-field columns, encoding a missing/`None` reading as the dtype's zero/empty sentinel (`0`/`0.0`/`""`) — indistinguishable from a real value. `io.py`'s normal corr files store metadata as None-faithful JSON. This PR makes the recorder's on-disk format **identical to a corr file's metadata sidecar**, so the two representations are one and can be changed together later. It also gives the test-bench recorder a documented read-back path (`read_metadata_hdf5`).

Motivating workflow: running `motor_manual` + `imu_manual` (and `potmon` later) for hardware tests while `record_metadata.py` captures all registered pico streams to disk for later analysis.

## Behavior changes

- **Read-back shape** is `{stream: [sample_dict, ...]}` (matches `read_hdf5`). Each dict carries a folded-in `_ts_unix` (float unix seconds) for joining streams; e.g. `np.array([d["az_pos"] for d in rows])`.
- **Write-once-on-exit** replaces the old per-second incremental flush. `Ctrl-C`/`SIGTERM` still save (handlers stop the loop; file written in `finally`); a hard `SIGKILL`/power-loss loses the run. This mirrors how `io.py` buffers a file's metadata in memory — the cost of matching its format. Acceptable for the attended bring-up runs this tool is for.

## Tests

- `tests/test_read_metadata.py` (new) — io.py pair: round-trip, `None`-survives-as-`None`, empty-file, and a **format-match** test asserting a recorder file and a corr file written from identical metadata read back equal.
- `tests/test_record_metadata.py` — rewired to `_collect`/`_drain_into` (e2e against dummy picos + unit); the two obsolete columnar tests (schema-dtypes, lazy-field) removed since that feature no longer exists.
- `OPERATIONS.md` — read-back note updated to the new shape.

80 passed across `test_read_metadata.py` / `test_record_metadata.py` / `test_io.py`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)