### PR TITLE
feat(live_status): matplotlib-style zoom tick density + snappy Ctrl-C shutdown

### DIFF
--- a/scripts/live_status.py
+++ b/scripts/live_status.py
@@ -17,7 +17,6 @@ import logging
 import signal
 import sys
 
-import redis
 from eigsep_redis import Transport
 
 from eigsep_observing import utils
@@ -30,27 +29,15 @@ from eigsep_observing.live_status import (
 
 logger = logging.getLogger(__name__)
 
-
-class _LazyTransport(Transport):
-    """Transport that skips the eager ``ping()`` in ``_make_redis``.
-
-    The dashboard's whole job is to *monitor* bus health, including the
-    bus-down state. Failing fast in the constructor turns "panda is
-    down" into a startup crash instead of a red tile. The aggregator's
-    per-tick error handling already catches connection errors and
-    flips ``snap_connected`` / ``panda_connected`` to False, which is
-    exactly the right UX for a monitor.
-    """
-
-    def _make_redis(self, host, port):
-        return redis.Redis(
-            host=host,
-            port=port,
-            decode_responses=False,
-            socket_timeout=None,
-            socket_connect_timeout=None,
-            retry_on_timeout=False,
-        )
+# socket_connect_timeout for the SNAP/panda transports. Kept finite, and
+# well under the aggregator.stop() join budget (2.0 s), so a drain thread
+# parked mid-connect to an unreachable bus aborts quickly instead of
+# sitting in the kernel's TCP connect — which is what keeps Ctrl-C snappy
+# even when a bus is down. (A hand-rolled lazy transport here once set
+# socket_connect_timeout=None and turned shutdown into a multi-second
+# stall; the base Transport's lazy=True does the same "boot with the bus
+# down" job with a bounded connect.)
+_CONNECT_TIMEOUT_S = 1.0
 
 
 def _parse_bind(spec: str) -> tuple[str, int]:
@@ -129,9 +116,22 @@ def main(argv=None):
     obs_cfg_path = args.obs_config or utils.get_config_path("obs_config.yaml")
     obs_cfg = utils.load_config(obs_cfg_path, compute_inttime=False)
 
-    transport_snap = _LazyTransport(host=args.snap_host, port=args.snap_port)
-    transport_panda = _LazyTransport(
-        host=args.panda_host, port=args.panda_port
+    # lazy=True so the dashboard boots — and keeps running — when a bus
+    # is down: the aggregator's per-tick error handling flips
+    # snap_connected / panda_connected to False, which is the right UX
+    # for a monitor (a red tile, not a startup crash). connect_timeout
+    # bounds shutdown when a bus is unreachable (see _CONNECT_TIMEOUT_S).
+    transport_snap = Transport(
+        host=args.snap_host,
+        port=args.snap_port,
+        lazy=True,
+        connect_timeout=_CONNECT_TIMEOUT_S,
+    )
+    transport_panda = Transport(
+        host=args.panda_host,
+        port=args.panda_port,
+        lazy=True,
+        connect_timeout=_CONNECT_TIMEOUT_S,
     )
 
     thresholds = Thresholds.from_yaml(

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -224,15 +224,23 @@ async function fetchJson(path) {
 // starts just below 0 so the DC bin (0 MHz) sits inside the axis
 // rather than hidden on the left spine, and ends at 250 MHz — the
 // 500 MHz real-sampling Nyquist (data tops out at 249.76 MHz) — so
-// the highest tick is the band edge. dtick=25 from tick0=0 puts
-// ticks at 0, 25, ..., 250.
+// the highest tick is the band edge.
+//
+// Ticks are left in Plotly's automatic ("nice number") tickmode, which
+// is matplotlib-style: it draws evenly-rounded labels for whatever span
+// is in view and recomputes them on zoom. So the full band shows ~6
+// round labels (0, 50, ..., 250) and zooming in automatically densifies
+// them — zoom into a 10 MHz window and you get 2 MHz ticks, etc. The old
+// fixed dtick=25 defeated this: it pinned 25 MHz spacing at every zoom
+// level, so labels vanished when you zoomed inside a 25 MHz window.
+// nticks caps the full-band density so a wide monitor doesn't creep back
+// toward a cluttered grid.
 // gridcolor (here and in every layout below) is stamped by
 // applyThemeToLayouts() from the active theme — see THEMES.
 const corrXaxis = {
   title: "Frequency [MHz]",
   range: [-5, 250],
-  tick0: 0,
-  dtick: 25,
+  nticks: 8,
 };
 
 // Plotly log axes take ranges in log10. [-2, 9] mirrors the legacy

--- a/tests/test_live_status_shutdown.py
+++ b/tests/test_live_status_shutdown.py
@@ -1,0 +1,85 @@
+"""Ctrl-C responsiveness guard for the live-status dashboard.
+
+``scripts/live_status.py`` builds its SNAP/panda transports lazily so the
+dashboard can boot — and keep running — while a bus is down. The connect
+timeout on those transports is load-bearing for *shutdown*: a drain
+thread parked mid-connect to an unreachable bus can only be joined once
+its connect attempt returns, so an unbounded ``socket_connect_timeout``
+turns Ctrl-C into a multi-second wait (per drain thread, and ``stop()``
+runs twice — once in the SIGINT handler, once in the ``finally``).
+
+This test pins the timeout finite and well under the ``stop()`` join
+budget, so a regression — e.g. reintroducing the old ``_LazyTransport``
+override that hardcoded ``socket_connect_timeout=None`` — fails loudly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(name):
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _connect_timeout(transport):
+    """The ``socket_connect_timeout`` actually handed to ``redis.Redis``.
+
+    Read from the live client (not ``transport.connect_timeout``): the
+    bug being guarded was a ``_make_redis`` override whose hardcoded
+    ``None`` diverged from the stored attribute, so only the real client
+    kwargs reveal it.
+    """
+    return transport.r.connection_pool.connection_kwargs[
+        "socket_connect_timeout"
+    ]
+
+
+def test_dashboard_transports_have_bounded_connect_timeout(monkeypatch):
+    mod = _load("live_status")
+
+    captured = {}
+
+    class _FakeAgg:
+        def __init__(self, *, transport_snap, transport_panda, **_kw):
+            captured["snap"] = transport_snap
+            captured["panda"] = transport_panda
+
+        def start(self):
+            pass
+
+        def stop(self, timeout=2.0):
+            pass
+
+    # Keep main() from blocking in Flask or clobbering pytest's signal
+    # handlers; we only care about how the transports are built.
+    monkeypatch.setattr(mod, "LiveStatusAggregator", _FakeAgg)
+    monkeypatch.setattr(
+        mod,
+        "create_app",
+        lambda _agg: types.SimpleNamespace(run=lambda **_kw: None),
+    )
+    monkeypatch.setattr(mod.signal, "signal", lambda *_a: None)
+
+    mod.main(["--bind", "127.0.0.1:5999"])
+
+    for side in ("snap", "panda"):
+        ct = _connect_timeout(captured[side])
+        assert ct is not None, (
+            f"{side} transport has an unbounded socket_connect_timeout; "
+            "a worker stuck mid-connect to a down bus would stall Ctrl-C"
+        )
+        # Must be comfortably under the aggregator.stop() join timeout
+        # (2.0 s) so a connecting drain thread exits before the join
+        # deadline, keeping shutdown to ~1 s.
+        assert 0 < ct < 2.0, (
+            f"{side} connect timeout {ct!r} is too large for a snappy Ctrl-C"
+        )


### PR DESCRIPTION
Two live-status dashboard fixes.

## 1. Matplotlib-style tick density on corr plot zoom

Zooming into the corr **magnitude**/**phase** plots now keeps the x-axis labels visible and densifies them matplotlib-style, instead of leaving them pinned at the fixed 25 MHz spacing (which made labels vanish when you zoomed inside a 25 MHz window).

The corr frequency x-axis hardcoded `tick0: 0, dtick: 25`, forcing 25 MHz spacing at *every* zoom level. The fix is to drop the fixed `dtick`/`tick0` and let **Plotly's automatic ("nice number") tickmode** drive the axis, capped with `nticks: 8`:

- That tickmode is matplotlib-style — it draws evenly-rounded labels for whatever span is in view and recomputes them on zoom.
- Full band → ~6 round labels (0, 50, …, 250).
- Zoom into a 10 MHz window → 2 MHz ticks, etc. — labels stay visible and get denser the further you zoom.
- `nticks` bounds the full-band density so a wide monitor doesn't creep back toward a cluttered grid.

The VNA plot already relied on this auto tickmode, so this just brings the corr plots in line. Net diff is `tick0: 0, dtick: 25` → `nticks: 8` plus an explanatory comment.

## 2. Snappy Ctrl-C shutdown

Quitting the dashboard with Ctrl-C could drag out to ~12 s (worst case) when a bus was down — exactly the situation you're most likely to be watching a monitor in.

Root cause: the dashboard built its SNAP/panda transports through a hand-rolled `_LazyTransport` whose `_make_redis` override hardcoded `socket_connect_timeout=None`. A drain thread parked mid-connect to an unreachable bus then sat in the kernel's TCP connect, so shutdown fell back on the `aggregator.stop()` join caps (2.0 s per daemon thread, and `stop()` runs twice — SIGINT handler + `finally`).

`_LazyTransport` predated `lazy=True` on the base `Transport`, which already skips the eager ping **and** passes a finite `socket_connect_timeout`. Drop the shim (and the now-unused `redis` import) and build the transports with `Transport(lazy=True, connect_timeout=1.0)`. 1.0 s is under the 2.0 s join budget, so a thread stuck mid-connect aborts before the join deadline: the first `stop()` joins cleanly, the `finally` `stop()` is a no-op, and down-bus Ctrl-C lands in ~1 s. This also matches `observe.py`, which already uses `Transport(lazy=True)`.

## Verification

- `node --check dashboard.js` → syntax OK; Plotly auto-tick picks spacings from `{1,2,5}×10ⁿ` (full span 255 / `nticks` 8 → dtick 50, ~6 ticks; a 10 MHz zoom → dtick 2).
- `tests/test_live_status_shutdown.py` (new, TDD): failed first (`socket_connect_timeout` was `None`), passes after the fix — builds the dashboard's transports via `main()` and asserts a finite connect timeout under the join budget, so reintroducing an unbounded connect fails loudly.
- 91 existing live-status tests pass; `ruff check`/`format` clean.

**Not verified in a browser:** the tick change reverts to Plotly's native auto-tick (already used by the VNA plot here), but I couldn't drive the live dashboard's browser to watch it zoom on my end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)