### PR TITLE
test(observer): make corr-liveness-watchdog tests deterministic (fix CI flake)

### DIFF
--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,8 +1,10 @@
+import itertools
 import logging
 import pytest
 import queue
 import threading
 import time
+from contextlib import contextmanager
 from unittest.mock import Mock, patch
 
 from cmt_vna.testing import DummyVNA
@@ -533,6 +535,50 @@ def test_record_corr_data_transient_header_blip_uses_cache(
     assert "Using cached corr header" in caplog.text
 
 
+@contextmanager
+def _deterministic_watchdog(observer):
+    """Make ``record_corr_data``'s liveness watchdog fire deterministically.
+
+    ``_tick_liveness_deadline`` arms a deadline on its first call and
+    only logs once ``time.monotonic()`` passes it — so the watchdog
+    needs at least two loop iterations to emit. These tests used to race
+    a real ``threading.Timer(1.5, stop_event.set)`` against a real
+    ``liveness_timeout`` window; on a loaded CI runner the wall-clock
+    stop could land before the second tick, the ERROR never logged, and
+    the ``any(...)`` assertion failed (observed flaking the 3.10 job).
+
+    This removes every real-time dependency:
+
+    - ``time.monotonic`` is replaced with a fake clock that advances a
+      full second per call, so the deadline (a sub-second
+      ``liveness_timeout``) is always exceeded by the second tick.
+      ``_tick_liveness_deadline`` is the only ``monotonic`` caller on
+      these watchdog paths, but the stop is driven separately (below),
+      so the clock only has to be monotonically increasing — exact
+      call-to-iteration alignment is not relied on.
+    - ``stop_event.wait`` is made non-blocking (returns the current
+      ``is_set()``), so the ``stop_event.wait(1)`` calls in the
+      header / stream-absent branches don't sleep.
+
+    The caller still drives ``stop_event`` from a counting closure on
+    whichever producer method the test exercises (``read`` or
+    ``get_header``), so the loop exits on its real control variable.
+    """
+    clock = itertools.count(1.0, 1.0)
+    with (
+        patch(
+            "eigsep_observing.observer.time.monotonic",
+            side_effect=lambda: next(clock),
+        ),
+        patch.object(
+            observer.stop_event,
+            "wait",
+            side_effect=lambda timeout=None: observer.stop_event.is_set(),
+        ),
+    ):
+        yield
+
+
 @patch("eigsep_observing.io.File")
 def test_record_corr_data_unsynced_watchdog_logs_and_waits(
     mock_file_class, observer_snap_only, caplog
@@ -551,17 +597,29 @@ def test_record_corr_data_unsynced_watchdog_logs_and_waits(
     mock_file.__len__ = Mock(return_value=0)
     mock_file_class.return_value = mock_file
 
-    observer.corr_config.upload_header({"sync_time": 0})
+    # Persistent sync_time=0 (SNAP not synchronized); stop the loop once
+    # the watchdog has ticked twice. get_header is the per-iteration hook
+    # on this path (read is never reached), so it doubles as the stop
+    # driver — deterministic, no wall-clock Timer.
+    calls = itertools.count(1)
 
-    stop_after = threading.Timer(1.5, observer.stop_event.set)
-    stop_after.start()
+    def get_header_side_effect():
+        if next(calls) >= 3:
+            observer.stop_event.set()
+        return {"sync_time": 0}
+
     caplog.set_level(logging.ERROR, logger="eigsep_observing.observer")
-    try:
+    with (
+        _deterministic_watchdog(observer),
+        patch.object(
+            observer.corr_config,
+            "get_header",
+            side_effect=get_header_side_effect,
+        ),
+    ):
         observer.record_corr_data(
             "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
         )
-    finally:
-        stop_after.cancel()
 
     # No data should have been read or written — no sync anchor.
     mock_file.add_data.assert_not_called()
@@ -586,20 +644,27 @@ def test_record_corr_data_no_header_ever_logs_and_waits(
     mock_file.__len__ = Mock(return_value=0)
     mock_file_class.return_value = mock_file
 
-    stop_after = threading.Timer(1.5, observer.stop_event.set)
-    stop_after.start()
+    # get_header raises every iteration (no cached header); count the
+    # calls and stop once the watchdog has ticked twice.
+    calls = itertools.count(1)
+
+    def get_header_side_effect():
+        if next(calls) >= 3:
+            observer.stop_event.set()
+        raise ValueError("no header")
+
     caplog.set_level(logging.ERROR, logger="eigsep_observing.observer")
-    try:
-        with patch.object(
+    with (
+        _deterministic_watchdog(observer),
+        patch.object(
             observer.corr_config,
             "get_header",
-            side_effect=ValueError("no header"),
-        ):
-            observer.record_corr_data(
-                "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
-            )
-    finally:
-        stop_after.cancel()
+            side_effect=get_header_side_effect,
+        ),
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
+        )
 
     mock_file.add_data.assert_not_called()
     mock_file.close.assert_called()
@@ -681,20 +746,25 @@ def test_record_corr_data_read_timeout_watchdog_logs_and_waits(
 
     observer.corr_config.upload_header({"sync_time": 1713200000.0})
 
-    stop_after = threading.Timer(1.5, observer.stop_event.set)
-    stop_after.start()
+    # read raises TimeoutError every iteration; count the calls and stop
+    # once the watchdog has ticked twice.
+    calls = itertools.count(1)
+
+    def read_side_effect(*a, **k):
+        if next(calls) >= 3:
+            observer.stop_event.set()
+        raise TimeoutError("no data")
+
     caplog.set_level(logging.ERROR, logger="eigsep_observing.observer")
-    try:
-        with patch.object(
-            observer.corr_reader,
-            "read",
-            side_effect=TimeoutError("no data"),
-        ):
-            observer.record_corr_data(
-                "/tmp/test", ntimes=1, timeout=0.05, liveness_timeout=0.2
-            )
-    finally:
-        stop_after.cancel()
+    with (
+        _deterministic_watchdog(observer),
+        patch.object(
+            observer.corr_reader, "read", side_effect=read_side_effect
+        ),
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=0.05, liveness_timeout=0.2
+        )
 
     mock_file.add_data.assert_not_called()
     mock_file.close.assert_called()
@@ -720,18 +790,25 @@ def test_record_corr_data_read_stream_absent_watchdog_logs_and_waits(
 
     observer.corr_config.upload_header({"sync_time": 1713200000.0})
 
-    stop_after = threading.Timer(1.5, observer.stop_event.set)
-    stop_after.start()
+    # read returns (None, {}) every iteration (stream not created yet);
+    # count the calls and stop once the watchdog has ticked twice.
+    calls = itertools.count(1)
+
+    def read_side_effect(*a, **k):
+        if next(calls) >= 3:
+            observer.stop_event.set()
+        return (None, {})
+
     caplog.set_level(logging.ERROR, logger="eigsep_observing.observer")
-    try:
-        with patch.object(
-            observer.corr_reader, "read", return_value=(None, {})
-        ):
-            observer.record_corr_data(
-                "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
-            )
-    finally:
-        stop_after.cancel()
+    with (
+        _deterministic_watchdog(observer),
+        patch.object(
+            observer.corr_reader, "read", side_effect=read_side_effect
+        ),
+    ):
+        observer.record_corr_data(
+            "/tmp/test", ntimes=1, timeout=5, liveness_timeout=0.2
+        )
 
     mock_file.add_data.assert_not_called()
     mock_file.close.assert_called()


### PR DESCRIPTION
## Summary

Makes the four `record_corr_data` liveness-watchdog tests in `tests/test_observer.py` deterministic, removing a wall-clock race that flaked CI.

## The flake

On PR #165, the `test (3.10)` matrix job failed on:
- `test_record_corr_data_read_timeout_watchdog_logs_and_waits`
- `test_record_corr_data_read_stream_absent_watchdog_logs_and_waits`

…while the **same job passed on rerun**, on **every other Python version (3.11–3.14)**, and in the parallel `push` run — the signature of a flaky, timing-dependent test rather than a regression. (The `test (3.10)` runner happened to run ~3× slower that time.)

## Root cause

Each test armed a real `threading.Timer(1.5, observer.stop_event.set)` and passed `liveness_timeout=0.2`, then asserted the watchdog ERROR (`"SNAP has not produced a complete corr row"`) was logged.

But `_tick_liveness_deadline` only logs on its **second** tick — the first call just arms the deadline (`monotonic() + liveness_timeout`); a later call logs once `monotonic()` passes it. So the assertion needs the loop to reach a second tick before the `1.5s` wall-clock stop fires. On a starved runner the process can be descheduled long enough that the stop lands after only one iteration → no ERROR logged → `assert any(...)` is `False`.

Two of the four happened to flake this time; all four shared the identical pattern (`..._unsynced_...` and `..._no_header_ever_...` carried the same latent fragility), so all four are hardened here.

## Fix

A shared `_deterministic_watchdog(observer)` context manager removes every real-time dependency:

- **Fake `time.monotonic`** that advances a full second per call, so a sub-second `liveness_timeout` deadline is always exceeded by the second tick.
- **Non-blocking `stop_event.wait`** (returns the current `is_set()`), so the `stop_event.wait(1)` calls in the header / stream-absent branches don't sleep.
- The loop still stops on its **real control variable**: each test drives `stop_event` from a counting closure on the per-iteration producer method it exercises (`read` for the timeout / stream-absent cases, `get_header` for the unsynced / no-header cases), setting the event once the watchdog has ticked twice.

This matches the project's testing guidance (drive the loop's actual control variable; the logger is not a control plane) and the deterministic `stop_event.set()`-from-`side_effect` idiom the other `record_corr_data` tests already use.

## Testing

- The four tests pass deterministically (ran 5× back-to-back, all green) and now execute in **~0.15s total** instead of ~6s of wall-clock waits.
- Full `tests/test_observer.py`: **50 passed**.
- `ruff check` / `ruff format` clean.

Branched from `main` (these tests predate the `fw-2p4` / PR #165 work, so this is an independent fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
