### PR TITLE
feat: wire system_current into schemas, live status, and watch_sensors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=3.8.0",
+  "picohost>=3.9.0",
   "eigsep-vna>=1.3",
   "eigsep_redis>=2.3.0",
 ]

--- a/scripts/watch_sensors.py
+++ b/scripts/watch_sensors.py
@@ -46,6 +46,7 @@ _PLOT_FIELDS = {
     "potmon": ("pot_az_angle",),
     "motor": ("az_pos", "el_pos"),
     "lidar": ("distance_m",),
+    "system_current": ("current_a",),
 }
 
 # Shown in the stream header line instead; redundant in the field list.

--- a/src/eigsep_observing/config/live_status_thresholds.yaml
+++ b/src/eigsep_observing/config/live_status_thresholds.yaml
@@ -37,6 +37,13 @@ corr.auto_mag_median:
   healthy: null  # TODO: set from a healthy run
   danger:  null
 
+# Whole-system current (ACS724-10AB inline on the shared 5 V feed).
+# Nominal bands: panda + both Peltiers draws ~3 A; the sensor saturates
+# ~12.5 A. Tune against a measured baseline — these are starting values.
+system_current.current_a:
+  healthy: [0.0, 5.0]
+  danger:  [0.0, 8.0]
+
 # Site-geometry signals — operator fills these in after deployment.
 lidar.distance_m:
   healthy: null  # TODO: set from site geometry

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -33,7 +33,7 @@ import numpy as np
 import pytest
 import yaml
 from picohost import PicoPotentiometer
-from picohost.base import PicoRFSwitch
+from picohost.base import PicoLidar, PicoRFSwitch
 from picohost.motor import PicoMotor
 from picohost.testing import (
     ImuEmulator,
@@ -157,6 +157,33 @@ def _rfswitch_post_handler_reading():
     return captured
 
 
+def _lidar_post_handler_readings():
+    """Return (lidar_dict, system_current_dict) after _lidar_redis_handler.
+
+    The lidar Pico's firmware emits one merged line (distance +
+    current_voltage); ``PicoLidar._lidar_redis_handler`` splits it into
+    two metadata publishes — ``metadata['lidar']`` (distance, current
+    stripped) and ``metadata['system_current']`` (current_voltage +
+    derived current_a). The contract these tests enforce is the
+    post-handler shape of each, so compose ``LidarEmulator.get_status()``
+    through the real handler and capture both publishes in order. Mirrors
+    ``_rfswitch_post_handler_reading`` / ``_motor_post_handler_reading``.
+    ``_current_cal`` is normally set in ``PicoLidar.__init__`` (two-point
+    current cal, picohost); ``__new__`` bypasses that, so set it to ``None``
+    to select the nominal ACS724 conversion — same pattern as
+    ``_motor_post_handler_reading`` setting ``_motor_pos_store = None``.
+    """
+    lidar = PicoLidar.__new__(PicoLidar)
+    lidar._current_cal = None  # bypass __init__: nominal conversion
+    captured = []
+    lidar._base_redis_handler = lambda d: captured.append(dict(d))
+    lidar._lidar_redis_handler(LidarEmulator().get_status())
+    assert len(captured) == 2, (
+        f"expected lidar + system_current publishes, got {len(captured)}"
+    )
+    return captured[0], captured[1]
+
+
 def _adc_stats_post_publish_reading():
     """Return an adc_stats reading after EigsepFpga._publish_adc_stats.
 
@@ -199,10 +226,11 @@ SENSOR_EMULATORS = {
     "rfswitch": _rfswitch_post_handler_reading,
     "tempctrl_lna": lambda: _peltier_post_handler_reading("tempctrl_lna"),
     "tempctrl_load": lambda: _peltier_post_handler_reading("tempctrl_load"),
-    "lidar": lambda: LidarEmulator().get_status(),
+    "lidar": lambda: _lidar_post_handler_readings()[0],
     "potmon": _potmon_post_handler_reading,
     "motor": _motor_post_handler_reading,
     "adc_stats": _adc_stats_post_publish_reading,
+    "system_current": lambda: _lidar_post_handler_readings()[1],
 }
 
 

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -868,6 +868,19 @@ SENSOR_SCHEMAS = {
         "app_id": int,
         "distance_m": float,
     },
+    # `system_current`: whole-system current draw, fanned out from the
+    # lidar Pico's ACS724 by picohost's PicoLidar._lidar_redis_handler.
+    # Like `adc_stats`, it is a derived stream with no `app_id` (not a
+    # 1:1 pico app). `status` is producer-fixed to "update" (the ADC read
+    # is decoupled from lidar's I2C result). `current_a` is the meaningful
+    # value (amps); `current_voltage` is the raw ADC-pin voltage diagnostic.
+    # Both floats reduce via the standard float->mean path.
+    "system_current": {
+        "sensor_name": str,
+        "status": str,
+        "current_voltage": float,
+        "current_a": float,
+    },
     # Motor positions are stepper counts. The C firmware emits them
     # as ints, but `PicoMotor._motor_redis_handler` coerces to float
     # at the Redis-publish boundary so they go through the float→mean

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -143,6 +143,15 @@ SIGNAL_REGISTRY: dict[str, Signal] = {
         "LOAD integral",
         enabled_by="use_tempctrl",
     ),
+    # Whole-system current draw (ACS724 on the lidar Pico, fanned out to
+    # the system_current stream). Always enabled — a system-wide vital,
+    # not gated by a subsystem flag. current_voltage is a raw ADC
+    # diagnostic shown on the card but not a classified signal.
+    "system_current.current_a": Signal(
+        "system_current.current_a",
+        "System current",
+        unit="A",
+    ),
     # Site-geometry signals — YAML override only (TODO after deploy).
     "lidar.distance_m": Signal(
         "lidar.distance_m",

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -770,6 +770,45 @@ function renderLidar(meta) {
   container.appendChild(row);
 }
 
+// Whole-system current. Updates both the glanceable header tile and the
+// detail card from the same /api/metadata entry (the value comes from
+// metadata, not /api/health, so the header tile is driven here rather
+// than in updateHealth). Colored by the current_a classify band.
+function renderSystemCurrent(meta) {
+  const entry = meta["system_current"];
+  const cls = entry && entry.classify
+    ? entry.classify["system_current.current_a"]
+    : undefined;
+  const value = (entry && entry.value) || {};
+
+  const tile = document.getElementById("tile-system-current");
+  if (tile) {
+    if (!entry) {
+      tile.className = "tile unknown";
+      tile.textContent = "Current: —";
+    } else {
+      tile.className = tileClass(cls);
+      tile.textContent = `Current: ${fmt(value.current_a, 2)} A`;
+    }
+  }
+
+  const container = document.getElementById("system-current-block");
+  if (container) {
+    container.replaceChildren();
+    if (!entry) {
+      container.textContent = "no system_current data";
+    } else {
+      container.appendChild(makePaneStatusHeader("system current", entry));
+      appendTileRow(
+        container, "current", tileClass(cls), `${fmt(value.current_a, 2)} A`,
+      );
+      appendValueRow(
+        container, "voltage", `${fmt(value.current_voltage, 3)} V`,
+      );
+    }
+  }
+}
+
 // ADC stats live as a sub-section of the corr-spectra card so the
 // clipping/RMS diagnostic sits right under the spectrum it describes.
 // Two-column grid, 12 cells (6 inputs x 2 cores).
@@ -897,6 +936,7 @@ async function tick() {
     renderMotor(metadata.data);
     renderPotmon(metadata.data);
     renderLidar(metadata.data);
+    renderSystemCurrent(metadata.data);
     renderRfswitch(rfswitch.data, metadata.data["rfswitch"]);
     renderAdcInCorr(adc.data);
     renderStatusLog(status.data);

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -28,6 +28,7 @@
     <span class="tile" id="tile-backend-redis" title="Backend Redis (rpi_ip) liveness. Any successful read on the SNAP-side Redis flips this green.">Backend Redis: ?</span>
     <span class="tile" id="tile-panda-observe" title="Panda observe script. 'running' = fresh heartbeat from panda_observe (or sibling script). 'script idle' = panda Redis is up but no script is publishing the heartbeat. 'panda offline' = panda Redis itself is unreachable.">Panda observe: ?</span>
     <span class="tile" id="tile-corr-loop" title="Corr loop. 'recording' = a new corr integration arrived within 2.5x the integration cadence — eigsep-fpga-init is publishing data. 'idle' = no new integration in that window. 'N dropped' = cumulative integrations the host failed to read before the FPGA overwrote the BRAM (since the observe loop started). 'Nms read' = wall-time of the most recent readout; watch it against the integration time as corr_acc_len is lowered.">Corr loop: ?</span>
+    <span class="tile" id="tile-system-current" title="Whole-system current draw (ACS724 on the lidar Pico). Colored by the system_current.current_a band in live_status_thresholds.yaml.">Current: ?</span>
     <span class="tile" id="tile-file">Last file: ?</span>
     <span class="tile" id="tile-reinit" title="SNAP --reinit count since the last Redis flush. Bumps on every supervised crash-recovery.">Reinits: ?</span>
     <span class="tile" id="tile-run" title="Active panda script (panda_observe / no_switch_observation / vna_position_sweep). 'idle' means no script is currently driving the run.">Run: ?</span>
@@ -49,6 +50,11 @@
 </header>
 
 <main class="grid">
+  <section class="card">
+    <h2>System current</h2>
+    <div id="system-current-block"></div>
+  </section>
+
   <section class="card wide">
     <h2>Correlation spectra</h2>
     <div id="plot-mag" class="plot"></div>

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -50,7 +50,7 @@
 </header>
 
 <main class="grid">
-  <section class="card">
+  <section class="card wide">
     <h2>System current</h2>
     <div id="system-current-block"></div>
   </section>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -490,9 +490,6 @@ def test_switch_session_unknown_entry_mode_skips_restore(client, caplog):
     """If the rfswitch hasn't published on entry, the session has no
     mode to restore to. Skip the restore and log a warning — auto-
     guessing RFANT would be surprising at the REPL."""
-    client.transport.r.hdel("metadata", "rfswitch")
-    assert client._read_switch_mode_from_redis() is None
-
     switch_calls = []
     original_safe_switch = client._safe_switch
 
@@ -501,9 +498,17 @@ def test_switch_session_unknown_entry_mode_skips_restore(client, caplog):
         return original_safe_switch(state)
 
     caplog.set_level("WARNING")
-    with patch.object(client, "_safe_switch", side_effect=recording):
-        with client.switch_session() as sw:
-            assert sw("RFNOFF") is True
+    # Patch the snapshot reader rather than hdel-ing Redis: the live
+    # DummyPicoRFSwitch emulator republishes sw_state_name every ~50 ms
+    # and would overwrite a raw hdel before switch_session reads the
+    # entry mode (flaky under load/xdist). Same technique as
+    # test_read_switch_mode_from_redis_no_rfswitch_data.
+    with patch.object(
+        client, "_read_switch_mode_from_redis", return_value=None
+    ):
+        with patch.object(client, "_safe_switch", side_effect=recording):
+            with client.switch_session() as sw:
+                assert sw("RFNOFF") is True
 
     assert switch_calls == ["RFNOFF"], (
         f"unknown-entry-mode session must not restore; got {switch_calls}"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3449,6 +3449,7 @@ def test_corr_pair_labels_coerces_int_keys():
     header = {"input_to_ant": {0: "primA", 2: "primB"}}
     assert io.corr_pair_labels(header, ["02"]) == {"02": "primA / primB [02]"}
 
+
 def test_system_current_schema_registered_and_validates():
     """system_current is a fanned-out stream (no app_id, like adc_stats).
     The schema's job is loud validation: current_a/current_voltage must be

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3324,7 +3324,6 @@ def test_rfswitch_consecutive_transitions_reset_window(caplog):
             )
         # Index 8: back to raw state RFNON.
         assert f.metadata["rfswitch"][8] == "RFNON"
-
         f.close()
 
 
@@ -3449,3 +3448,52 @@ def test_corr_pair_labels_coerces_int_keys():
     """input_to_ant with int keys (e.g. from some readers) still labels."""
     header = {"input_to_ant": {0: "primA", 2: "primB"}}
     assert io.corr_pair_labels(header, ["02"]) == {"02": "primA / primB [02]"}
+
+def test_system_current_schema_registered_and_validates():
+    """system_current is a fanned-out stream (no app_id, like adc_stats).
+    The schema's job is loud validation: current_a/current_voltage must be
+    real floats so the float->mean reducer doesn't silently drop an
+    int-emitting producer to None."""
+    schema = io.SENSOR_SCHEMAS["system_current"]
+    assert schema == {
+        "sensor_name": str,
+        "status": str,
+        "current_voltage": float,
+        "current_a": float,
+    }
+    good = {
+        "sensor_name": "system_current",
+        "status": "update",
+        "current_voltage": 1.70,
+        "current_a": 2.0,
+    }
+    assert io._validate_metadata(good, schema) == []
+    # int current_a violates the strict float check (would be dropped to
+    # None by the float reducer) -> must surface as a contract violation.
+    bad = {**good, "current_a": 2}
+    violations = io._validate_metadata(bad, schema)
+    assert any("current_a" in v for v in violations)
+
+
+def test_avg_metadata_system_current():
+    """Both floats reduce via the generic float->mean path; the
+    producer-fixed status='update' row stays clean."""
+    data = [
+        {
+            "sensor_name": "system_current",
+            "status": "update",
+            "current_voltage": 1.70,
+            "current_a": 2.0,
+        },
+        {
+            "sensor_name": "system_current",
+            "status": "update",
+            "current_voltage": 1.74,
+            "current_a": 4.0,
+        },
+    ]
+    result = io.avg_metadata(data)
+    assert result["sensor_name"] == "system_current"
+    assert result["status"] == "update"
+    assert result["current_a"] == pytest.approx(3.0)
+    assert result["current_voltage"] == pytest.approx(1.72)

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1377,6 +1377,31 @@ def test_vna_drain_drops_payload_with_unknown_mode(agg_primed, caplog):
     )
 
 
+def test_metadata_payload_classifies_system_current():
+    """A system_current snapshot entry is classified against the
+    current_a band by the existing /api/metadata projection (no app.py
+    change needed — the route is generic over snapshot-hash streams)."""
+    from eigsep_observing.live_status.app import _metadata_payload
+    from eigsep_observing.live_status.aggregator import StateSnapshot
+
+    now = 1000.0
+    state = StateSnapshot()
+    state.metadata_snapshot = {
+        "system_current": {
+            "sensor_name": "system_current",
+            "status": "update",
+            "current_voltage": 1.70,
+            "current_a": 3.0,
+        },
+        "system_current_ts": now,
+    }
+    state.metadata_snapshot_read_unix = now
+    payload = _metadata_payload(state, _payload_thresholds())
+    entry = payload["system_current"]
+    assert entry["classify"]["system_current.current_a"] == "ok"
+    assert entry["status"] == "update"
+
+
 def client_for(agg):
     """Helper: build a Flask test_client for a primed aggregator."""
     app = create_app(agg)

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -312,3 +312,26 @@ def test_thresholds_invalid_band_raises():
                 "adc.rms": {"healthy": [20.0, 10.0]},  # lo > hi
             },
         )
+
+
+# ---------------------------------------------------------------------
+# system_current signal + threshold band
+# ---------------------------------------------------------------------
+
+
+def test_system_current_signal_registered_and_always_enabled():
+    sig = SIGNAL_REGISTRY["system_current.current_a"]
+    assert sig.unit == "A"
+    assert sig.enabled_by is None  # system-wide vital, never gated
+    assert sig.max_age_s == 30.0
+    # Present even when tempctrl (and other optional subsystems) are off.
+    assert "system_current.current_a" in enabled_signals(OBS_CFG_TEMPCTRL_OFF)
+
+
+def test_system_current_band_from_bundled_yaml():
+    th = Thresholds.from_yaml(OBS_CFG_TEMPCTRL_ON, CORR_HEADER)
+    assert th.bands["system_current.current_a"]["healthy"] == [0.0, 5.0]
+    assert th.bands["system_current.current_a"]["danger"] == [0.0, 8.0]
+    assert th.classify("system_current.current_a", 3.0) == "ok"
+    assert th.classify("system_current.current_a", 6.0) == "warn"
+    assert th.classify("system_current.current_a", 9.0) == "danger"

--- a/tests/test_watch_sensors.py
+++ b/tests/test_watch_sensors.py
@@ -1,0 +1,31 @@
+"""Smoke test for the watch_sensors bring-up script.
+
+watch_sensors lives under scripts/ (not an importable package), so load
+it by file path the same way tests/test_motor_scripts.py does.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name):
+    path = _REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_system_current_in_default_panda_streams():
+    ws = _load("watch_sensors")
+    # Panda stream (not adc_stats, which is SNAP-side) -> shown by default.
+    assert "system_current" in ws._PANDA_STREAMS
+
+
+def test_system_current_plots_current_a_only():
+    ws = _load("watch_sensors")
+    # The raw ADC current_voltage is not operator-meaningful; only amps
+    # are traced in --plot.
+    assert ws._plot_fields_for("system_current") == ["current_a"]

--- a/uv.lock
+++ b/uv.lock
@@ -400,7 +400,7 @@ requires-dist = [
     { name = "ipython", marker = "extra == 'interactive'" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "picohost", specifier = ">=3.8.0" },
+    { name = "picohost", specifier = ">=3.9.0" },
     { name = "plotly" },
     { name = "pyserial-mock", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1289,7 +1289,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.8.0"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eigsep-redis" },
@@ -1298,9 +1298,9 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyserial" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/52/a4ad229268361d28103cc356efdb043518b51e6f022d06dda47b8ffdb9ae/picohost-3.8.0.tar.gz", hash = "sha256:7ff3dbe7ff62b4af80d81a185024da168f8f0f306c217a05028e91b770fa8134", size = 133026, upload-time = "2026-06-20T23:11:42.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/92/404af5665a9386b34595676a395a4a47f61d5055786de782f88adf8ed691/picohost-3.9.0.tar.gz", hash = "sha256:ad5a8baeeab01557b851c53ada4ba2fead92fdb3df4ca495cc6b59412aa7d7b0", size = 146500, upload-time = "2026-06-28T16:50:39.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/04dcfbb00453a45e62d0e9de1c950b092bfebdee25988d5877e6d2716a14/picohost-3.8.0-py3-none-any.whl", hash = "sha256:529ff167d6619d5e89b81892c8b996d12e1d57b9326591e6c55914e97b01253e", size = 77729, upload-time = "2026-06-20T23:11:41.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ca/282bee7d4db12fce29646199e8ac76421240e9742a076a22b193342b84c8/picohost-3.9.0-py3-none-any.whl", hash = "sha256:2164dcefaec3cafc6d96d48e68e87349970751f19219d701be9ddf78999cb4df", size = 87795, upload-time = "2026-06-28T16:50:38.712Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires the producer's new **`system_current`** metadata stream (ACS724 whole-system
current monitor that piggybacks on the **lidar Pico**; `picohost`'s
`PicoLidar._lidar_redis_handler` fans the lidar status line into `lidar` +
`system_current`) into the consumer. The stream is `{sensor_name, status,
current_voltage, current_a}` — no `app_id`, like `adc_stats`.

- **`io.py`** — `system_current` added to `SENSOR_SCHEMAS`; flows into the
  per-integration corr-file metadata sidecar via the generic `avg_metadata`
  float→mean path (no other change needed).
- **Producer-contract test** — registers `system_current`; also fixes the
  `lidar` contract to the post-handler shape (the lidar emulator now emits
  `current_voltage`, stripped by the handler).
- **Live status** — `system_current.current_a` always-enabled signal + nominal
  band `healthy [0,5] / danger [0,8]` A; a glanceable header tile + a full-width
  top-of-grid **System current** card.
- **`watch_sensors`** — automatic in the text table; `--plot` curated to trace
  `current_a` only.

Current-based **safety / auto-shutdown is out of scope** (deferred to its own spec).

## ⚠️ Do not merge yet — held for the picohost release

Developed against an editable install of the unreleased
`pico-firmware/picohost` branch `feat/system-current-monitor`. The repo still
pins `picohost>=3.8.0`; on a clean CI checkout the two contract tests
(`test_every_schema_has_conforming_emulator[lidar]` / `[system_current]`) will
**fail** until picohost ships a release with `PicoLidar._lidar_redis_handler` +
the emulator `current_voltage`.

**Merge gate (Task 7):** once that picohost release exists, bump the `picohost`
pin + re-lock `uv.lock`, re-run the targeted suite against the index build, then
mark ready.

## Tests

175 passed across the changed surfaces (contract, io, live-status thresholds +
app, watch_sensors), against the local editable picohost. The one warning is a
pre-existing repo-wide `junit_family` pytest-config nit.

## Design / plan

- Spec: `docs/superpowers/specs/2026-06-27-system-current-consumer-wiring-design.md`
- Plan: `docs/superpowers/plans/2026-06-27-system-current-consumer-wiring.md`

## Follow-ups
- Scope the current-based safety feature (shed tempctrl/motor on danger current;
  global pause + dashboard alert on sustained high current).
- Tune the nominal amp band against a measured baseline (consider a non-zero
  healthy floor so a 0 A "lost the load" reading isn't classified `ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
