### PR TITLE
feat(run_tag): active/passive driver split + manual-session metadata completeness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,34 @@ restart required. The wiring:
   `metadata_stream.skip_to_latest()` to drop outage-era backlog (see
   the existing `Metadata flow` section below for why).
 
+## Manual sessions: the autonomous driver vs the always-on pico-manager
+
+An operator doing bring-up (e.g. `motor_manual`, `rfswitch_manual`)
+stops the autonomous driver `panda_observe` first — `run_tag.session`'s
+refuse-on-conflict enforces this (see `scripts/CLAUDE.md`). Stopping
+`panda_observe` is not all-or-nothing; know what actually goes quiet:
+
+- **Stops** (these are `panda_observe` threads): RF switch-schedule
+  cycling (`switch_loop` — the switch *freezes* in its last state, no
+  reset to RFANT), periodic VNA / motor scans (`vna_loop` / `motor_loop`),
+  and the `panda:hb*` heartbeat (so `panda_connected` reads `False`).
+- **Keeps running**: Peltier temperature control — the PI loop lives in
+  pico firmware and the connection/replay is owned by the always-on
+  `pico-manager.service`, not `panda_observe`. It only trips off (via
+  the firmware watchdog) if the pico loses its connection entirely.
+- **Keeps recording**: corr (ground PC, independent) and, now, its
+  sensor-metadata sidecar. The picos keep publishing metadata via
+  `pico-manager` even with `panda_observe` stopped, so
+  `record_corr_data` gates the metadata drain on **metadata-stream
+  reachability (`ConnectionError`)**, not on the heartbeat (the local
+  `metadata_stream_down` flag, not `panda_connected`). Corr files
+  written during a manual session therefore stay metadata-complete and
+  carry the active tool's `run_tag` flag.
+
+So "full functionality" (autonomous switching + periodic scans +
+heartbeat) only holds when `panda_observe` is running; manual debugging
+is a deliberate, flagged degraded mode, not a silent data gap.
+
 ## Metadata flow: streaming for corr, snapshot for VNA
 
 Two reader classes expose metadata with deliberately different semantics. They

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -94,6 +94,37 @@ Redis transport is reachable.
   or at the operator level (terminal-orchestrated motion before
   VNA, like `vna_sweep`).
 
+## run_tag: active drivers claim it, passive readouts don't
+
+`run_tag` (`eigsep_observing.run_tag`) is the single Redis key naming
+which driver owns the panda's physical state right now; it is stamped
+into every corr / VNA file header for offline provenance. Bring-up
+scripts split into two classes by whether they change that state:
+
+- **Active drivers** — send commands or write VNA files
+  (`motor_manual`, `motor_control`, `rfswitch_manual`,
+  `tempctrl_manual`, `vna_manual`, `record_vna`). They **claim**
+  `run_tag.session(...)`. Because the ground PC is always recording
+  corr, the tag flags the spectra captured during a hand-driven
+  session as "not autonomous science." `run_tag.session` is
+  refuse-on-conflict, which here is a **safety feature**: it refuses to
+  start while another driver (the autonomous `panda_observe`, or
+  another active tool) owns the state, forcing the operator to stop the
+  autonomous driver before hand-driving shared hardware. One active
+  driver of the physical state at a time; combined motor+VNA runs use
+  the dedicated alt-mode `vna_position_sweep` in
+  `src/eigsep_observing/scripts/`.
+- **Passive readouts** — `MetadataSnapshotReader`-only, no commands, no
+  files (`imu_manual`, `monitor_meta`, `potmon_manual`, `lidar_manual`,
+  `pico_preflight`). They **never** claim `run_tag`: they change no
+  physical state, have no provenance to record, and must coexist with
+  whatever active driver is running. Claiming would block that
+  coexistence and misattribute a concurrent driver's files.
+
+`tests/test_obs_config_uploaders.py` enforces the split both ways:
+active drivers (plus the autonomous uploaders) must enter
+`run_tag.session`; exempt (passive / coexisting) scripts must not.
+
 ## Cross-process coordination is YAGNI
 
 If a future workflow genuinely needs "pause the production

--- a/scripts/lidar_manual.py
+++ b/scripts/lidar_manual.py
@@ -16,7 +16,6 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader
 
-from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import add_redis_args, build_transport
 from eigsep_observing.utils import configure_eig_logger
 
@@ -105,12 +104,15 @@ def main():
     transport = build_transport(
         args.dummy, host=args.redis_host, real_port=args.redis_port
     )
-    with run_tag.session(transport, "lidar_manual"):
-        snapshot = MetadataSnapshotReader(transport)
-        try:
-            _render_loop(snapshot, args.interval, args.max_range)
-        except KeyboardInterrupt:
-            print()
+    # Passive readout: no run_tag.session, by design. Snapshot-only
+    # (MetadataSnapshotReader), no commands or files, so it changes no
+    # physical state and must coexist with the active driver it watches.
+    # See imu_manual.py / scripts/CLAUDE.md for the active-vs-passive rule.
+    snapshot = MetadataSnapshotReader(transport)
+    try:
+        _render_loop(snapshot, args.interval, args.max_range)
+    except KeyboardInterrupt:
+        print()
 
 
 if __name__ == "__main__":

--- a/scripts/monitor_meta.py
+++ b/scripts/monitor_meta.py
@@ -3,20 +3,21 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader, Transport
 
-from eigsep_observing import run_tag
-
 
 def main():
     transport = Transport("10.10.10.11")
     snapshot = MetadataSnapshotReader(transport)
-    with run_tag.session(transport, "monitor_meta"):
-        while True:
-            try:
-                m = snapshot.get()
-                print(json.dumps(m, indent=2, sort_keys=False))
-                time.sleep(1.0)
-            except KeyboardInterrupt:
-                break
+    # Passive readout: no run_tag.session, by design. Snapshot-only
+    # (MetadataSnapshotReader), no commands or files, so it changes no
+    # physical state and must coexist with the active driver it watches.
+    # See imu_manual.py / scripts/CLAUDE.md for the active-vs-passive rule.
+    while True:
+        try:
+            m = snapshot.get()
+            print(json.dumps(m, indent=2, sort_keys=False))
+            time.sleep(1.0)
+        except KeyboardInterrupt:
+            break
 
 
 if __name__ == "__main__":

--- a/scripts/pico_preflight.py
+++ b/scripts/pico_preflight.py
@@ -30,7 +30,6 @@ import argparse
 import sys
 import time
 
-from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import add_redis_args
 from eigsep_observing.io import SENSOR_SCHEMAS
 from eigsep_redis import HeartbeatReader, MetadataSnapshotReader, Transport
@@ -205,24 +204,27 @@ def parse_args():
 def main():
     args = parse_args()
     transport = Transport(host=args.redis_host, port=args.redis_port)
-    with run_tag.session(transport, "pico_preflight"):
-        if args.watch is None:
+    # Passive readout: no run_tag.session, by design. Snapshot-only
+    # (MetadataSnapshotReader), no commands or files, so it changes no
+    # physical state and must coexist with the active driver it watches.
+    # See imu_manual.py / scripts/CLAUDE.md for the active-vs-passive rule.
+    if args.watch is None:
+        render(transport)
+        return 0
+    try:
+        while True:
+            # ANSI clear + home so the table redraws in place.
+            sys.stdout.write("\x1b[2J\x1b[H")
+            print(
+                f"pico_preflight @ {args.redis_host}  "
+                f"({time.strftime('%H:%M:%S')})"
+            )
+            print()
             render(transport)
-            return 0
-        try:
-            while True:
-                # ANSI clear + home so the table redraws in place.
-                sys.stdout.write("\x1b[2J\x1b[H")
-                print(
-                    f"pico_preflight @ {args.redis_host}  "
-                    f"({time.strftime('%H:%M:%S')})"
-                )
-                print()
-                render(transport)
-                sys.stdout.flush()
-                time.sleep(args.watch)
-        except KeyboardInterrupt:
-            return 0
+            sys.stdout.flush()
+            time.sleep(args.watch)
+    except KeyboardInterrupt:
+        return 0
 
 
 if __name__ == "__main__":

--- a/scripts/potmon_manual.py
+++ b/scripts/potmon_manual.py
@@ -17,7 +17,6 @@ import time
 
 from eigsep_redis import MetadataSnapshotReader
 
-from eigsep_observing import run_tag
 from eigsep_observing._scripts_util import add_redis_args, build_transport
 from eigsep_observing.utils import configure_eig_logger
 
@@ -104,12 +103,15 @@ def main():
     transport = build_transport(
         args.dummy, host=args.redis_host, real_port=args.redis_port
     )
-    with run_tag.session(transport, "potmon_manual"):
-        snapshot = MetadataSnapshotReader(transport)
-        try:
-            _render_loop(snapshot, args.interval)
-        except KeyboardInterrupt:
-            print()
+    # Passive readout: no run_tag.session, by design. Snapshot-only
+    # (MetadataSnapshotReader), no commands or files, so it changes no
+    # physical state and must coexist with the active driver it watches.
+    # See imu_manual.py / scripts/CLAUDE.md for the active-vs-passive rule.
+    snapshot = MetadataSnapshotReader(transport)
+    try:
+        _render_loop(snapshot, args.interval)
+    except KeyboardInterrupt:
+        print()
 
 
 if __name__ == "__main__":

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -362,9 +362,13 @@ class EigObserver:
         cached_header = None
         cached_sync_time = None
         last_write_deadline = None
-        # Track panda drops so we can skip metadata stream positions to
+        # Track metadata-stream drops so we can skip stream positions to
         # the current tail on reconnect via metadata_stream.skip_to_latest().
-        panda_was_down = False
+        # This tracks the metadata pipeline's reachability, NOT the
+        # autonomous driver's heartbeat: the picos publish metadata via
+        # the always-on pico-manager service, so a manual session (with
+        # panda_observe stopped) still drains live sensor metadata.
+        metadata_stream_down = False
         last_drain_warn_monotonic = 0.0
         try:
             while not self.stop_event.is_set():
@@ -458,72 +462,73 @@ class EigObserver:
                         return
                     continue
                 self.logger.info(f"{acc_cnt=}")
-                if self.panda_connected:
-                    if panda_was_down:
-                        # On reconnect, jump every metadata stream
-                        # past the outage backlog so the next drain
-                        # picks up the producer's "now". Keeps the
-                        # metadata cadence aligned with corr
-                        # integrations instead of smearing historical
-                        # readings into the current row.
-                        try:
-                            self.metadata_stream.skip_to_latest()
-                        except redis.exceptions.ConnectionError:
-                            # Bounced again between panda_connected
-                            # and the skip; treat as still-down and
-                            # try again next iteration.
-                            metadata = {}
-                            adc = self.adc_metadata_stream.drain()
-                            if adc:
-                                metadata.update(adc)
-                            if not metadata:
-                                metadata = None
-                            file.add_data(
-                                acc_cnt,
-                                cached_sync_time,
-                                data,
-                                metadata=metadata,
-                            )
-                            last_write_deadline = None
-                            continue
+                # Drain the metadata sidecar whenever the panda Redis is
+                # reachable, independent of the autonomous driver's
+                # heartbeat. The picos publish via the always-on
+                # pico-manager service, so a manual session (panda_observe
+                # stopped, heartbeat gone) still has live sensor metadata.
+                # ConnectionError is the real "panda unreachable" signal;
+                # corr stays sacred (metadata=None).
+                if metadata_stream_down:
+                    # On reconnect, jump every metadata stream past the
+                    # outage backlog so the next drain picks up the
+                    # producer's "now". Keeps the metadata cadence aligned
+                    # with corr integrations instead of smearing
+                    # historical readings into the current row.
                     try:
-                        metadata = self.metadata_stream.drain()
-                    except redis.exceptions.ConnectionError as exc:
-                        # Safety net for the corr-is-sacred contract:
-                        # ERROR (not WARNING) per CLAUDE.md, throttled
-                        # to one emit per ``_DRAIN_WARN_INTERVAL_S``
-                        # window so a long outage doesn't flood the log.
-                        panda_was_down = True
-                        now_mono = time.monotonic()
-                        if (
-                            now_mono - last_drain_warn_monotonic
-                            >= _DRAIN_WARN_INTERVAL_S
-                        ):
-                            self.logger.error(
-                                "Panda metadata drain failed: %s. "
-                                "Continuing corr writes with empty "
-                                "metadata until panda is back.",
-                                exc,
-                            )
-                            last_drain_warn_monotonic = now_mono
+                        self.metadata_stream.skip_to_latest()
+                    except redis.exceptions.ConnectionError:
+                        # Bounced again between the skip attempt and the
+                        # drain; treat as still-down and try next
+                        # iteration.
                         metadata = {}
-                    else:
-                        # Only signal "reconnected" once the drain
-                        # actually succeeds. If skip_to_latest() passes
-                        # but drain immediately raises (flapping panda:
-                        # heartbeat ok, single op fails), the INFO
-                        # would otherwise fire at ~4 Hz for the length
-                        # of the flap. Tying it to drain success makes
-                        # the INFO mean "metadata pipeline is back."
-                        if panda_was_down:
-                            self.logger.info(
-                                "Panda reconnected; metadata stream "
-                                "positions reset to current tails."
-                            )
-                            panda_was_down = False
-                else:
-                    panda_was_down = True
+                        adc = self.adc_metadata_stream.drain()
+                        if adc:
+                            metadata.update(adc)
+                        if not metadata:
+                            metadata = None
+                        file.add_data(
+                            acc_cnt,
+                            cached_sync_time,
+                            data,
+                            metadata=metadata,
+                        )
+                        last_write_deadline = None
+                        continue
+                try:
+                    metadata = self.metadata_stream.drain()
+                except redis.exceptions.ConnectionError as exc:
+                    # Safety net for the corr-is-sacred contract:
+                    # ERROR (not WARNING) per CLAUDE.md, throttled
+                    # to one emit per ``_DRAIN_WARN_INTERVAL_S``
+                    # window so a long outage doesn't flood the log.
+                    metadata_stream_down = True
+                    now_mono = time.monotonic()
+                    if (
+                        now_mono - last_drain_warn_monotonic
+                        >= _DRAIN_WARN_INTERVAL_S
+                    ):
+                        self.logger.error(
+                            "Panda metadata drain failed: %s. "
+                            "Continuing corr writes with empty "
+                            "metadata until panda is back.",
+                            exc,
+                        )
+                        last_drain_warn_monotonic = now_mono
                     metadata = {}
+                else:
+                    # Only signal "reconnected" once the drain actually
+                    # succeeds. If skip_to_latest() passes but drain
+                    # immediately raises, the INFO would otherwise fire
+                    # at ~4 Hz for the length of the flap. Tying it to
+                    # drain success makes the INFO mean "metadata
+                    # pipeline is back."
+                    if metadata_stream_down:
+                        self.logger.info(
+                            "Panda metadata pipeline back; stream "
+                            "positions reset to current tails."
+                        )
+                        metadata_stream_down = False
                 # adc_stats lives on the SNAP transport,
                 # merge into the same metadata dict
                 adc = self.adc_metadata_stream.drain()

--- a/src/eigsep_observing/run_tag.py
+++ b/src/eigsep_observing/run_tag.py
@@ -1,13 +1,27 @@
-"""Cross-process tag identifying which panda script is driving the run.
+"""Cross-process tag identifying which driver owns the panda's state.
 
-Published by the panda-side entry-points
-(``eigsep-panda`` console script,
-``src/eigsep_observing/scripts/no_switch_observation.py``,
-``src/eigsep_observing/scripts/vna_position_sweep.py``) when they
-start, cleared in their ``finally`` blocks. Consumed by ``EigObserver.record_corr_data`` (corr
-file headers) and ``PandaClient.measure_s11`` (VNA file headers) so
-the active script's identity is captured per-file for offline
-provenance.
+Published (via :func:`session`) by the autonomous panda drivers — the
+``eigsep-panda`` console script (``panda_observe``),
+``no_switch_observation``, ``vna_position_sweep`` — and by the active
+manual bring-up drivers that send commands or write VNA files
+(``motor_manual``, ``motor_control``, ``rfswitch_manual``,
+``tempctrl_manual``, ``vna_manual``, ``record_vna``). The tag is
+cleared in their ``finally`` blocks. Consumed by
+``EigObserver.record_corr_data`` (corr file headers) and
+``PandaClient.measure_s11`` (VNA file headers) so each file records
+which driver owned the physical state when the data was captured — and
+in particular flags data taken during a hand-driven manual session
+rather than autonomous observing.
+
+Passive readouts (``imu_manual``, ``monitor_meta``, ``potmon_manual``,
+``lidar_manual``, ``pico_preflight``) deliberately do NOT publish: they
+change no physical state and must coexist with the active driver. See
+``scripts/CLAUDE.md`` for the active-vs-passive rule.
+
+:func:`session` is refuse-on-conflict: it refuses to start while a
+different driver owns the tag. Among these mutually-exclusive drivers
+that is the "stop the autonomous driver before hand-driving shared
+hardware" guard.
 
 Mirrors :mod:`eigsep_observing.file_heartbeat` and
 :mod:`eigsep_observing.snap_reinit`: a single Redis key holds a small
@@ -15,11 +29,10 @@ JSON blob, overwritten on each publish — consumers only ever care
 about the most recent value. ``clear`` overwrites with a null payload
 rather than deleting the key (Transport doesn't expose ``delete``).
 
-Steady-state runs publish ``"panda_observe"`` so downstream's
-``run_tag`` field is uniformly populated by exactly one of the three
-scripts that own the panda. A ``None`` then signals a misconfiguration
-(broken publish, panda not running, transport unavailable) rather than
-the default for normal operations.
+Steady-state runs publish ``"panda_observe"``. A ``None`` signals that
+no driver is active — a misconfiguration if something is recording
+(broken publish, panda not running, transport unavailable), not the
+default for normal operations.
 
 ``session`` auto-reclaims a stale tag whose holder is *provably dead*.
 An unclean shutdown (power loss, ``SIGKILL``, a hard reboot mid-run)

--- a/tests/test_obs_config_uploaders.py
+++ b/tests/test_obs_config_uploaders.py
@@ -1,9 +1,10 @@
 """Structural guards on the obs_config upload + run_tag.session contract.
 
-Three AST-level invariants on the ``scripts/`` and
+AST-level invariants on the ``scripts/`` and
 ``src/eigsep_observing/scripts/`` directories. They fail closed so a
-future PR can't quietly add a fourth uploader, drop a session wrap, or
-let an uploader stop publishing its owner.
+future PR can't quietly add an uploader, drop a session wrap from an
+active driver, let an exempt (passive/coexisting) script start claiming
+the tag, or let an uploader stop publishing its owner.
 """
 
 import ast
@@ -22,33 +23,38 @@ UPLOADER_SCRIPTS = {
     "vna_position_sweep.py",
 }
 
-# Panda-side bring-up scripts that must enter run_tag.session so corr
-# and VNA files written during their run carry the active driver's
-# identity in the run_tag overlay.
-BRING_UP_SCRIPTS = {
+# Panda-side ACTIVE driver scripts that must enter run_tag.session.
+# These send commands or write VNA files, so they change physical state
+# that affects the always-recording corr/VNA data; the run_tag overlay
+# flags those files with the active driver's identity ("hand-driven, not
+# autonomous science"). refuse-on-conflict makes them mutually exclusive
+# with the autonomous driver and each other — one active driver of the
+# physical state at a time (combined motor+VNA runs use the dedicated
+# alt-mode vna_position_sweep). Passive readouts are NOT here; they only
+# read snapshots and must coexist, so they live in RUN_TAG_EXEMPT.
+ACTIVE_DRIVER_SCRIPTS = {
     "vna_manual.py",
     "rfswitch_manual.py",
     "tempctrl_manual.py",
     "motor_manual.py",
     "motor_control.py",
-    "potmon_manual.py",
-    "lidar_manual.py",
-    "pico_preflight.py",
-    "monitor_meta.py",
+    "record_vna.py",
 }
 
-# Scripts explicitly exempt from publishing run_tag:
+# Scripts explicitly exempt from publishing run_tag, with the reason:
+#   - Passive readouts (imu_manual.py, monitor_meta.py,
+#     potmon_manual.py, lidar_manual.py, pico_preflight.py):
+#     MetadataSnapshotReader-only — no commands, no files — so they
+#     change no physical state and have no provenance to record. They
+#     must coexist with whatever active driver is running, so they must
+#     NOT claim the refuse-on-conflict tag. See imu_manual.py /
+#     scripts/CLAUDE.md for the active-vs-passive rule.
 #   - live_status.py / live_plotter.py: long-running dashboards that
 #     may run alongside any driver; publishing would trample or be
 #     refused by the session check.
-#   - record_metadata.py / record_vna.py: test-bench recorders that
-#     run alongside the active driver(s); same trample/refuse concern
-#     as the dashboards.
-#   - imu_manual.py: read-only IMU readout (MetadataSnapshotReader
-#     only, no commands, no files) that must coexist with the driver
-#     it watches; claiming the tag would block that coexistence and
-#     misattribute a concurrent observer's files. See its main() for
-#     the full rationale.
+#   - record_metadata.py: test-bench metadata recorder that runs
+#     alongside the active driver(s); it only reads/relays metadata and
+#     drives no hardware, so it coexists like the dashboards.
 #   - observe.py: ground-PC eigsep-observe writer, a consumer of the
 #     panda transport (it reads obs_config but never publishes run_tag).
 #   - SNAP-side scripts (republish_header.py, adc_snapshot*.py,
@@ -61,7 +67,6 @@ RUN_TAG_EXEMPT = {
     "live_status.py",
     "live_plotter.py",
     "record_metadata.py",
-    "record_vna.py",
     "observe.py",
     "republish_header.py",
     "adc_snapshot.py",
@@ -69,6 +74,10 @@ RUN_TAG_EXEMPT = {
     "capture_spectrum.py",
     "fpga_init.py",
     "imu_manual.py",
+    "monitor_meta.py",
+    "potmon_manual.py",
+    "lidar_manual.py",
+    "pico_preflight.py",
     "clear_run_tag.py",
 }
 
@@ -145,15 +154,16 @@ def test_obs_config_upload_whitelist():
     )
 
 
-def test_bring_up_scripts_use_run_tag_session():
-    """Every panda-side driver script enters ``run_tag.session``.
+def test_active_driver_scripts_use_run_tag_session():
+    """Every active panda-side driver enters ``run_tag.session``.
 
-    Together with the refuse-on-conflict policy in
+    The active manual drivers plus the autonomous uploaders. Together
+    with the refuse-on-conflict policy in
     :func:`eigsep_observing.run_tag.session`, this means corr / VNA
     files written during a driver's run always carry that driver's
     identity in the ``run_tag`` overlay.
     """
-    must_publish = BRING_UP_SCRIPTS | UPLOADER_SCRIPTS
+    must_publish = ACTIVE_DRIVER_SCRIPTS | UPLOADER_SCRIPTS
     missing = []
     for path in _iter_script_files():
         if path.name not in must_publish:
@@ -163,6 +173,30 @@ def test_bring_up_scripts_use_run_tag_session():
             missing.append(str(path.relative_to(_REPO_ROOT)))
     assert not missing, (
         f"Scripts must wrap their main work in run_tag.session(...): {missing}"
+    )
+
+
+def test_exempt_scripts_do_not_claim_run_tag():
+    """Exempt scripts must NOT enter ``run_tag.session``.
+
+    The bidirectional partner to
+    :func:`test_active_driver_scripts_use_run_tag_session`: a script is
+    in ``RUN_TAG_EXEMPT`` *because* it must coexist (passive readout,
+    dashboard, recorder, or SNAP-side tool), so claiming the
+    refuse-on-conflict tag would block that coexistence. Fails closed —
+    would have caught ``record_vna`` sitting in ``RUN_TAG_EXEMPT`` while
+    still calling ``run_tag.session``.
+    """
+    offenders = []
+    for path in _iter_script_files():
+        if path.name not in RUN_TAG_EXEMPT:
+            continue
+        tree = _parse(path)
+        if _has_call_named(tree, "run_tag.session"):
+            offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        "Exempt scripts must not call run_tag.session (they must coexist "
+        f"with the active driver): {offenders}"
     )
 
 
@@ -196,12 +230,13 @@ def test_script_directory_partition_is_total():
     silently bypass the previous two guards. This check forces the
     author to update the partition.
     """
-    known = BRING_UP_SCRIPTS | UPLOADER_SCRIPTS | RUN_TAG_EXEMPT
+    known = ACTIVE_DRIVER_SCRIPTS | UPLOADER_SCRIPTS | RUN_TAG_EXEMPT
     orphans = []
     for path in _iter_script_files():
         if path.name not in known:
             orphans.append(str(path.relative_to(_REPO_ROOT)))
     assert not orphans, (
-        "New scripts must be added to BRING_UP_SCRIPTS, UPLOADER_SCRIPTS, "
-        f"or RUN_TAG_EXEMPT in {Path(__file__).name}: {orphans}"
+        "New scripts must be added to ACTIVE_DRIVER_SCRIPTS, "
+        "UPLOADER_SCRIPTS, or RUN_TAG_EXEMPT in "
+        f"{Path(__file__).name}: {orphans}"
     )

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -787,10 +787,13 @@ def test_record_corr_data_read_timeout_then_success_resets_deadline(
 def test_record_corr_data_panda_connected_drains_metadata(
     mock_file_class, observer_both, transport_panda
 ):
-    """When the panda is connected, the metadata stream is drained and
-    forwarded to ``file.add_data``; when not, ``metadata=None`` is passed
-    (covered by ``test_record_corr_data``). This exercises the only
-    success-path branch that touches cross-class logic.
+    """With the panda metadata stream reachable, the drained readings
+    are forwarded to ``file.add_data``. This exercises the success-path
+    branch that touches cross-class logic. The drain is gated on stream
+    reachability, not the heartbeat — see
+    ``test_record_corr_data_drains_metadata_without_heartbeat`` for the
+    no-heartbeat case and ``test_record_corr_data`` for the empty-stream
+    → ``metadata=None`` case.
     """
     observer = observer_both
     sync_time = 1713200000.0
@@ -822,6 +825,55 @@ def test_record_corr_data_panda_connected_drains_metadata(
 
     # add_data received the drained metadata, keyed by the stream name
     # MetadataWriter.add uses (``stream:<key>``).
+    mock_file.add_data.assert_called_once()
+    call_kwargs = mock_file.add_data.call_args.kwargs
+    assert call_kwargs["metadata"] == {"stream:sensor_a": [sample]}
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_drains_metadata_without_heartbeat(
+    mock_file_class, observer_snap_only, transport_panda_down
+):
+    """The metadata sidecar is drained whenever the panda Redis is
+    reachable, even with no heartbeat.
+
+    A manual session stops ``panda_observe`` (so the heartbeat goes away
+    and ``panda_connected`` is False), but the picos keep publishing
+    metadata via the always-on pico-manager service. The corr loop must
+    still attach that metadata: the drain is gated on Redis reachability
+    (``ConnectionError``), not on ``panda_connected``. Regression guard
+    for the heartbeat-decoupling fix — under the old heartbeat gate this
+    integration would have been written with ``metadata=None``.
+    """
+    observer = observer_snap_only
+    assert observer.panda_connected is False  # no heartbeat seeded
+
+    observer.corr_config.upload_header({"sync_time": 1713200000.0})
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    mock_data = generate_data(ntimes=1)
+
+    # Picos publish metadata via pico-manager even with panda_observe
+    # stopped. Push one reading and rewind the read pointer so drain()
+    # picks it up (mirrors test_..._panda_connected_drains_metadata, but
+    # against the no-heartbeat transport).
+    sample = {"temp_c": 23.5, "status": "update"}
+    MetadataWriter(transport_panda_down).add("sensor_a", sample)
+    transport_panda_down.set_last_read_id("stream:sensor_a", "0-0")
+
+    def read_side_effect(*a, **kw):
+        observer.stop_event.set()
+        return (123, mock_data)
+
+    with patch.object(
+        observer.corr_reader, "read", side_effect=read_side_effect
+    ):
+        observer.record_corr_data("/tmp/test", ntimes=1, timeout=5)
+
     mock_file.add_data.assert_called_once()
     call_kwargs = mock_file.add_data.call_args.kwargs
     assert call_kwargs["metadata"] == {"stream:sensor_a": [sample]}
@@ -1687,9 +1739,9 @@ def test_record_corr_data_skip_to_tail_on_panda_recover(
 
     # Confirm we actually exercised the recover-and-resume path.
     assert len(drain_calls) >= 2
-    assert any("Panda reconnected" in rec.message for rec in caplog.records), [
-        r.message for r in caplog.records
-    ]
+    assert any(
+        "metadata pipeline back" in rec.message for rec in caplog.records
+    ), [r.message for r in caplog.records]
 
     # No call to add_data carried the stale backlog reading.
     seen_metadata = [

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -808,6 +808,14 @@ def test_record_corr_data_panda_connected_drains_metadata(
 
     # Push one sensor reading onto the panda metadata stream via the
     # real MetadataWriter (runs against fakeredis in DummyTransport).
+    #
+    # Fixture deviation: stream ``sensor_a`` and field ``temp_c`` are
+    # synthetic — neither is in ``SENSOR_SCHEMAS``. Intentional: this
+    # test exercises the drain → ``file.add_data`` forwarding path,
+    # which runs below the schema layer (``add_data`` is mocked, so the
+    # ``_avg_sensor_values`` reduction never runs). A real producer
+    # payload would add no coverage; see ``tests/test_io.py`` for the
+    # end-to-end producer→avg→write→read fixture round-trip.
     sample = {"temp_c": 23.5, "status": "update"}
     MetadataWriter(transport_panda).add("sensor_a", sample)
     # Rewind last-read-id so drain() picks up the entry we just pushed
@@ -861,6 +869,14 @@ def test_record_corr_data_drains_metadata_without_heartbeat(
     # stopped. Push one reading and rewind the read pointer so drain()
     # picks it up (mirrors test_..._panda_connected_drains_metadata, but
     # against the no-heartbeat transport).
+    #
+    # Fixture deviation: stream ``sensor_a`` and field ``temp_c`` are
+    # synthetic — neither is in ``SENSOR_SCHEMAS``. Intentional: this
+    # test exercises the ConnectionError-gated drain → ``file.add_data``
+    # forwarding path, which runs below the schema layer (``add_data`` is
+    # mocked, so the ``_avg_sensor_values`` reduction never runs). A real
+    # producer payload would add no coverage; see ``tests/test_io.py``
+    # for the end-to-end producer→avg→write→read fixture round-trip.
     sample = {"temp_c": 23.5, "status": "update"}
     MetadataWriter(transport_panda_down).add("sensor_a", sample)
     transport_panda_down.set_last_read_id("stream:sensor_a", "0-0")


### PR DESCRIPTION
## Context

When `run_tag.session` was removed from `imu_manual` (commits `cb553f4` / `3675907`) we carved out one script but **deferred the general policy** for how run tags should work. This resolves it.

`run_tag.session()` is **refuse-on-conflict** (raises if any other tag is held), which structurally contradicts `scripts/CLAUDE.md`'s requirement that bring-up scripts **coexist** with the production driver and with each other. Every bring-up script claimed the tag, so starting `vna_manual` while `panda_observe` (or `motor_manual`) held it would refuse.

The reframe: in the field the ground PC is **always recording corr**, so an active manual session is exactly when you want corr files flagged "hand-driven, not autonomous science." The `imu_manual` carve-out generalizes to a rule.

## Decisions

- **One active manual tool at a time** — global refuse-on-conflict stays; it's a *safety guard* ("stop the autonomous driver before hand-driving shared hardware"). Combined motor+VNA workflows use the dedicated alt-mode `vna_position_sweep`.
- **Manual-session corr must stay metadata-complete** — the heartbeat-gating gap is fixed here.

## Changes

### run_tag: active drivers claim it, passive readouts don't
- **Passive readouts** (snapshot-only, no commands/files) stop claiming `run_tag` and must coexist: `monitor_meta`, `potmon_manual`, `lidar_manual`, `pico_preflight` join `imu_manual`.
- **Active drivers** (send commands / write VNA files) keep claiming: `motor_manual`, `motor_control`, `rfswitch_manual`, `tempctrl_manual`, `vna_manual`, `record_vna`.
- Fixes the latent **`record_vna` contradiction** (was in `RUN_TAG_EXEMPT` yet still calling `run_tag.session`) — reclassified as an active driver.

### Manual-session metadata completeness
- `record_corr_data` now drains the metadata sidecar whenever the panda Redis is **reachable** (gated on `ConnectionError`, tracked by `metadata_stream_down`), **not** on the heartbeat (`panda_connected`). The picos publish via the always-on pico-manager, so a manual session (with `panda_observe` stopped) keeps full corr metadata instead of `metadata=None`. `status_logger` and the VNA loop stay correctly heartbeat-gated.

### Test guards (`tests/test_obs_config_uploaders.py`)
- `BRING_UP_SCRIPTS` → `ACTIVE_DRIVER_SCRIPTS`; the 4 passive readouts move to `RUN_TAG_EXEMPT`.
- New **bidirectional** guard `test_exempt_scripts_do_not_claim_run_tag` — fails closed; would have caught the `record_vna` contradiction.
- New observer regression guard `test_record_corr_data_drains_metadata_without_heartbeat`.

### Docs
- Active-vs-passive rule in `scripts/CLAUDE.md` and the `run_tag.py` docstring.
- "Manual sessions: the autonomous driver vs the always-on pico-manager" in top-level `CLAUDE.md` (tempctrl survives in firmware; switch freezes; corr+metadata keep recording).

## Test plan

- `ruff check` + `ruff format --check`: clean (8 files)
- **55 tests pass**: `tests/test_obs_config_uploaders.py` (5) + `tests/test_observer.py` (50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)