### PR TITLE
fix(io): add voltage/resistance to tempctrl _PELTIER_SCHEMA

### DIFF
--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -706,6 +706,12 @@ _PELTIER_SCHEMA = {
     "watchdog_tripped": bool,
     "watchdog_timeout_ms": int,
     "T_now": float,
+    # Analog-thermistor diagnostics added by pico-firmware #109: the Pico
+    # reports the raw ADC voltage at the divider node and the derived
+    # thermistor resistance alongside the converted temperature. Scalar
+    # floats, so they reduce via the standard float->mean path.
+    "voltage": float,
+    "resistance": float,
     "timestamp": float,
     "T_target": float,
     "drive_level": float,


### PR DESCRIPTION
Closes #159.

## What

Adds `voltage` and `resistance` (scalar floats) to `_PELTIER_SCHEMA` in `src/eigsep_observing/io.py`, so the `tempctrl_lna` / `tempctrl_load` producer-contract test stays green once picohost ships the analog-thermistor diagnostics from [pico-firmware #109](https://github.com/EIGSEP/pico-firmware/pull/109).

## ⚠️ Blocked on picohost bump — do not merge alone

This must land **together with (or after)** bumping the `picohost` dependency to a release containing pico-firmware #109. The current frozen pin (`picohost==3.6.0`) does **not** emit these fields, so on its own this change flips the contract test from "extra keys" to "missing keys" and CI will be red.

Verified both directions locally with `_validate_metadata`:

| picohost | result |
|---|---|
| 3.6.0 (current frozen pin) | `missing keys: ['resistance', 'voltage']` ❌ |
| local pico-firmware #109 | `violations=[]` ✅ |

## Notes

- Both fields reduce via the existing `_avg_sensor_values` float→mean path; no reducer change needed.
- The contract fixtures derive dynamically from the real picohost emulator + handler, so they auto-pick-up the new fields — only the schema was stale.
- No other consumer needs changes (the live-status dashboard may optionally surface them).