### PR TITLE
feat: field-zero + motor travel-limit guard + closed-loop homing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,9 +90,9 @@ addopts = [
   "--cov-report=term-missing",
   "--cov-report=xml",
   "--junitxml=junit.xml",
-  "-o junit_family=legacy",
   "--timeout=60",
 ]
+junit_family = "legacy"
 
 [tool.coverage.run]
 omit = [

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -144,6 +144,9 @@ def _render(screen, zeroer, snapshot, deg):
         screen.addstr(
             9, 0, ">>> ZERO HERE? 'y' confirm, any other key cancels <<<"
         )
+    if zeroer.notice:
+        width = screen.getmaxyx()[1]
+        screen.addstr(11, 0, f"! {zeroer.notice}"[: width - 1])
     screen.refresh()
 
 

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -203,6 +203,14 @@ def _parse_args():
         action="store_true",
         help="Skip the pot-slip pre-check (step 1).",
     )
+    p.add_argument(
+        "--override-limits",
+        action="store_true",
+        help=(
+            "Disable travel limits for this session "
+            "(recovery from out-of-window)."
+        ),
+    )
     return p.parse_args()
 
 
@@ -225,7 +233,16 @@ def main():
     slope_m = float(cal["pot_az"][0])
 
     with run_tag.session(transport, "field_zero"):
-        mc = MotorClient(transport, source="field_zero")
+        if args.override_limits:
+            logger.warning(
+                "Travel limits DISABLED for this session "
+                "(--override-limits) — recovery mode."
+            )
+        mc = MotorClient(
+            transport,
+            source="field_zero",
+            enforce_limits=not args.override_limits,
+        )
         if not args.no_slip_check:
             verdict, exp, meas = run_slip_check(
                 mc, snapshot, slope_m, args.move_deg
@@ -246,7 +263,11 @@ def main():
                     "Pot tracking marginal; proceeding but inspect "
                     "the coupling."
                 )
-        zeroer = MotorZeroer(transport, source="field_zero")
+        zeroer = MotorZeroer(
+            transport,
+            source="field_zero",
+            enforce_limits=not args.override_limits,
+        )
         zeroer.set_delay()
         zeroer.halt()
         curses.wrapper(

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -35,16 +35,24 @@ def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
     """Classify how well the pot tracked a known motor move.
 
     expected_dv / measured_dv are pot voltage swings (V) for the same
-    commanded move. Returns "ok" / "warn" / "fail" on the fractional
-    shortfall. A non-positive expected swing is unusable -> "fail".
+    commanded move. Only a shortfall (pot under-traveled) indicates
+    slip: "warn" at ``warn``, "fail" at ``fail`` fractional shortfall.
+    An overshoot of at least ``warn`` returns "overshoot" — the pot
+    swung MORE than the stored slope predicts, which a slipping
+    coupling cannot do; it means the stored slope is stale, and it
+    must never block zeroing (the zero is slope-independent: home_ref
+    stores raw v0 and the re-pin keeps the slope). A non-positive
+    expected swing is unusable -> "fail".
     """
     if expected_dv <= 0:
         return "fail"
-    frac = abs(measured_dv - expected_dv) / abs(expected_dv)
-    if frac >= fail:
+    frac_short = (expected_dv - measured_dv) / expected_dv
+    if frac_short >= fail:
         return "fail"
-    if frac >= warn:
+    if frac_short >= warn:
         return "warn"
+    if frac_short <= -warn:
+        return "overshoot"
     return "ok"
 
 

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -7,7 +7,25 @@ add the interactive zeroing and the pot re-pin; this task is the pure
 slip-verdict helper.
 """
 
+import curses
+import logging
+from argparse import ArgumentParser
+
 from picohost.buses import PotCalStore
+from picohost.proxy import PicoProxy
+
+from eigsep_redis import MetadataSnapshotReader
+
+from eigsep_observing import MotorClient, MotorZeroer, run_tag
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
+from eigsep_observing.utils import configure_eig_logger
+
+configure_eig_logger(level=logging.INFO, console=False)
+logger = logging.getLogger(__name__)
 
 
 def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
@@ -49,3 +67,150 @@ def rezero_pot(transport, pot_proxy, v0):
     transport.r.bgsave()
     pot_proxy.send_command("set_calibration", pot_az_params=[m, b])
     return m, b
+
+
+def _pot_voltage(snapshot):
+    snap = snapshot.get().get("potmon") or {}
+    return snap.get("pot_az_voltage")
+
+
+def run_slip_check(motor_client, snapshot, slope_m, move_deg=30.0):
+    """Probe pot tracking with a there-and-back motor move.
+
+    Reads pot V, jogs +move_deg, reads pot V, jogs -move_deg (back to
+    start). expected_dv = move_deg / |slope_m| (angle = m*V + b =>
+    dV = dAngle / m). Returns (verdict, expected_dv, measured_dv).
+    """
+    v_before = _pot_voltage(snapshot)
+    motor_client.jog_az(move_deg)
+    v_after = _pot_voltage(snapshot)
+    motor_client.jog_az(-move_deg)
+    expected_dv = abs(move_deg) / abs(slope_m)
+    measured_dv = abs(v_after - v_before)
+    return slip_verdict(expected_dv, measured_dv), expected_dv, measured_dv
+
+
+def _render(screen, zeroer, snapshot, deg):
+    az, el, connected = zeroer.status_text()
+    pot = snapshot.get().get("potmon") or {}
+    imu = snapshot.get().get("imu_az") or {}
+    screen.clear()
+    screen.addstr(0, 0, "=== Field Zero ===")
+    screen.addstr(2, 0, f"Jog step: {deg:.1f} deg")
+    if connected:
+        screen.addstr(3, 0, f"AZ: {az}   EL: {el}")
+    else:
+        screen.addstr(3, 0, "MOTOR DISCONNECTED (waiting)")
+    screen.addstr(
+        4,
+        0,
+        f"pot: {pot.get('pot_az_angle')} deg ({pot.get('pot_az_voltage')} V)",
+    )
+    screen.addstr(
+        5, 0, f"imu_az: az={imu.get('az_deg')} el={imu.get('el_deg')}"
+    )
+    screen.addstr(
+        7,
+        0,
+        "u/d EL | l/r AZ | +/- step | Enter=zero(confirm) | q=quit",
+    )
+    if zeroer.pending_zero:
+        screen.addstr(
+            9, 0, ">>> ZERO HERE? 'y' confirm, any other key cancels <<<"
+        )
+    screen.refresh()
+
+
+def _curses_main(screen, zeroer, snapshot, pot_proxy, transport, deg):
+    curses.noecho()
+    screen.timeout(100)
+    try:
+        while True:
+            _render(screen, zeroer, snapshot, deg)
+            deg, should_exit, zeroed = zeroer.handle_key(screen.getch(), deg)
+            if should_exit:
+                if zeroed:
+                    v0 = _pot_voltage(snapshot)
+                    m, b = rezero_pot(transport, pot_proxy, v0)
+                    logger.info(
+                        "Zeroed: motor origin reset; pot re-pinned "
+                        "m=%.3f b=%.3f at v0=%.4f",
+                        m,
+                        b,
+                        v0,
+                    )
+                break
+    finally:
+        zeroer.cancel_home()
+        zeroer.halt()
+
+
+def _parse_args():
+    p = ArgumentParser(
+        description="Field zero: verify pot, set az/el zero, re-pin cal"
+    )
+    p.add_argument("--dummy", action="store_true")
+    add_redis_args(p)
+    p.add_argument(
+        "--move-deg",
+        type=float,
+        default=30.0,
+        help="Slip-check probe move in degrees (default: 30)",
+    )
+    p.add_argument(
+        "--deg",
+        type=float,
+        default=1.0,
+        help="Initial jog step size in degrees (default: 1.0)",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = _parse_args()
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
+    motor_proxy = PicoProxy("motor", transport, source="field_zero")
+    pot_proxy = PicoProxy("potmon", transport, source="field_zero")
+    require_pico(motor_proxy)
+    require_pico(pot_proxy)
+    snapshot = MetadataSnapshotReader(transport)
+
+    cal = PotCalStore(transport).get()
+    if not cal or "pot_az" not in cal:
+        raise SystemExit(
+            "No pot calibration; run calibrate-pot --mode azimuth first."
+        )
+    slope_m = float(cal["pot_az"][0])
+
+    with run_tag.session(transport, "field_zero"):
+        mc = MotorClient(transport, source="field_zero")
+        verdict, exp, meas = run_slip_check(
+            mc, snapshot, slope_m, args.move_deg
+        )
+        logger.info(
+            "Pot slip check: %s (expected %.4f V, measured %.4f V)",
+            verdict,
+            exp,
+            meas,
+        )
+        if verdict == "fail":
+            raise SystemExit(
+                f"POT SLIP DETECTED ({meas:.3f} V vs {exp:.3f} V "
+                "expected). Fix the pot coupling before zeroing."
+            )
+        if verdict == "warn":
+            logger.warning(
+                "Pot tracking marginal; proceeding but inspect the coupling."
+            )
+        zeroer = MotorZeroer(transport, source="field_zero")
+        zeroer.set_delay()
+        zeroer.halt()
+        curses.wrapper(
+            _curses_main, zeroer, snapshot, pot_proxy, transport, args.deg
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -16,7 +16,12 @@ from picohost.proxy import PicoProxy
 
 from eigsep_redis import MetadataSnapshotReader
 
-from eigsep_observing import MotorClient, MotorZeroer, run_tag
+from eigsep_observing import (
+    MotorClient,
+    MotorLimitError,
+    MotorZeroer,
+    run_tag,
+)
 from eigsep_observing.home_ref import publish_home_ref
 from eigsep_observing._scripts_util import (
     add_redis_args,
@@ -117,13 +122,24 @@ def run_slip_check(motor_client, snapshot, slope_m, move_deg=30.0):
     Reads pot V, jogs +move_deg, reads pot V, jogs -move_deg (back to
     start). expected_dv = move_deg / |slope_m| (angle = m*V + b =>
     dV = dAngle / m). Returns (verdict, expected_dv, measured_dv).
+    A probe jog denied by the travel guard / sensor fence raises
+    SystemExit with recovery instructions (the rig may be left
+    off-position mid-probe).
     """
     v_before = _pot_voltage(snapshot)
     if v_before is None:
         raise SystemExit(_POT_DOWN_MSG)
-    motor_client.jog_az(move_deg)
-    v_after = _pot_voltage(snapshot)
-    motor_client.jog_az(-move_deg)
+    try:
+        motor_client.jog_az(move_deg)
+        v_after = _pot_voltage(snapshot)
+        motor_client.jog_az(-move_deg)
+    except MotorLimitError as exc:
+        raise SystemExit(
+            f"Slip-check probe move denied by travel limit: {exc} "
+            "The rig may be left off-position; jog back with "
+            "motor_manual, or re-run with --override-limits "
+            "(recovery) or --no-slip-check (skip the probe)."
+        ) from exc
     if v_after is None:
         raise SystemExit(_POT_DOWN_MSG)
     expected_dv = abs(move_deg) / abs(slope_m)

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -17,6 +17,7 @@ from picohost.proxy import PicoProxy
 from eigsep_redis import MetadataSnapshotReader
 
 from eigsep_observing import MotorClient, MotorZeroer, run_tag
+from eigsep_observing.home_ref import publish_home_ref
 from eigsep_observing._scripts_util import (
     add_redis_args,
     build_transport,
@@ -102,6 +103,16 @@ def run_slip_check(motor_client, snapshot, slope_m, move_deg=30.0):
     return slip_verdict(expected_dv, measured_dv), expected_dv, measured_dv
 
 
+def _write_home_ref(transport, snapshot, v0):
+    """Write the home reference K/V after a confirmed zero.
+
+    Records the pot voltage at the zeroed position (slope-independent
+    az reference) and the current IMU elevation (None when uncalibrated).
+    """
+    el = (snapshot.get().get("imu_el") or {}).get("el_deg")
+    publish_home_ref(transport, pot_az_voltage_v0=v0, imu_el_deg_home=el)
+
+
 def _render(screen, zeroer, snapshot, deg):
     az, el, connected = zeroer.status_text()
     pot = snapshot.get().get("potmon") or {}
@@ -155,6 +166,7 @@ def _curses_main(screen, zeroer, snapshot, pot_proxy, transport, deg):
                         )
                     else:
                         m, b = rezero_pot(transport, pot_proxy, v0)
+                        _write_home_ref(transport, snapshot, v0)
                         logger.info(
                             "Zeroed: motor origin reset; pot re-pinned "
                             "m=%.3f b=%.3f at v0=%.4f",
@@ -186,6 +198,11 @@ def _parse_args():
         default=1.0,
         help="Initial jog step size in degrees (default: 1.0)",
     )
+    p.add_argument(
+        "--no-slip-check",
+        action="store_true",
+        help="Skip the pot-slip pre-check (step 1).",
+    )
     return p.parse_args()
 
 
@@ -209,24 +226,26 @@ def main():
 
     with run_tag.session(transport, "field_zero"):
         mc = MotorClient(transport, source="field_zero")
-        verdict, exp, meas = run_slip_check(
-            mc, snapshot, slope_m, args.move_deg
-        )
-        logger.info(
-            "Pot slip check: %s (expected %.4f V, measured %.4f V)",
-            verdict,
-            exp,
-            meas,
-        )
-        if verdict == "fail":
-            raise SystemExit(
-                f"POT SLIP DETECTED ({meas:.3f} V vs {exp:.3f} V "
-                "expected). Fix the pot coupling before zeroing."
+        if not args.no_slip_check:
+            verdict, exp, meas = run_slip_check(
+                mc, snapshot, slope_m, args.move_deg
             )
-        if verdict == "warn":
-            logger.warning(
-                "Pot tracking marginal; proceeding but inspect the coupling."
+            logger.info(
+                "Pot slip check: %s (expected %.4f V, measured %.4f V)",
+                verdict,
+                exp,
+                meas,
             )
+            if verdict == "fail":
+                raise SystemExit(
+                    f"POT SLIP DETECTED ({meas:.3f} V vs {exp:.3f} V "
+                    "expected). Fix the pot coupling before zeroing."
+                )
+            if verdict == "warn":
+                logger.warning(
+                    "Pot tracking marginal; proceeding but inspect "
+                    "the coupling."
+                )
         zeroer = MotorZeroer(transport, source="field_zero")
         zeroer.set_delay()
         zeroer.halt()

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -2,9 +2,9 @@
 re-pin the pot calibration intercept with the box in its hanging pose.
 
 Self-contained active driver (see scripts/CLAUDE.md): claims run_tag,
-talks to hardware only via PicoProxy, requires pico-manager. Later tasks
-add the interactive zeroing and the pot re-pin; this task is the pure
-slip-verdict helper.
+talks to hardware only via PicoProxy, requires pico-manager. Performs
+pot-slip pre-check, interactive jog-to-zero, motor-origin reset, and
+pot intercept re-pin.
 """
 
 import curses
@@ -26,6 +26,8 @@ from eigsep_observing.utils import configure_eig_logger
 
 configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
+
+_POT_DOWN_MSG = "potmon not publishing pot_az_voltage; cannot run slip check"
 
 
 def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
@@ -82,9 +84,13 @@ def run_slip_check(motor_client, snapshot, slope_m, move_deg=30.0):
     dV = dAngle / m). Returns (verdict, expected_dv, measured_dv).
     """
     v_before = _pot_voltage(snapshot)
+    if v_before is None:
+        raise SystemExit(_POT_DOWN_MSG)
     motor_client.jog_az(move_deg)
     v_after = _pot_voltage(snapshot)
     motor_client.jog_az(-move_deg)
+    if v_after is None:
+        raise SystemExit(_POT_DOWN_MSG)
     expected_dv = abs(move_deg) / abs(slope_m)
     measured_dv = abs(v_after - v_before)
     return slip_verdict(expected_dv, measured_dv), expected_dv, measured_dv

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -7,6 +7,8 @@ add the interactive zeroing and the pot re-pin; this task is the pure
 slip-verdict helper.
 """
 
+from picohost.buses import PotCalStore
+
 
 def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
     """Classify how well the pot tracked a known motor move.
@@ -23,3 +25,27 @@ def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
     if frac >= warn:
         return "warn"
     return "ok"
+
+
+def rezero_pot(transport, pot_proxy, v0):
+    """Re-pin the pot intercept at home voltage v0, keeping the stored slope.
+
+    angle = m*V + b, with b chosen so angle(v0) = 0  ->  b = -m*v0.
+    Persists (BGSAVE) and pushes the new cal to the live pico.
+    Returns (m, b).
+    """
+    store = PotCalStore(transport)
+    cal = store.get()
+    if not cal or "pot_az" not in cal:
+        raise RuntimeError(
+            "No stored pot calibration; run "
+            "calibrate-pot --mode azimuth first."
+        )
+    m = float(cal["pot_az"][0])
+    b = -m * float(v0)
+    cal["pot_az"] = [m, b]
+    cal.setdefault("metadata", {})["mode"] = "field_zero_rezero"
+    store.upload(cal)
+    transport.r.bgsave()
+    pot_proxy.send_command("set_calibration", pot_az_params=[m, b])
+    return m, b

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -56,6 +56,26 @@ def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
     return "ok"
 
 
+def _prompt_override(expected_dv, measured_dv):
+    """Ask the operator whether to zero despite a failed slip check.
+
+    Field reality: a slipping/odd pot coupling often cannot be fixed
+    on the rig, and the zero itself is slope-independent, so the
+    operator gets the final say — with the numbers in hand, before
+    the probe move has to be repeated. Returns True only on an
+    explicit y/yes; EOF (non-interactive stdin) is No.
+    """
+    print(
+        f"POT SLIP DETECTED: measured {measured_dv:.3f} V vs "
+        f"{expected_dv:.3f} V expected for the probe move."
+    )
+    try:
+        answer = input("Proceed with zeroing anyway? [y/N] ")
+    except EOFError:
+        return False
+    return answer.strip().lower() in ("y", "yes")
+
+
 def rezero_pot(transport, pot_proxy, v0):
     """Re-pin the pot intercept at home voltage v0, keeping the stored slope.
 
@@ -258,22 +278,40 @@ def main():
             verdict, exp, meas = run_slip_check(
                 mc, snapshot, slope_m, args.move_deg
             )
-            logger.info(
-                "Pot slip check: %s (expected %.4f V, measured %.4f V)",
-                verdict,
-                exp,
-                meas,
+            msg = (
+                f"Pot slip check: {verdict} "
+                f"(expected {exp:.4f} V, measured {meas:.4f} V)"
             )
+            print(msg)
+            logger.info(msg)
             if verdict == "fail":
-                raise SystemExit(
-                    f"POT SLIP DETECTED ({meas:.3f} V vs {exp:.3f} V "
-                    "expected). Fix the pot coupling before zeroing."
-                )
-            if verdict == "warn":
+                if not _prompt_override(exp, meas):
+                    raise SystemExit(
+                        f"POT SLIP DETECTED ({meas:.3f} V vs "
+                        f"{exp:.3f} V expected). Fix the pot coupling "
+                        "before zeroing."
+                    )
                 logger.warning(
+                    "OPERATOR OVERRIDE: zeroing despite failed pot "
+                    "slip check (measured %.4f V vs %.4f V expected).",
+                    meas,
+                    exp,
+                )
+            elif verdict == "warn":
+                warn_msg = (
                     "Pot tracking marginal; proceeding but inspect "
                     "the coupling."
                 )
+                print(warn_msg)
+                logger.warning(warn_msg)
+            elif verdict == "overshoot":
+                over_msg = (
+                    "Pot swing LARGER than expected — not slip; the "
+                    "stored slope is likely stale. Proceeding; re-run "
+                    "calibrate-pot --mode azimuth when convenient."
+                )
+                print(over_msg)
+                logger.warning(over_msg)
         zeroer = MotorZeroer(
             transport,
             source="field_zero",

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -67,7 +67,13 @@ def rezero_pot(transport, pot_proxy, v0):
     cal.setdefault("metadata", {})["mode"] = "field_zero_rezero"
     store.upload(cal)
     transport.r.bgsave()
-    pot_proxy.send_command("set_calibration", pot_az_params=[m, b])
+    try:
+        pot_proxy.send_command("set_calibration", pot_az_params=[m, b])
+    except (TimeoutError, RuntimeError):
+        logger.warning(
+            "Live push of pot cal failed; cal is stored in Redis and "
+            "will apply on the next PicoManager restart."
+        )
     return m, b
 
 
@@ -113,7 +119,10 @@ def _render(screen, zeroer, snapshot, deg):
         f"pot: {pot.get('pot_az_angle')} deg ({pot.get('pot_az_voltage')} V)",
     )
     screen.addstr(
-        5, 0, f"imu_az: az={imu.get('az_deg')} el={imu.get('el_deg')}"
+        5,
+        0,
+        f"imu_az: yaw={imu.get('yaw')} az={imu.get('az_deg')} "
+        f"el={imu.get('el_deg')}",
     )
     screen.addstr(
         7,
@@ -137,14 +146,22 @@ def _curses_main(screen, zeroer, snapshot, pot_proxy, transport, deg):
             if should_exit:
                 if zeroed:
                     v0 = _pot_voltage(snapshot)
-                    m, b = rezero_pot(transport, pot_proxy, v0)
-                    logger.info(
-                        "Zeroed: motor origin reset; pot re-pinned "
-                        "m=%.3f b=%.3f at v0=%.4f",
-                        m,
-                        b,
-                        v0,
-                    )
+                    if v0 is None:
+                        logger.warning(
+                            "Motor origin reset, but pot re-pin SKIPPED: "
+                            "potmon not publishing pot_az_voltage. Re-pin "
+                            "once potmon is back (calibrate-pot --mode "
+                            "rezero)."
+                        )
+                    else:
+                        m, b = rezero_pot(transport, pot_proxy, v0)
+                        logger.info(
+                            "Zeroed: motor origin reset; pot re-pinned "
+                            "m=%.3f b=%.3f at v0=%.4f",
+                            m,
+                            b,
+                            v0,
+                        )
                 break
     finally:
         zeroer.cancel_home()

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -1,0 +1,25 @@
+"""Field zero: verify the pot tracks, set the operational az/el zero, and
+re-pin the pot calibration intercept with the box in its hanging pose.
+
+Self-contained active driver (see scripts/CLAUDE.md): claims run_tag,
+talks to hardware only via PicoProxy, requires pico-manager. Later tasks
+add the interactive zeroing and the pot re-pin; this task is the pure
+slip-verdict helper.
+"""
+
+
+def slip_verdict(expected_dv, measured_dv, *, warn=0.05, fail=0.10):
+    """Classify how well the pot tracked a known motor move.
+
+    expected_dv / measured_dv are pot voltage swings (V) for the same
+    commanded move. Returns "ok" / "warn" / "fail" on the fractional
+    shortfall. A non-positive expected swing is unusable -> "fail".
+    """
+    if expected_dv <= 0:
+        return "fail"
+    frac = abs(measured_dv - expected_dv) / abs(expected_dv)
+    if frac >= fail:
+        return "fail"
+    if frac >= warn:
+        return "warn"
+    return "ok"

--- a/scripts/motor_home.py
+++ b/scripts/motor_home.py
@@ -23,12 +23,21 @@ configure_eig_logger(level=logging.INFO, console=False)
 logger = logging.getLogger(__name__)
 
 
-def run(transport, *, dry_run=False):
+def run(transport, *, dry_run=False, override_limits=False):
     if read_home_ref(transport) is None:
         raise SystemExit(
             "No home reference; run field_zero to set home first."
         )
-    homer = MotorHomer(transport, source="motor_home")
+    if override_limits:
+        logger.warning(
+            "Travel limits DISABLED for this session"
+            " (--override-limits) — recovery mode."
+        )
+    homer = MotorHomer(
+        transport,
+        source="motor_home",
+        enforce_limits=not override_limits,
+    )
     require_pico(homer.motor_client._proxy)
     if dry_run:
         pot_v, el_est = homer._read_sensors()
@@ -54,12 +63,20 @@ def main():
         action="store_true",
         help="Report residuals vs home without moving.",
     )
+    p.add_argument(
+        "--override-limits",
+        action="store_true",
+        help=(
+            "Disable travel limits for this session"
+            " (recovery from out-of-window)."
+        ),
+    )
     add_redis_args(p)
     args = p.parse_args()
     transport = build_transport(
         args.dummy, host=args.redis_host, real_port=args.redis_port
     )
-    run(transport, dry_run=args.dry_run)
+    run(transport, dry_run=args.dry_run, override_limits=args.override_limits)
 
 
 if __name__ == "__main__":

--- a/scripts/motor_home.py
+++ b/scripts/motor_home.py
@@ -1,0 +1,66 @@
+"""Closed-loop return-to-home. Standalone active driver (claims run_tag);
+talks to hardware only via MotorClient/PicoProxy; requires pico-manager.
+
+Drives the antenna back to the home set by field_zero, using pot-voltage
+(az) + IMU (el) feedback, settling between moves. Re-zeros the step counter
+on convergence. Run after a motor_scan / motor_manual session to re-
+establish a known position.
+"""
+
+import logging
+from argparse import ArgumentParser
+
+from eigsep_observing import MotorHomer, run_tag
+from eigsep_observing._scripts_util import (
+    add_redis_args,
+    build_transport,
+    require_pico,
+)
+from eigsep_observing.home_ref import read_home_ref
+from eigsep_observing.utils import configure_eig_logger
+
+configure_eig_logger(level=logging.INFO, console=False)
+logger = logging.getLogger(__name__)
+
+
+def run(transport, *, dry_run=False):
+    if read_home_ref(transport) is None:
+        raise SystemExit(
+            "No home reference; run field_zero to set home first."
+        )
+    homer = MotorHomer(transport, source="motor_home")
+    require_pico(homer.motor_client._proxy)
+    if dry_run:
+        pot_v, el_est = homer._read_sensors()
+        ref = read_home_ref(transport)
+        logger.info(
+            "Dry run: pot=%s V (home %.3f), el=%s (%s)",
+            pot_v,
+            ref["pot_az_voltage_v0"],
+            el_est.el_deg,
+            el_est.source,
+        )
+        return
+    with run_tag.session(transport, "motor_home"):
+        result = homer.home()
+        logger.info("Home result: %s", result)
+
+
+def main():
+    p = ArgumentParser(description="Closed-loop return-to-home")
+    p.add_argument("--dummy", action="store_true")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report residuals vs home without moving.",
+    )
+    add_redis_args(p)
+    args = p.parse_args()
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
+    run(transport, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -65,11 +65,16 @@ def _render(screen, zeroer, deg):
     screen.refresh()
 
 
+def _build_zeroer(transport, args):
+    """Build a ``MotorZeroer``, honouring ``args.override_limits``."""
+    return MotorZeroer(transport, enforce_limits=not args.override_limits)
+
+
 def _curses_main(screen, transport, args):
     curses.noecho()
     screen.timeout(100)
 
-    zeroer = MotorZeroer(transport)
+    zeroer = _build_zeroer(transport, args)
     zeroer.set_delay()
     zeroer.halt()
     deg = args.deg
@@ -111,6 +116,14 @@ def _parse_args():
         default=1.0,
         help="Initial jog step size in degrees (default: 1.0)",
     )
+    parser.add_argument(
+        "--override-limits",
+        action="store_true",
+        help=(
+            "Disable travel limits for this session"
+            " (recovery from out-of-window)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -120,6 +133,11 @@ def main():
         args.dummy, host=args.redis_host, real_port=args.redis_port
     )
     require_pico(PicoProxy("motor", transport, source="motor_manual"))
+    if args.override_limits:
+        logger.warning(
+            "Travel limits DISABLED for this session"
+            " (--override-limits) — recovery mode."
+        )
     with run_tag.session(transport, "motor_manual"):
         curses.wrapper(_curses_main, transport, args)
 

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -62,6 +62,9 @@ def _render(screen, zeroer, deg):
             0,
             ">>> ZERO HERE? 'y' to confirm, any other key to cancel <<<",
         )
+    if zeroer.notice:
+        width = screen.getmaxyx()[1]
+        screen.addstr(12, 0, f"! {zeroer.notice}"[: width - 1])
     screen.refresh()
 
 

--- a/scripts/set_motor_limits.py
+++ b/scripts/set_motor_limits.py
@@ -6,6 +6,11 @@ travel-limit guard is rig-wide. Run once per rig (and after re-surveying the
 safe pot-voltage / IMU-el endpoints). Drives no motor; does not claim
 run_tag.
 
+A *set* merges with the existing limits — only the windows you specify
+change; unspecified fields keep their stored values. Use
+``--no-pot-fence`` / ``--no-imu-fence`` to explicitly disable those
+fences (sets the field to None).
+
   set_motor_limits.py --show
   set_motor_limits.py --az-limits -180 180 --el-limits -30 30 \\
       --pot-az-v 0.2 3.1 --imu-el -30 30
@@ -39,33 +44,41 @@ def publish_from_args(transport, *, az_limits, el_limits, pot_az_v, imu_el):
 def run(transport, args):
     if args.show:
         current = read_motor_limits(transport)
-        logger.info("Current motor limits: %s", current or "unset")
-        print(f"Current motor limits: {current if current else 'unset'}")
+        msg = f"Current motor limits: {current if current else 'unset'}"
+        logger.info(msg)
+        print(msg)
         return
-    pot_az_v = None if args.no_pot_fence else args.pot_az_v
-    imu_el = None if args.no_imu_fence else args.imu_el
-    publish_from_args(
+    existing = read_motor_limits(transport) or {}
+
+    def _resolve(window_arg, no_fence, key, default):
+        if no_fence:
+            return None
+        if window_arg is not None:
+            return window_arg
+        return existing.get(key, default)
+
+    az = _resolve(args.az_limits, False, "az_limits_deg", [-180.0, 180.0])
+    el = _resolve(args.el_limits, False, "el_limits_deg", [-180.0, 180.0])
+    pot = _resolve(args.pot_az_v, args.no_pot_fence, "pot_az_v_limits", None)
+    imu = _resolve(args.imu_el, args.no_imu_fence, "imu_el_limits_deg", None)
+    publish_motor_limits(
         transport,
-        az_limits=args.az_limits,
-        el_limits=args.el_limits,
-        pot_az_v=pot_az_v,
-        imu_el=imu_el,
+        az_limits_deg=az,
+        el_limits_deg=el,
+        pot_az_v_limits=pot,
+        imu_el_limits_deg=imu,
     )
-    logger.info(
-        "Published motor limits: az=%s el=%s pot_v=%s imu_el=%s",
-        args.az_limits,
-        args.el_limits,
-        pot_az_v,
-        imu_el,
-    )
+    msg = f"Published motor limits: az={az} el={el} pot_v={pot} imu_el={imu}"
+    logger.info(msg)
+    print(msg)
 
 
 def main():
     p = ArgumentParser(description="Set/inspect rig-wide motor limits")
     p.add_argument("--dummy", action="store_true")
     p.add_argument("--show", action="store_true")
-    p.add_argument("--az-limits", type=float, nargs=2, default=[-180.0, 180.0])
-    p.add_argument("--el-limits", type=float, nargs=2, default=[-180.0, 180.0])
+    p.add_argument("--az-limits", type=float, nargs=2, default=None)
+    p.add_argument("--el-limits", type=float, nargs=2, default=None)
     p.add_argument("--pot-az-v", type=float, nargs=2, default=None)
     p.add_argument("--no-pot-fence", action="store_true")
     p.add_argument("--imu-el", type=float, nargs=2, default=None)

--- a/scripts/set_motor_limits.py
+++ b/scripts/set_motor_limits.py
@@ -40,6 +40,7 @@ def run(transport, args):
     if args.show:
         current = read_motor_limits(transport)
         logger.info("Current motor limits: %s", current or "unset")
+        print(f"Current motor limits: {current if current else 'unset'}")
         return
     pot_az_v = None if args.no_pot_fence else args.pot_az_v
     imu_el = None if args.no_imu_fence else args.imu_el

--- a/scripts/set_motor_limits.py
+++ b/scripts/set_motor_limits.py
@@ -1,0 +1,81 @@
+"""Set or inspect the rig-wide motor safe-travel limits (MotorLimitStore).
+
+Operator admin tool. Writes a dedicated Redis K/V (NOT obs_config), read by
+every MotorClient — autonomous observer and bring-up scripts alike — so the
+travel-limit guard is rig-wide. Run once per rig (and after re-surveying the
+safe pot-voltage / IMU-el endpoints). Drives no motor; does not claim
+run_tag.
+
+  set_motor_limits.py --show
+  set_motor_limits.py --az-limits -180 180 --el-limits -30 30 \\
+      --pot-az-v 0.2 3.1 --imu-el -30 30
+  set_motor_limits.py --el-limits -30 30 --no-pot-fence --no-imu-fence
+"""
+
+import logging
+from argparse import ArgumentParser
+
+from eigsep_observing._scripts_util import add_redis_args, build_transport
+from eigsep_observing.motor_limits import (
+    publish_motor_limits,
+    read_motor_limits,
+)
+from eigsep_observing.utils import configure_eig_logger
+
+configure_eig_logger(level=logging.INFO, console=False)
+logger = logging.getLogger(__name__)
+
+
+def publish_from_args(transport, *, az_limits, el_limits, pot_az_v, imu_el):
+    publish_motor_limits(
+        transport,
+        az_limits_deg=az_limits,
+        el_limits_deg=el_limits,
+        pot_az_v_limits=pot_az_v,
+        imu_el_limits_deg=imu_el,
+    )
+
+
+def run(transport, args):
+    if args.show:
+        current = read_motor_limits(transport)
+        logger.info("Current motor limits: %s", current or "unset")
+        return
+    pot_az_v = None if args.no_pot_fence else args.pot_az_v
+    imu_el = None if args.no_imu_fence else args.imu_el
+    publish_from_args(
+        transport,
+        az_limits=args.az_limits,
+        el_limits=args.el_limits,
+        pot_az_v=pot_az_v,
+        imu_el=imu_el,
+    )
+    logger.info(
+        "Published motor limits: az=%s el=%s pot_v=%s imu_el=%s",
+        args.az_limits,
+        args.el_limits,
+        pot_az_v,
+        imu_el,
+    )
+
+
+def main():
+    p = ArgumentParser(description="Set/inspect rig-wide motor limits")
+    p.add_argument("--dummy", action="store_true")
+    p.add_argument("--show", action="store_true")
+    p.add_argument("--az-limits", type=float, nargs=2, default=[-180.0, 180.0])
+    p.add_argument("--el-limits", type=float, nargs=2, default=[-180.0, 180.0])
+    p.add_argument("--pot-az-v", type=float, nargs=2, default=None)
+    p.add_argument("--no-pot-fence", action="store_true")
+    p.add_argument("--imu-el", type=float, nargs=2, default=None)
+    p.add_argument("--no-imu-fence", action="store_true")
+    add_redis_args(p)
+    args = p.parse_args()
+    transport = build_transport(
+        args.dummy, host=args.redis_host, real_port=args.redis_port
+    )
+    run(transport, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eigsep_observing/__init__.py
+++ b/src/eigsep_observing/__init__.py
@@ -6,6 +6,7 @@ from .motion_switch import MotionSwitchCoordinator
 from .observer import EigObserver
 from .fpga import EigsepFpga
 from .motor_client import MotorClient, MotorLimitError
+from .motor_homer import MotorHomer
 from .motor_zeroer import MotorZeroer
 from .status_log_handler import StatusStreamHandler
 from .tempctrl_client import TempCtrlClient

--- a/src/eigsep_observing/__init__.py
+++ b/src/eigsep_observing/__init__.py
@@ -5,7 +5,7 @@ from .client import PandaClient
 from .motion_switch import MotionSwitchCoordinator
 from .observer import EigObserver
 from .fpga import EigsepFpga
-from .motor_client import MotorClient
+from .motor_client import MotorClient, MotorLimitError
 from .motor_zeroer import MotorZeroer
 from .status_log_handler import StatusStreamHandler
 from .tempctrl_client import TempCtrlClient

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -16,6 +16,7 @@ from picohost.proxy import PicoProxy
 from . import vna_service
 from .motion_switch import MotionSwitchCoordinator
 from .motor_client import MotorClient
+from .motor_homer import MotorHomer
 from .tempctrl_client import TempCtrlClient
 from .vna import VnaWriter
 from .vna import measure_s11 as _measure_s11
@@ -130,6 +131,7 @@ class PandaClient:
             self.init_motor_client()
         else:
             self.motor_client = None
+            self.motor_homer = None
             self.logger.info("Motor client not initialized")
 
         if self.cfg.get("use_tempctrl", False):
@@ -470,6 +472,10 @@ class PandaClient:
         :class:`MotorClient` constructor (per-axis step delays, poll
         interval, stall timeout). Absent/empty → use client defaults.
 
+        When ``home_after_scan`` is true, also builds a
+        :class:`MotorHomer` bound to the same client; kwargs come from
+        ``motor_homer_kwargs`` (optional dict).
+
         Notes
         -----
         Called by the constructor when ``use_motor`` is true. Safe to
@@ -477,6 +483,7 @@ class PandaClient:
         construction cannot fail.
         """
         self.motor_client = None
+        self.motor_homer = None
         raw_kwargs = self.cfg.get("motor_client_kwargs")
         kwargs = raw_kwargs or {}
         if not isinstance(kwargs, dict):
@@ -496,6 +503,13 @@ class PandaClient:
             )
             return
         self.logger.info(f"Motor client initialized (kwargs={kwargs})")
+        if self.cfg.get("home_after_scan", False):
+            homer_kwargs = self.cfg.get("motor_homer_kwargs", {}) or {}
+            self.motor_homer = MotorHomer(
+                self.transport,
+                motor_client=self.motor_client,
+                **homer_kwargs,
+            )
 
     def init_tempctrl(self):
         """
@@ -978,6 +992,24 @@ class PandaClient:
                     self.motor_client.scan(
                         stop_event=self.stop_client, **scan_kwargs
                     )
+                    if self.motor_homer is not None:
+                        try:
+                            result = self.motor_homer.home(
+                                stop_event=self.stop_client
+                            )
+                            if not result.converged and not result.degraded:
+                                self._warn_with_status(
+                                    "Post-scan homing did not converge; "
+                                    "motors left parked."
+                                )
+                        except (TimeoutError, RuntimeError) as homer_exc:
+                            self._warn_with_status(
+                                f"Post-scan homing failed "
+                                f"({type(homer_exc).__name__}: "
+                                f"{homer_exc}); "
+                                "leaving open-loop park."
+                            )
+                            self.motor_client.home()
                     wait_s = interval
                 except (TimeoutError, RuntimeError) as exc:
                     self._error_with_status(

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -15,13 +15,19 @@ from picohost.proxy import PicoProxy
 
 from . import vna_service
 from .motion_switch import MotionSwitchCoordinator
-from .motor_client import MotorClient
+from .motor_client import MotorClient, MotorLimitError
 from .motor_homer import MotorHomer
 from .tempctrl_client import TempCtrlClient
 from .vna import VnaWriter
 from .vna import measure_s11 as _measure_s11
 
 logger = logging.getLogger(__name__)
+
+# Exception types that motor_loop should absorb and recover from.
+# MotorLimitError is a ValueError; without explicit inclusion it would
+# propagate out of the bare Thread(target=client.motor_loop) in
+# scripts/panda_observe.py and silently kill autonomous scanning.
+_MOTOR_LOOP_ERRORS = (TimeoutError, RuntimeError, MotorLimitError)
 
 # Valid RF switch state names, sourced from the firmware-side class so
 # that a pico firmware change flows through automatically.
@@ -504,12 +510,26 @@ class PandaClient:
             return
         self.logger.info(f"Motor client initialized (kwargs={kwargs})")
         if self.cfg.get("home_after_scan", False):
-            homer_kwargs = self.cfg.get("motor_homer_kwargs", {}) or {}
-            self.motor_homer = MotorHomer(
-                self.transport,
-                motor_client=self.motor_client,
-                **homer_kwargs,
-            )
+            raw_homer_kwargs = self.cfg.get("motor_homer_kwargs", {})
+            homer_kwargs = raw_homer_kwargs or {}
+            if not isinstance(homer_kwargs, dict):
+                self.logger.warning(
+                    "Invalid motor_homer_kwargs config; expected dict, "
+                    f"got {type(raw_homer_kwargs).__name__}. "
+                    "Motor homer disabled."
+                )
+                return
+            try:
+                self.motor_homer = MotorHomer(
+                    self.transport,
+                    motor_client=self.motor_client,
+                    **homer_kwargs,
+                )
+            except TypeError as err:
+                self.logger.warning(
+                    "Invalid motor_homer_kwargs for MotorHomer: "
+                    f"{err}. Motor homer disabled."
+                )
 
     def init_tempctrl(self):
         """
@@ -957,7 +977,7 @@ class PandaClient:
         # below re-surfaces the same fault and drives the retry loop.
         try:
             self.motor_client.set_delay()
-        except (RuntimeError, TimeoutError) as exc:
+        except _MOTOR_LOOP_ERRORS as exc:
             self._warn_with_status(
                 f"Motor set_delay failed at loop start "
                 f"({type(exc).__name__}: {exc}); scans will retry."
@@ -976,7 +996,7 @@ class PandaClient:
                         logging.INFO,
                     )
                     wait_s = interval
-                except (TimeoutError, RuntimeError) as exc:
+                except _MOTOR_LOOP_ERRORS as exc:
                     # Log locally only so repeated failures during a
                     # persistent fault don't flood the bounded status
                     # stream. Operator already saw the original ERROR
@@ -1002,7 +1022,7 @@ class PandaClient:
                                     "Post-scan homing did not converge; "
                                     "motors left parked."
                                 )
-                        except (TimeoutError, RuntimeError) as homer_exc:
+                        except _MOTOR_LOOP_ERRORS as homer_exc:
                             self._warn_with_status(
                                 f"Post-scan homing failed "
                                 f"({type(homer_exc).__name__}: "
@@ -1011,7 +1031,7 @@ class PandaClient:
                             )
                             self.motor_client.home()
                     wait_s = interval
-                except (TimeoutError, RuntimeError) as exc:
+                except _MOTOR_LOOP_ERRORS as exc:
                     self._error_with_status(
                         f"Motor scan aborted ({type(exc).__name__}: {exc})."
                     )
@@ -1021,7 +1041,7 @@ class PandaClient:
                             "Motors parked at home after scan failure."
                         )
                         wait_s = interval
-                    except (TimeoutError, RuntimeError) as park_exc:
+                    except _MOTOR_LOOP_ERRORS as park_exc:
                         self._error_with_status(
                             f"Post-failure home() also failed "
                             f"({type(park_exc).__name__}: {park_exc}); "

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -36,6 +36,8 @@ motor_client_kwargs:
   el_limits_deg: [-180.0, 180.0]
   pot_az_v_limits: null
   imu_el_limits_deg: null
+home_after_scan: false
+motor_homer_kwargs: {settle_s: 0.0, max_iters: 3}
 
 # motion-switch coordination (default off; tests opt in per-fixture)
 serialize_motion_and_switching: false

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -31,11 +31,11 @@ use_motor: true
 motor_interval: 1  # seconds between scans
 motor_failure_retry_s: 0.5  # fast retry for tests
 motor_scan: {}
-motor_client_kwargs:
-  az_limits_deg: [-180.0, 180.0]
-  el_limits_deg: [-180.0, 180.0]
-  pot_az_v_limits: null
-  imu_el_limits_deg: null
+# Motor safe-travel limits are now rig-wide in the MotorLimitStore Redis K/V,
+# set via scripts/set_motor_limits.py (read by every MotorClient). They are
+# intentionally NOT here. motor_client_kwargs may still carry non-limit
+# MotorClient kwargs (step delays, poll interval) if needed.
+motor_client_kwargs: {}
 home_after_scan: false
 motor_homer_kwargs: {settle_s: 0.0, max_iters: 3}
 

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -31,6 +31,11 @@ use_motor: true
 motor_interval: 1  # seconds between scans
 motor_failure_retry_s: 0.5  # fast retry for tests
 motor_scan: {}
+motor_client_kwargs:
+  az_limits_deg: [-180.0, 180.0]
+  el_limits_deg: [-180.0, 180.0]
+  pot_az_v_limits: null
+  imu_el_limits_deg: null
 
 # motion-switch coordination (default off; tests opt in per-fixture)
 serialize_motion_and_switching: false

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -48,6 +48,14 @@ motor_client_kwargs:
   # applies).
   pot_az_v_limits: null
   imu_el_limits_deg: [-180.0, 180.0]
+home_after_scan: false  # closed-loop return-to-home after each scan
+motor_homer_kwargs:     # forwarded to MotorHomer (only used when home_after_scan: true)
+  tol_az_deg: 3.0
+  tol_el_deg: 2.0
+  settle_s: 10.0
+  damping: 0.5
+  max_iters: 6
+  reset_count: true
 
 # motion-switch coordination
 # When true, motor moves and RF switching mutually exclude each other

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -36,18 +36,11 @@ use_motor: false
 motor_interval: 3600  # seconds between scans
 motor_failure_retry_s: 60  # shorter wait after a failed scan to home
 motor_scan: {}  # kwargs forwarded to MotorClient.scan; {}
-# Motor safe-travel limits (passed to MotorClient via motor_client_kwargs).
-# Commanded-target window in degrees about home (home = 0); ±180 = one turn.
-# Narrow el below ±180 if the elevation mechanism has a tighter range.
-motor_client_kwargs:
-  az_limits_deg: [-180.0, 180.0]
-  el_limits_deg: [-180.0, 180.0]
-  # Raw-sensor fence (slope-independent). Measure pot V at the safe az
-  # extremes and the IMU el at the safe el extremes, then fill these in.
-  # Leave null to disable that axis's sensor fence (commanded guard still
-  # applies).
-  pot_az_v_limits: null
-  imu_el_limits_deg: [-180.0, 180.0]
+# Motor safe-travel limits are now rig-wide in the MotorLimitStore Redis K/V,
+# set via scripts/set_motor_limits.py (read by every MotorClient). They are
+# intentionally NOT here. motor_client_kwargs may still carry non-limit
+# MotorClient kwargs (step delays, poll interval) if needed.
+motor_client_kwargs: {}
 home_after_scan: false  # closed-loop return-to-home after each scan
 motor_homer_kwargs:     # forwarded to MotorHomer (only used when home_after_scan: true)
   tol_az_deg: 3.0

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -36,6 +36,18 @@ use_motor: false
 motor_interval: 3600  # seconds between scans
 motor_failure_retry_s: 60  # shorter wait after a failed scan to home
 motor_scan: {}  # kwargs forwarded to MotorClient.scan; {}
+# Motor safe-travel limits (passed to MotorClient via motor_client_kwargs).
+# Commanded-target window in degrees about home (home = 0); ±180 = one turn.
+# Narrow el below ±180 if the elevation mechanism has a tighter range.
+motor_client_kwargs:
+  az_limits_deg: [-180.0, 180.0]
+  el_limits_deg: [-180.0, 180.0]
+  # Raw-sensor fence (slope-independent). Measure pot V at the safe az
+  # extremes and the IMU el at the safe el extremes, then fill these in.
+  # Leave null to disable that axis's sensor fence (commanded guard still
+  # applies).
+  pot_az_v_limits: null
+  imu_el_limits_deg: [-180.0, 180.0]
 
 # motion-switch coordination
 # When true, motor moves and RF switching mutually exclude each other

--- a/src/eigsep_observing/el_sensor.py
+++ b/src/eigsep_observing/el_sensor.py
@@ -1,0 +1,64 @@
+"""Redundant elevation estimate from the two IMUs.
+
+imu_el (on the box, azimuth-invariant) reports SIGNED elevation over the
+full range and is the primary. imu_az (on the turntable) reports only |θ|
+(azimuth-sensitive ⇒ sign-degenerate) and is a magnitude-only failover when
+imu_el is dead. The two are NEVER averaged — they are different quantities;
+their disagreement (|imu_el| vs imu_az |θ|) is a fault signal.
+"""
+
+from collections import namedtuple
+
+import redis
+
+ElEstimate = namedtuple("ElEstimate", "el_deg magnitude_only source")
+
+
+def _get(reader, key):
+    try:
+        return (reader.get(key) or {}).get("el_deg")
+    except (KeyError, redis.exceptions.ConnectionError):
+        return None
+
+
+def read_el_estimate(snapshot_reader, *, logger=None, crosscheck_tol_deg=5.0):
+    """Return an :class:`ElEstimate` from the two IMU streams.
+
+    Parameters
+    ----------
+    snapshot_reader : MetadataSnapshotReader (or duck-type with .get)
+        Provides ``imu_el`` and ``imu_az`` snapshot dicts.
+    logger : logging.Logger or None
+        When supplied, a WARNING is emitted if both IMUs are present but
+        their magnitudes disagree by more than *crosscheck_tol_deg*.
+    crosscheck_tol_deg : float
+        Tolerance in degrees for the cross-check (default 5.0).
+
+    Returns
+    -------
+    ElEstimate
+        Named tuple ``(el_deg, magnitude_only, source)``.
+        *source* is ``"imu_el"`` (signed primary), ``"imu_az"``
+        (magnitude-only failover), or ``"none"`` (both absent /
+        connection error).  A ``redis.exceptions.ConnectionError`` from
+        the reader also yields ``ElEstimate(None, False, "none")``.
+    """
+    el = _get(snapshot_reader, "imu_el")
+    az = _get(snapshot_reader, "imu_az")
+    if el is not None:
+        if (
+            az is not None
+            and logger is not None
+            and abs(abs(el) - az) > crosscheck_tol_deg
+        ):
+            logger.warning(
+                "IMU elevation readings disagree: imu_el=%.1f deg, "
+                "imu_az|θ|=%.1f deg (>%.1f) — possible IMU fault.",
+                el,
+                az,
+                crosscheck_tol_deg,
+            )
+        return ElEstimate(el, False, "imu_el")
+    if az is not None:
+        return ElEstimate(az, True, "imu_az")
+    return ElEstimate(None, False, "none")

--- a/src/eigsep_observing/home_ref.py
+++ b/src/eigsep_observing/home_ref.py
@@ -1,0 +1,38 @@
+"""Redis K/V for the operational motor home reference.
+
+Written by field_zero when it sets zero; read by MotorHomer to know where
+to return. Raw, drift-free, power-cycle-stable values: az home as the pot
+voltage v0 (slope-independent), el home as the signed imu_el elevation.
+Follows the shared _redis_json_kv sibling pattern (run_tag, corr_health,
+snap_reinit, file_heartbeat) — not on the metadata bus, not a *Writer/
+*Reader class.
+"""
+
+import logging
+
+from ._redis_json_kv import publish_json, read_json
+
+logger = logging.getLogger(__name__)
+
+_KEY = "home_ref"
+
+
+def publish_home_ref(transport, *, pot_az_voltage_v0, imu_el_deg_home):
+    publish_json(
+        transport,
+        _KEY,
+        {
+            "pot_az_voltage_v0": pot_az_voltage_v0,
+            "imu_el_deg_home": imu_el_deg_home,
+        },
+    )
+
+
+def read_home_ref(transport):
+    return read_json(
+        transport,
+        _KEY,
+        label="home_ref",
+        logger=logger,
+        parse=lambda payload: payload,
+    )

--- a/src/eigsep_observing/motor_cal.py
+++ b/src/eigsep_observing/motor_cal.py
@@ -1,0 +1,19 @@
+"""Serial-less PicoMotor for step<->degree conversion.
+
+PicoManager builds the real motor pico with PicoMotor's constructor
+defaults and never overrides step_angle_deg / gear_teeth / microstep,
+so reusing those defaults here makes host-side degree math match the
+mover's own deg_to_steps exactly. The __new__ bypass avoids serial I/O.
+"""
+
+import inspect
+
+from picohost.motor import PicoMotor
+
+
+def cal_motor():
+    sig = inspect.signature(PicoMotor.__init__)
+    cal = PicoMotor.__new__(PicoMotor)
+    for attr in ("step_angle_deg", "gear_teeth", "microstep"):
+        setattr(cal, attr, sig.parameters[attr].default)
+    return cal

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -390,7 +390,11 @@ class MotorClient:
             pot_v = (self._reader.get("potmon") or {}).get("pot_az_voltage")
         except (KeyError, redis.exceptions.ConnectionError):
             pot_v = None
-        el = read_el_estimate(self._reader, logger=self.logger).el_deg
+        # IMU cross-check warning suppressed on the high-frequency fence
+        # path (~10 Hz inside _wait_for_stop); the homer's settle-cadence
+        # read (MotorHomer._read_sensors) and the live-status dashboard
+        # surface IMU disagreement at a sane rate.
+        el = read_el_estimate(self._reader, logger=None).el_deg
         return pot_v, el
 
     def _check_sensor_fence(self, axis):

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -19,9 +19,15 @@ import numpy as np
 from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
 
+from .motor_cal import cal_motor
 from .motion_switch import MotionSwitchCoordinator
 
 logger = logging.getLogger(__name__)
+
+
+class MotorLimitError(ValueError):
+    """Raised when a commanded move or a live sensor reading would take an
+    axis outside its configured safe-travel window."""
 
 
 class MotorClient:
@@ -66,6 +72,10 @@ class MotorClient:
         poll_interval_s=0.1,
         stall_timeout_s=30.0,
         start_timeout_s=1.0,
+        az_limits_deg=(-180.0, 180.0),
+        el_limits_deg=(-180.0, 180.0),
+        pot_az_v_limits=None,
+        imu_el_limits_deg=None,
         source="motor_client",
         coord=None,
     ):
@@ -81,6 +91,11 @@ class MotorClient:
         self.poll_interval_s = poll_interval_s
         self.stall_timeout_s = stall_timeout_s
         self.start_timeout_s = start_timeout_s
+        self.az_limits_deg = az_limits_deg
+        self.el_limits_deg = el_limits_deg
+        self.pot_az_v_limits = pot_az_v_limits
+        self.imu_el_limits_deg = imu_el_limits_deg
+        self._cal = cal_motor()
         self.logger = logger
         if coord is None:
             coord = MotionSwitchCoordinator(

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -20,6 +20,7 @@ import redis.exceptions
 from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
 
+from .el_sensor import read_el_estimate
 from .motor_cal import cal_motor
 from .motion_switch import MotionSwitchCoordinator
 
@@ -377,8 +378,6 @@ class MotorClient:
         connection error yields ``None``.  The fence treats ``el`` as a
         magnitude vs a symmetric window, so the magnitude-only failover is
         handled correctly without sign."""
-        from .el_sensor import read_el_estimate
-
         try:
             pot_v = (self._reader.get("potmon") or {}).get("pot_az_voltage")
         except (KeyError, redis.exceptions.ConnectionError):

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -146,6 +146,14 @@ class MotorClient:
         except (RuntimeError, TimeoutError) as exc:
             self.logger.warning("halt skipped: %s", exc)
 
+    def reset_step_position(self, az_step=0, el_step=0):
+        """Define the current physical pose as the given step counts
+        (default origin). No motion — intentionally bypasses the travel
+        guard; used by MotorHomer to re-zero the count at converged home."""
+        self._proxy.send_command(
+            "reset_step_position", az_step=az_step, el_step=el_step
+        )
+
     def _motor_status(self):
         try:
             return self._reader.get("motor")

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -22,7 +22,10 @@ from picohost.proxy import PicoProxy
 
 from .el_sensor import read_el_estimate
 from .motor_cal import cal_motor
+from .motor_limits import read_motor_limits
 from .motion_switch import MotionSwitchCoordinator
+
+_UNSET = object()
 
 logger = logging.getLogger(__name__)
 
@@ -53,24 +56,34 @@ class MotorClient:
         Must exceed the producer status cadence (~200 ms) so a real move
         is never mistaken for a no-op — this start phase is what keeps a
         move reliably one-axis-at-a-time.
-    az_limits_deg : tuple of (float, float)
+    az_limits_deg : tuple of (float, float) or _UNSET
         Inclusive ``(min, max)`` azimuth travel limits in degrees.
-        Defaults to ``(-180.0, 180.0)``. Commands that would violate
-        these bounds raise :class:`MotorLimitError`.
-    el_limits_deg : tuple of (float, float)
+        Precedence: explicit kwarg > MotorLimitStore K/V > ``(-180.0,
+        180.0)``. Commands that would violate these bounds raise
+        :class:`MotorLimitError`.
+    el_limits_deg : tuple of (float, float) or _UNSET
         Inclusive ``(min, max)`` elevation travel limits in degrees.
-        Defaults to ``(-180.0, 180.0)``. Commands that would violate
-        these bounds raise :class:`MotorLimitError`.
-    pot_az_v_limits : tuple of (float, float) or None
+        Precedence: explicit kwarg > MotorLimitStore K/V > ``(-180.0,
+        180.0)``. Commands that would violate these bounds raise
+        :class:`MotorLimitError`.
+    pot_az_v_limits : tuple of (float, float) or None or _UNSET
         Inclusive ``(min, max)`` safe voltage range for the azimuth
-        potentiometer. When ``None`` (default) no potentiometer limit
-        is enforced. A live reading outside this window raises
+        potentiometer. When ``None`` no potentiometer limit is enforced.
+        Precedence: explicit kwarg > MotorLimitStore K/V > ``None``.
+        A live reading outside this window raises
         :class:`MotorLimitError`.
-    imu_el_limits_deg : tuple of (float, float) or None
+    imu_el_limits_deg : tuple of (float, float) or None or _UNSET
         Inclusive ``(min, max)`` safe elevation range derived from the
-        IMU. When ``None`` (default) no IMU elevation limit is
-        enforced. A live reading outside this window raises
+        IMU. When ``None`` no IMU elevation limit is enforced.
+        Precedence: explicit kwarg > MotorLimitStore K/V > ``None``.
+        A live reading outside this window raises
         :class:`MotorLimitError`.
+    enforce_limits : bool
+        When ``False`` both the commanded-target guard
+        (:meth:`_check_target_limit`) and the live-sensor fence
+        (:meth:`_check_sensor_fence`) are bypassed entirely. Intended
+        for bring-up scripts that need unconstrained motion (e.g.
+        field-zero calibration). Default ``True``.
     source : str
         Identifier stamped on proxy command stream entries.
     coord : MotionSwitchCoordinator or None
@@ -92,10 +105,11 @@ class MotorClient:
         poll_interval_s=0.1,
         stall_timeout_s=30.0,
         start_timeout_s=1.0,
-        az_limits_deg=(-180.0, 180.0),
-        el_limits_deg=(-180.0, 180.0),
-        pot_az_v_limits=None,
-        imu_el_limits_deg=None,
+        az_limits_deg=_UNSET,
+        el_limits_deg=_UNSET,
+        pot_az_v_limits=_UNSET,
+        imu_el_limits_deg=_UNSET,
+        enforce_limits=True,
         source="motor_client",
         coord=None,
     ):
@@ -111,10 +125,20 @@ class MotorClient:
         self.poll_interval_s = poll_interval_s
         self.stall_timeout_s = stall_timeout_s
         self.start_timeout_s = start_timeout_s
-        self.az_limits_deg = az_limits_deg
-        self.el_limits_deg = el_limits_deg
-        self.pot_az_v_limits = pot_az_v_limits
-        self.imu_el_limits_deg = imu_el_limits_deg
+        stored = self._load_stored_limits(transport)
+        self.az_limits_deg = self._resolve_limit(
+            az_limits_deg, stored.get("az_limits_deg"), (-180.0, 180.0)
+        )
+        self.el_limits_deg = self._resolve_limit(
+            el_limits_deg, stored.get("el_limits_deg"), (-180.0, 180.0)
+        )
+        self.pot_az_v_limits = self._resolve_limit(
+            pot_az_v_limits, stored.get("pot_az_v_limits"), None
+        )
+        self.imu_el_limits_deg = self._resolve_limit(
+            imu_el_limits_deg, stored.get("imu_el_limits_deg"), None
+        )
+        self.enforce_limits = enforce_limits
         self._cal = cal_motor()
         self.logger = logger
         if coord is None:
@@ -122,6 +146,31 @@ class MotorClient:
                 threading.RLock(), serialize=False, logger=self.logger
             )
         self._coord = coord
+
+    @staticmethod
+    def _resolve_limit(explicit, stored, default):
+        """Precedence: explicit kwarg > stored K/V value > hardcoded default.
+
+        A stored ``None`` (fence explicitly disabled in the K/V) means
+        'no window', so it is treated the same as absent → default.
+        """
+        if explicit is not _UNSET:
+            return explicit
+        if stored is not None:
+            return stored
+        return default
+
+    @staticmethod
+    def _load_stored_limits(transport):
+        """MotorLimitStore values, or {} if unset / Redis unreachable.
+
+        A ConnectionError must never block MotorClient construction —
+        fall back to the hardcoded safe defaults.
+        """
+        try:
+            return read_motor_limits(transport) or {}
+        except redis.exceptions.ConnectionError:
+            return {}
 
     @property
     def is_available(self):
@@ -362,6 +411,8 @@ class MotorClient:
         """Raise MotorLimitError if the resulting absolute position for
         *axis* falls outside its configured window. No-op for axis-less
         actions or actions with no positional target."""
+        if not self.enforce_limits:
+            return
         if axis is None:
             return
         deg = self._resulting_deg(action, before_target_steps, kwargs)
@@ -401,6 +452,8 @@ class MotorClient:
         """Raise MotorLimitError if a present sensor reading shows the
         relevant axis already outside its configured raw-sensor window.
         No-op for an unset window or a missing reading."""
+        if not self.enforce_limits:
+            return
         pot_v, el = self._read_fence_sensors()
         if axis in (None, "az") and self.pot_az_v_limits and pot_v is not None:
             lo, hi = self.pot_az_v_limits

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -15,6 +15,7 @@ import threading
 import time
 
 import numpy as np
+import redis.exceptions
 
 from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
@@ -293,6 +294,7 @@ class MotorClient:
         with self._coord.motion_section(label=label):
             before_target = self._axis_target(axis)
             self._check_target_limit(axis, action, before_target, kwargs)
+            self._check_sensor_fence(axis)
             self._proxy.send_command(action, **kwargs)
             self._wait_for_start(axis, before_target, stop_event=stop_event)
             if stop_event is not None and stop_event.is_set():
@@ -349,6 +351,42 @@ class MotorClient:
                 f"{axis} move to {deg:.1f} deg outside safe window "
                 f"[{lo:.1f}, {hi:.1f}]; refusing to send {action}."
             )
+
+    def _read_fence_sensors(self):
+        """(pot_az_voltage, imu_el_deg) from the snapshot; each None if
+        unavailable. ConnectionError (panda down) yields (None, None) so a
+        sensor-less move is allowed rather than crashing — the commanded
+        guard still applies."""
+        try:
+            snap = self._reader.get("potmon") or {}
+            pot_v = snap.get("pot_az_voltage")
+        except (KeyError, redis.exceptions.ConnectionError):
+            pot_v = None
+        try:
+            el = (self._reader.get("imu_el") or {}).get("el_deg")
+        except (KeyError, redis.exceptions.ConnectionError):
+            el = None
+        return pot_v, el
+
+    def _check_sensor_fence(self, axis):
+        """Raise MotorLimitError if a present sensor reading shows the
+        relevant axis already outside its configured raw-sensor window.
+        No-op for an unset window or a missing reading."""
+        pot_v, el = self._read_fence_sensors()
+        if axis in (None, "az") and self.pot_az_v_limits and pot_v is not None:
+            lo, hi = self.pot_az_v_limits
+            if not (lo <= pot_v <= hi):
+                raise MotorLimitError(
+                    f"pot_az_voltage {pot_v:.3f} V outside safe window "
+                    f"[{lo:.3f}, {hi:.3f}]; refusing az move."
+                )
+        if axis in (None, "el") and self.imu_el_limits_deg and el is not None:
+            lo, hi = self.imu_el_limits_deg
+            if not (lo <= el <= hi):
+                raise MotorLimitError(
+                    f"imu el {el:.1f} deg outside safe window "
+                    f"[{lo:.1f}, {hi:.1f}]; refusing el move."
+                )
 
     def move_to(
         self,

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -202,7 +202,7 @@ class MotorClient:
                     return
             time.sleep(self.poll_interval_s)
 
-    def _wait_for_stop(self, timeout=None, stop_event=None):
+    def _wait_for_stop(self, timeout=None, stop_event=None, axis=None):
         """Block until the motor's position equals its target on both axes.
 
         Mirrors the progress-reset stall detection in
@@ -215,6 +215,11 @@ class MotorClient:
         drive ``home`` from a background thread (``motor_manual.py``).
         ``scan`` does not pass an event here (it cancels between moves),
         so its semantics are unchanged.
+
+        If ``axis`` is supplied, the sensor fence is polled on every
+        iteration. A breach calls :meth:`halt` and re-raises
+        :class:`MotorLimitError` immediately, aborting the move
+        mid-flight.
         """
         timeout = self.stall_timeout_s if timeout is None else timeout
         t = time.monotonic()
@@ -223,6 +228,12 @@ class MotorClient:
             if stop_event is not None and stop_event.is_set():
                 self.halt()
                 return
+            if axis is not None:
+                try:
+                    self._check_sensor_fence(axis)
+                except MotorLimitError:
+                    self.halt()
+                    raise
             status = self._motor_status()
             if status is None:
                 if time.monotonic() - t >= timeout:
@@ -300,7 +311,7 @@ class MotorClient:
             if stop_event is not None and stop_event.is_set():
                 self.halt()
                 return
-            self._wait_for_stop(timeout=timeout, stop_event=stop_event)
+            self._wait_for_stop(timeout=timeout, stop_event=stop_event, axis=axis)
 
     def _axis_target(self, axis):
         """Current ``{axis}_target_pos`` from the snapshot, or ``None``.

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -162,15 +162,12 @@ class MotorClient:
 
     @staticmethod
     def _load_stored_limits(transport):
-        """MotorLimitStore values, or {} if unset / Redis unreachable.
-
-        A ConnectionError must never block MotorClient construction —
-        fall back to the hardcoded safe defaults.
-        """
-        try:
-            return read_motor_limits(transport) or {}
-        except redis.exceptions.ConnectionError:
-            return {}
+        """MotorLimitStore values as a dict, or {} when unset / unreachable
+        / malformed. Never blocks MotorClient construction — any non-dict
+        payload (corrupt/hand-edited key) degrades to the hardcoded safe
+        defaults."""
+        stored = read_motor_limits(transport)
+        return stored if isinstance(stored, dict) else {}
 
     @property
     def is_available(self):

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -292,6 +292,7 @@ class MotorClient:
         )
         with self._coord.motion_section(label=label):
             before_target = self._axis_target(axis)
+            self._check_target_limit(axis, action, before_target, kwargs)
             self._proxy.send_command(action, **kwargs)
             self._wait_for_start(axis, before_target, stop_event=stop_event)
             if stop_event is not None and stop_event.is_set():
@@ -311,6 +312,43 @@ class MotorClient:
         if status is None:
             return None
         return status.get(f"{axis}_target_pos")
+
+    def _resulting_deg(self, action, before_target_steps, kwargs):
+        """Absolute resulting axis position in degrees for a move action,
+        or None for actions without a positional target (e.g. ``halt``).
+
+        Handles the three move shapes: absolute degrees
+        (``*_target_deg``), absolute steps (``*_target_steps``), and
+        relative degrees (``*_move_deg``, added to the current target).
+        """
+        if action.endswith("_target_deg"):
+            return float(kwargs["target_deg"])
+        if action.endswith("_target_steps"):
+            return self._cal.steps_to_deg(int(kwargs["target_steps"]))
+        if action.endswith("_move_deg"):
+            base = (
+                0 if before_target_steps is None else int(before_target_steps)
+            )
+            return self._cal.steps_to_deg(
+                base + self._cal.deg_to_steps(float(kwargs["delta_deg"]))
+            )
+        return None
+
+    def _check_target_limit(self, axis, action, before_target_steps, kwargs):
+        """Raise MotorLimitError if the resulting absolute position for
+        *axis* falls outside its configured window. No-op for axis-less
+        actions or actions with no positional target."""
+        if axis is None:
+            return
+        deg = self._resulting_deg(action, before_target_steps, kwargs)
+        if deg is None:
+            return
+        lo, hi = self.az_limits_deg if axis == "az" else self.el_limits_deg
+        if not (lo <= deg <= hi):
+            raise MotorLimitError(
+                f"{axis} move to {deg:.1f} deg outside safe window "
+                f"[{lo:.1f}, {hi:.1f}]; refusing to send {action}."
+            )
 
     def move_to(
         self,

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -311,7 +311,9 @@ class MotorClient:
             if stop_event is not None and stop_event.is_set():
                 self.halt()
                 return
-            self._wait_for_stop(timeout=timeout, stop_event=stop_event, axis=axis)
+            self._wait_for_stop(
+                timeout=timeout, stop_event=stop_event, axis=axis
+            )
 
     def _axis_target(self, axis):
         """Current ``{axis}_target_pos`` from the snapshot, or ``None``.
@@ -367,16 +369,21 @@ class MotorClient:
         """(pot_az_voltage, imu_el_deg) from the snapshot; each None if
         unavailable. ConnectionError (panda down) yields (None, None) so a
         sensor-less move is allowed rather than crashing — the commanded
-        guard still applies."""
+        guard still applies.
+
+        The elevation reading comes from :func:`.el_sensor.read_el_estimate`:
+        ``imu_el`` (signed) is the primary; ``imu_az`` (|θ|) is the
+        magnitude-only failover when ``imu_el`` is absent.  Both absent or a
+        connection error yields ``None``.  The fence treats ``el`` as a
+        magnitude vs a symmetric window, so the magnitude-only failover is
+        handled correctly without sign."""
+        from .el_sensor import read_el_estimate
+
         try:
-            snap = self._reader.get("potmon") or {}
-            pot_v = snap.get("pot_az_voltage")
+            pot_v = (self._reader.get("potmon") or {}).get("pot_az_voltage")
         except (KeyError, redis.exceptions.ConnectionError):
             pot_v = None
-        try:
-            el = (self._reader.get("imu_el") or {}).get("el_deg")
-        except (KeyError, redis.exceptions.ConnectionError):
-            el = None
+        el = read_el_estimate(self._reader, logger=self.logger).el_deg
         return pot_v, el
 
     def _check_sensor_fence(self, axis):

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -51,6 +51,24 @@ class MotorClient:
         Must exceed the producer status cadence (~200 ms) so a real move
         is never mistaken for a no-op — this start phase is what keeps a
         move reliably one-axis-at-a-time.
+    az_limits_deg : tuple of (float, float)
+        Inclusive ``(min, max)`` azimuth travel limits in degrees.
+        Defaults to ``(-180.0, 180.0)``. Commands that would violate
+        these bounds raise :class:`MotorLimitError`.
+    el_limits_deg : tuple of (float, float)
+        Inclusive ``(min, max)`` elevation travel limits in degrees.
+        Defaults to ``(-180.0, 180.0)``. Commands that would violate
+        these bounds raise :class:`MotorLimitError`.
+    pot_az_v_limits : tuple of (float, float) or None
+        Inclusive ``(min, max)`` safe voltage range for the azimuth
+        potentiometer. When ``None`` (default) no potentiometer limit
+        is enforced. A live reading outside this window raises
+        :class:`MotorLimitError`.
+    imu_el_limits_deg : tuple of (float, float) or None
+        Inclusive ``(min, max)`` safe elevation range derived from the
+        IMU. When ``None`` (default) no IMU elevation limit is
+        enforced. A live reading outside this window raises
+        :class:`MotorLimitError`.
     source : str
         Identifier stamped on proxy command stream entries.
     coord : MotionSwitchCoordinator or None

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -113,8 +113,13 @@ class MotorHomer:
             slope = (cal.get("pot_az") or [None])[0]
             if slope:
                 return abs(float(slope))
-        except Exception:
-            pass
+        except Exception as exc:
+            self.logger.warning(
+                "PotCalStore unavailable; using az gain fallback "
+                "%.1f deg/V: %s",
+                _AZ_GAIN_FALLBACK_DEG_PER_VOLT,
+                exc,
+            )
         return _AZ_GAIN_FALLBACK_DEG_PER_VOLT
 
     def _az_residual_deg(self, ref, pot_v):

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -9,13 +9,14 @@ the redundant imu_el-signed / imu_az-|θ| estimate.
 """
 
 import logging
+import time
 from dataclasses import dataclass
 
 from eigsep_redis import MetadataSnapshotReader
 from picohost.buses import PotCalStore
 
-from .el_sensor import read_el_estimate  # noqa: F401 (used by home() in C5)
-from .home_ref import read_home_ref  # noqa: F401 (used by home() in C5)
+from .el_sensor import read_el_estimate
+from .home_ref import read_home_ref
 from .motor_client import MotorClient
 
 logger = logging.getLogger(__name__)
@@ -183,3 +184,127 @@ class MotorHomer:
         ok_az = res_az is None or abs(res_az) <= self.tol_az_deg
         ok_el = res_el is None or abs(res_el) <= self.tol_el_deg
         return ok_az and ok_el
+
+    # ------------------------------------------------------------------
+    # Task C5: sensor read, settle, and converge loop
+    # ------------------------------------------------------------------
+
+    def _read_sensors(self):
+        """Return ``(pot_v, el_est)`` from the snapshot reader.
+
+        ``pot_v`` is the current az pot voltage (``None`` if absent or
+        on exception).  ``el_est`` is an :class:`~.el_sensor.ElEstimate`
+        from the two IMU streams (``el_deg=None`` when both are absent).
+        """
+        try:
+            pot_v = (self.snapshot.get("potmon") or {}).get("pot_az_voltage")
+        except Exception:
+            pot_v = None
+        el_est = read_el_estimate(self.snapshot, logger=self.logger)
+        return pot_v, el_est
+
+    def _settle(self, stop_event):
+        """Wait ``settle_s`` seconds; uses ``stop_event.wait`` when present."""
+        if stop_event is not None:
+            stop_event.wait(self.settle_s)
+        elif self.settle_s:
+            time.sleep(self.settle_s)
+
+    def home(self, stop_event=None):
+        """Drive the motor back to its recorded home pose.
+
+        Parameters
+        ----------
+        stop_event : threading.Event or None
+            When set, the loop exits at the next interruptible point.
+
+        Returns
+        -------
+        HomeResult
+            ``converged`` is ``True`` when both residuals are within
+            tolerance; ``degraded`` is ``True`` when sensors were
+            unavailable and open-loop fall-back was used.
+
+        Raises
+        ------
+        RuntimeError
+            When no home reference is stored in Redis.
+        """
+        ref = read_home_ref(self.transport)
+        if ref is None:
+            raise RuntimeError(
+                "No home reference in Redis; run field_zero to set home first."
+            )
+
+        pot_v, el_est = self._read_sensors()
+        if pot_v is None and el_est.el_deg is None:
+            self.logger.warning(
+                "Homing sensors unavailable; falling back to open-loop "
+                "home() — position will not be verified."
+            )
+            self.motor_client.home(stop_event=stop_event)
+            return HomeResult(
+                False,
+                0,
+                float("nan"),
+                float("nan"),
+                degraded=True,
+                reset_count=False,
+            )
+
+        self.motor_client.home(stop_event=stop_event)  # coarse approach
+        az_sign, el_sign = 1.0, 1.0
+        last_az = last_el = None
+        res_az = res_el = float("nan")
+        converged = False
+        i = 0
+        for i in range(1, self.max_iters + 1):
+            if stop_event is not None and stop_event.is_set():
+                break
+            self._settle(stop_event)
+            pot_v, el_est = self._read_sensors()
+            res_az = self._az_residual_deg(ref, pot_v)
+            res_el, _ = self._el_residual(ref, el_est)
+            if self._within_tol(res_az, res_el):
+                converged = True
+                break
+            # az corrective jog with sign auto-detect
+            if res_az is not None and abs(res_az) > self.tol_az_deg:
+                if last_az is not None and abs(res_az) > last_az:
+                    az_sign = -az_sign
+                last_az = abs(res_az)
+                self.motor_client.jog_az(
+                    az_sign * self.damping * res_az,
+                    stop_event=stop_event,
+                )
+            # el corrective jog with sign auto-detect (needed in the
+            # magnitude-only failover; harmless when signed)
+            if res_el is not None and abs(res_el) > self.tol_el_deg:
+                if last_el is not None and abs(res_el) > last_el:
+                    el_sign = -el_sign
+                last_el = abs(res_el)
+                self.motor_client.jog_el(
+                    el_sign * self.damping * res_el,
+                    stop_event=stop_event,
+                )
+
+        did_reset = False
+        if converged and self.reset_count:
+            self.motor_client.reset_step_position(az_step=0, el_step=0)
+            did_reset = True
+        if not converged:
+            self.logger.warning(
+                "Homing did not converge in %d iterations "
+                "(residual az=%.1f el=%.1f deg).",
+                self.max_iters,
+                res_az if res_az is not None else float("nan"),
+                res_el if res_el is not None else float("nan"),
+            )
+        return HomeResult(
+            converged,
+            i,
+            res_az,
+            res_el,
+            degraded=False,
+            reset_count=did_reset,
+        )

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -82,11 +82,14 @@ class MotorHomer:
         max_iters=6,
         az_gain_deg_per_volt=None,
         reset_count=True,
+        enforce_limits=True,
         source="motor_homer",
     ):
         self.transport = transport
         if motor_client is None:
-            motor_client = MotorClient(transport, source=source)
+            motor_client = MotorClient(
+                transport, source=source, enforce_limits=enforce_limits
+            )
         self.motor_client = motor_client
         self.snapshot = snapshot or MetadataSnapshotReader(transport)
         self.tol_az_deg = tol_az_deg

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -1,0 +1,180 @@
+"""Closed-loop return-to-known-home for the motor.
+
+Sibling of MotorZeroer. Reads the home reference (home_ref K/V), then runs
+a coarse-approach → settle → measure → damped-corrective-jog loop through
+MotorClient (inheriting the travel-limit guard) until the pot voltage and
+IMU elevation are back within tolerance of home, then re-zeros the step
+counter. Az feedback is raw pot voltage (slope-independent); el feedback is
+the redundant imu_el-signed / imu_az-|θ| estimate.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from eigsep_redis import MetadataSnapshotReader
+from picohost.buses import PotCalStore
+
+from .el_sensor import read_el_estimate  # noqa: F401 (used by home() in C5)
+from .home_ref import read_home_ref  # noqa: F401 (used by home() in C5)
+from .motor_client import MotorClient
+
+logger = logging.getLogger(__name__)
+
+_AZ_GAIN_FALLBACK_DEG_PER_VOLT = 90.0
+
+
+@dataclass
+class HomeResult:
+    converged: bool
+    iterations: int
+    residual_az_deg: float
+    residual_el_deg: float
+    degraded: bool
+    reset_count: bool
+
+
+class MotorHomer:
+    """Drive the motor back to its recorded home pose.
+
+    Parameters
+    ----------
+    transport : eigsep_redis.Transport
+        Shared transport; used to build the snapshot reader and
+        PotCalStore when not supplied.
+    motor_client : MotorClient or None
+        Pre-built client.  When ``None`` a default is constructed.
+    snapshot : MetadataSnapshotReader or None
+        Pre-built reader.  When ``None`` a default is constructed.
+    tol_az_deg : float
+        Azimuth convergence tolerance in degrees (default 3.0).
+    tol_el_deg : float
+        Elevation convergence tolerance in degrees (default 2.0).
+    settle_s : float
+        Seconds to wait after a jog before re-reading sensors
+        (default 10.0).
+    damping : float
+        Fraction of the residual applied per corrective jog (default 0.5).
+    max_iters : int
+        Maximum correction iterations before giving up (default 6).
+    az_gain_deg_per_volt : float or None
+        Override for the az pot gain (deg/V).  When ``None`` the gain
+        is read from ``PotCalStore`` (``abs(slope)``), with a fallback
+        of ``_AZ_GAIN_FALLBACK_DEG_PER_VOLT`` (90.0) when the store is
+        empty or unreachable.
+    reset_count : bool
+        Whether to re-zero the step counter upon convergence (default True).
+    source : str
+        Identifier stamped on proxy command stream entries.
+    """
+
+    def __init__(
+        self,
+        transport,
+        *,
+        motor_client=None,
+        snapshot=None,
+        tol_az_deg=3.0,
+        tol_el_deg=2.0,
+        settle_s=10.0,
+        damping=0.5,
+        max_iters=6,
+        az_gain_deg_per_volt=None,
+        reset_count=True,
+        source="motor_homer",
+    ):
+        self.transport = transport
+        if motor_client is None:
+            motor_client = MotorClient(transport, source=source)
+        self.motor_client = motor_client
+        self.snapshot = snapshot or MetadataSnapshotReader(transport)
+        self.tol_az_deg = tol_az_deg
+        self.tol_el_deg = tol_el_deg
+        self.settle_s = settle_s
+        self.damping = damping
+        self.max_iters = max_iters
+        self.az_gain_deg_per_volt = az_gain_deg_per_volt
+        self.reset_count = reset_count
+        self.logger = logger
+
+    # ------------------------------------------------------------------
+    # Pure helpers (also called by Task C5's home() loop)
+    # ------------------------------------------------------------------
+
+    def _az_gain(self):
+        """Deg/volt magnitude for the az potentiometer.
+
+        Priority: constructor override → PotCalStore abs(slope) →
+        ``_AZ_GAIN_FALLBACK_DEG_PER_VOLT`` (90.0).
+        """
+        if self.az_gain_deg_per_volt is not None:
+            return abs(self.az_gain_deg_per_volt)
+        try:
+            cal = PotCalStore(self.transport).get() or {}
+            slope = (cal.get("pot_az") or [None])[0]
+            if slope:
+                return abs(float(slope))
+        except Exception:
+            pass
+        return _AZ_GAIN_FALLBACK_DEG_PER_VOLT
+
+    def _az_residual_deg(self, ref, pot_v):
+        """Degrees to jog so the pot returns to its home voltage.
+
+        The sign convention: positive residual → need to jog positive az.
+        Returns ``None`` when no pot reading is available.
+
+        Parameters
+        ----------
+        ref : dict
+            Home reference dict from ``read_home_ref``; must contain
+            ``pot_az_voltage_v0``.
+        pot_v : float or None
+            Current pot voltage reading.
+        """
+        if pot_v is None:
+            return None
+        dv = ref["pot_az_voltage_v0"] - pot_v
+        return dv * self._az_gain()
+
+    def _el_residual(self, ref, el_est):
+        """Elevation residual in degrees and whether it is magnitude-only.
+
+        Returns ``(residual_deg, magnitude_only)``.
+
+        When the primary IMU (``imu_el``, signed) is available the
+        residual is signed: ``home_el - current_el``.  When only the
+        failover IMU (``imu_az``, magnitude-only |θ|) is available the
+        residual is a magnitude comparison: ``|current| - |home|``.
+
+        Parameters
+        ----------
+        ref : dict
+            Home reference dict from ``read_home_ref``; must contain
+            ``imu_el_deg_home``.
+        el_est : ElEstimate
+            Current elevation estimate from ``read_el_estimate``.
+        """
+        if el_est.el_deg is None:
+            return None, False
+        home = ref.get("imu_el_deg_home") or 0.0
+        if el_est.magnitude_only:
+            return el_est.el_deg - abs(home), True
+        return home - el_est.el_deg, False
+
+    def _within_tol(self, res_az, res_el):
+        """True when both residuals are within their configured tolerances.
+
+        A ``None`` residual (sensor absent) is treated as "within
+        tolerance" so a missing sensor does not block convergence on the
+        axis that is present.
+
+        Parameters
+        ----------
+        res_az : float or None
+            Azimuth residual in degrees (from ``_az_residual_deg``).
+        res_el : float or None
+            Elevation residual in degrees (from ``_el_residual``).
+        """
+        ok_az = res_az is None or abs(res_az) <= self.tol_az_deg
+        ok_el = res_el is None or abs(res_el) <= self.tol_el_deg
+        return ok_az and ok_el

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -65,6 +65,10 @@ class MotorHomer:
         empty or unreachable.
     reset_count : bool
         Whether to re-zero the step counter upon convergence (default True).
+    enforce_limits : bool
+        Passed to the internally built ``MotorClient``; ignored when an
+        external ``motor_client`` is supplied (that client's own
+        ``enforce_limits`` governs).
     source : str
         Identifier stamped on proxy command stream entries.
     """

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -11,6 +11,7 @@ the redundant imu_el-signed / imu_az-|θ| estimate.
 import logging
 import time
 from dataclasses import dataclass
+from typing import Optional
 
 from eigsep_redis import MetadataSnapshotReader
 from picohost.buses import PotCalStore
@@ -28,8 +29,8 @@ _AZ_GAIN_FALLBACK_DEG_PER_VOLT = 90.0
 class HomeResult:
     converged: bool
     iterations: int
-    residual_az_deg: float
-    residual_el_deg: float
+    residual_az_deg: Optional[float]
+    residual_el_deg: Optional[float]
     degraded: bool
     reset_count: bool
 
@@ -265,6 +266,19 @@ class MotorHomer:
             pot_v, el_est = self._read_sensors()
             res_az = self._az_residual_deg(ref, pot_v)
             res_el, _ = self._el_residual(ref, el_est)
+            if res_az is None and res_el is None:
+                self.logger.warning(
+                    "Homing lost all sensor feedback mid-loop; aborting "
+                    "without re-zero (position unverified)."
+                )
+                return HomeResult(
+                    False,
+                    i,
+                    res_az,
+                    res_el,
+                    degraded=True,
+                    reset_count=False,
+                )
             if self._within_tol(res_az, res_el):
                 converged = True
                 break

--- a/src/eigsep_observing/motor_limits.py
+++ b/src/eigsep_observing/motor_limits.py
@@ -1,0 +1,47 @@
+"""Redis K/V for rig-wide motor safe-travel limits.
+
+Single source of truth read by EVERY MotorClient (autonomous observer and
+bring-up scripts alike), so the travel-limit guard is rig-wide rather than
+per-process. Set/inspected by scripts/set_motor_limits.py. Follows the
+shared _redis_json_kv sibling pattern (home_ref, run_tag, ...). Not on the
+metadata bus; NOT obs_config (so the scripts/CLAUDE.md "no ConfigStore
+upload" rule is not in play).
+"""
+
+import logging
+
+from ._redis_json_kv import publish_json, read_json
+
+logger = logging.getLogger(__name__)
+
+_KEY = "motor_limits"
+
+
+def publish_motor_limits(
+    transport,
+    *,
+    az_limits_deg,
+    el_limits_deg,
+    pot_az_v_limits,
+    imu_el_limits_deg,
+):
+    publish_json(
+        transport,
+        _KEY,
+        {
+            "az_limits_deg": az_limits_deg,
+            "el_limits_deg": el_limits_deg,
+            "pot_az_v_limits": pot_az_v_limits,
+            "imu_el_limits_deg": imu_el_limits_deg,
+        },
+    )
+
+
+def read_motor_limits(transport):
+    return read_json(
+        transport,
+        _KEY,
+        label="motor_limits",
+        logger=logger,
+        parse=lambda payload: payload,
+    )

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -7,15 +7,14 @@ rendering, and the same logic is reachable by unit tests without a
 terminal.
 """
 
-import inspect
 import logging
 import threading
 import time
 
 from eigsep_redis import MetadataSnapshotReader
-from picohost.motor import PicoMotor
 from picohost.proxy import PicoProxy
 
+from .motor_cal import cal_motor
 from .motor_client import MotorClient
 
 logger = logging.getLogger(__name__)
@@ -25,29 +24,7 @@ logger = logging.getLogger(__name__)
 _KEY_ENTER = ord("\n")
 _REQUIRE_STATUS_RETRY_S = 0.5
 
-
-def _default_cal_motor():
-    """A serial-less :class:`PicoMotor` carrying only the calibration
-    constants, used purely to convert step counts to axis degrees for
-    display.
-
-    ``PicoManager`` constructs the real motor pico with ``PicoMotor``'s
-    constructor defaults and never overrides ``step_angle_deg`` /
-    ``gear_teeth`` / ``microstep`` (see ``picohost.manager``), so reusing
-    those defaults here makes the displayed degrees match the mover's
-    own ``deg_to_steps`` exactly instead of duplicating the gear math.
-    Pulling the values from the constructor signature keeps them in
-    lockstep with picohost. The ``__new__`` bypass (no serial I/O)
-    mirrors ``contract_tests.test_producer_contracts``.
-    """
-    sig = inspect.signature(PicoMotor.__init__)
-    cal = PicoMotor.__new__(PicoMotor)
-    for attr in ("step_angle_deg", "gear_teeth", "microstep"):
-        setattr(cal, attr, sig.parameters[attr].default)
-    return cal
-
-
-_CAL_MOTOR = _default_cal_motor()
+_CAL_MOTOR = cal_motor()
 
 
 def _format_pos(raw):

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -55,6 +55,7 @@ class MotorZeroer:
         el_up_delay_us=2400,
         el_dn_delay_us=600,
         source="motor_zeroer",
+        enforce_limits=True,
         motor_client=None,
     ):
         self.transport = transport
@@ -74,7 +75,11 @@ class MotorZeroer:
         # background thread so the curses loop keeps rendering live
         # position; injectable for tests.
         if motor_client is None:
-            motor_client = MotorClient(transport, source="motor_manual_home")
+            motor_client = MotorClient(
+                transport,
+                source="motor_manual_home",
+                enforce_limits=enforce_limits,
+            )
         self._motor_client = motor_client
         self._homing = False
         self._home_thread = None

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -44,6 +44,9 @@ class MotorZeroer:
 
     Parameters mirror :class:`eigsep_observing.motor_client.MotorClient`
     for consistency — the same delay values apply to manual jogging.
+    ``enforce_limits`` is passed to the internally built ``MotorClient``;
+    it is ignored when an external ``motor_client`` is supplied (that
+    client's own ``enforce_limits`` governs).
     """
 
     def __init__(

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -15,7 +15,7 @@ from eigsep_redis import MetadataSnapshotReader
 from picohost.proxy import PicoProxy
 
 from .motor_cal import cal_motor
-from .motor_client import MotorClient
+from .motor_client import MotorClient, MotorLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,12 @@ class MotorZeroer:
         self.logger = logger
         # Two-step zero guard: Enter arms this, a deliberate 'y' commits.
         self._pending_zero = False
+        # Operator-visible one-liner for the curses UIs: set when a
+        # jog or home is denied (MotorLimitError) or fails; cleared by
+        # the next successful jog. The manual scripts log with
+        # console=False, so a log-only warning would be invisible
+        # mid-session — the render loops draw this instead.
+        self.notice = None
         # "Go home" drives both axes to step 0 via the same
         # MotorClient.home primitive motor_scan.py uses. It runs in a
         # background thread so the curses loop keeps rendering live
@@ -168,8 +174,12 @@ class MotorZeroer:
         def _run():
             try:
                 self._motor_client.home(stop_event=self._home_stop)
+            except MotorLimitError as exc:
+                self.logger.warning("home denied: %s", exc)
+                self.notice = str(exc)
             except (RuntimeError, TimeoutError) as exc:
                 self.logger.warning("home failed: %s", exc)
+                self.notice = f"home failed: {exc}"
             finally:
                 self._homing = False
 
@@ -284,8 +294,14 @@ class MotorZeroer:
                     self.jog_az(deg_state)
                 else:
                     self.jog_az(-deg_state)
+            except MotorLimitError as exc:
+                self.logger.warning("jog %s denied: %s", key, exc)
+                self.notice = str(exc)
             except (RuntimeError, TimeoutError) as exc:
                 self.logger.warning("jog %s failed: %s", key, exc)
+                self.notice = f"jog failed: {exc}"
+            else:
+                self.notice = None
         return deg_state, False, False
 
     def _confirm_zero(self, ch, deg_state):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1329,6 +1329,21 @@ def test_use_motor_true_builds_motor_client(transport, dummy_cfg):
         client.stop()
 
 
+def test_motor_client_receives_limit_kwargs(transport, dummy_cfg):
+    """Limit kwargs in ``motor_client_kwargs`` flow through
+    ``init_motor_client`` into the ``MotorClient`` constructor verbatim.
+    Verifies that the ``**kwargs`` splat in ``init_motor_client`` does
+    not filter travel-limit keys."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_client_kwargs"] = {"el_limits_deg": [-30.0, 30.0]}
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        assert tuple(client.motor_client.el_limits_deg) == (-30.0, 30.0)
+    finally:
+        client.stop()
+
+
 def test_motor_loop_returns_when_motor_client_is_none(caplog, client):
     """motor_loop must return promptly when ``motor_client`` is None —
     no polling, no silent spin. The warning must ride both channels

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2066,6 +2066,85 @@ def test_motor_loop_failure_park_stays_open_loop(transport, dummy_cfg):
         client.stop()
 
 
+def test_motor_loop_survives_motor_limit_error(transport, dummy_cfg, caplog):
+    """A ``MotorLimitError`` from ``scan`` (sensor fence or commanded-target
+    guard) must not propagate out of ``motor_loop``.  It must be treated
+    identically to a scan ``RuntimeError``: logged at ERROR on both channels,
+    followed by an open-loop park attempt, then the loop exits cleanly because
+    ``stop_client`` was set inside the raising scan stub."""
+    from eigsep_observing.motor_client import MotorLimitError
+
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 60
+    cfg["motor_scan"] = {"repeat_count": 1}
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        home_calls = []
+
+        def raising_scan(**kwargs):
+            client.stop_client.set()
+            raise MotorLimitError("out of window")
+
+        def recording_home():
+            home_calls.append(True)
+
+        _arm_status_reader(client)
+        with (
+            patch.object(
+                client.motor_client, "scan", side_effect=raising_scan
+            ),
+            patch.object(
+                client.motor_client, "home", side_effect=recording_home
+            ),
+        ):
+            caplog.set_level("ERROR")
+            client.motor_loop()  # must return, not raise
+
+        assert home_calls == [True], (
+            "motor_loop must attempt open-loop park after MotorLimitError "
+            "so a power loss doesn't strand the rig at an arbitrary position"
+        )
+        assert any(
+            "Motor scan aborted" in r.getMessage()
+            and "MotorLimitError" in r.getMessage()
+            and r.levelname == "ERROR"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.ERROR
+        assert "Motor scan aborted" in status
+    finally:
+        client.stop()
+
+
+def test_invalid_motor_homer_kwargs_disables_homer(
+    transport, dummy_cfg, caplog
+):
+    """A ``motor_homer_kwargs`` with an unknown key must not raise during
+    ``PandaClient.__init__``; ``init_motor_client`` must catch the resulting
+    ``TypeError``, warn, and leave ``motor_homer`` as ``None`` so the loop
+    still works (open-loop park only)."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["home_after_scan"] = True
+    cfg["motor_homer_kwargs"] = {"nonexistent_kwarg": 1}
+    caplog.set_level("WARNING")
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        assert client.motor_homer is None, (
+            "Invalid motor_homer_kwargs must disable motor_homer, not raise"
+        )
+        assert any(
+            "Invalid motor_homer_kwargs" in r.getMessage()
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+    finally:
+        client.stop()
+
+
 # ``tempctrl_loop`` mirrors ``motor_loop``: periodic action gated by a
 # ``use_*`` flag. Unit tests for the command dispatch + emulator state
 # live in tests/test_tempctrl_client.py; these tests cover the

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1964,6 +1964,108 @@ def test_motor_loop_set_delay_failure_is_warning_not_fatal(
         client.stop()
 
 
+def test_motor_loop_homes_closed_loop_after_scan(transport, dummy_cfg):
+    """With ``home_after_scan: true``, motor_loop calls
+    ``motor_homer.home`` (with ``stop_event``) after a successful scan.
+    The closed-loop homer is NOT called on the failure park path."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_scan"] = {"repeat_count": 1}
+    cfg["home_after_scan"] = True
+    cfg["motor_homer_kwargs"] = {"settle_s": 0.0, "max_iters": 1}
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        assert client.motor_homer is not None, (
+            "home_after_scan=True must build motor_homer in init_motor_client"
+        )
+        homer_calls = []
+
+        def fake_scan(**kwargs):
+            pass  # scan succeeds
+
+        def recording_homer_home(stop_event=None):
+            homer_calls.append(stop_event)
+            client.stop_client.set()
+            from eigsep_observing.motor_homer import HomeResult
+
+            return HomeResult(
+                converged=True,
+                iterations=1,
+                residual_az_deg=0.0,
+                residual_el_deg=0.0,
+                degraded=False,
+                reset_count=False,
+            )
+
+        with (
+            patch.object(client.motor_client, "scan", side_effect=fake_scan),
+            patch.object(
+                client.motor_homer, "home", side_effect=recording_homer_home
+            ),
+        ):
+            client.motor_loop()
+
+        assert len(homer_calls) == 1, (
+            f"motor_homer.home must be called once after a successful scan; "
+            f"got {len(homer_calls)} calls"
+        )
+        assert homer_calls[0] is client.stop_client, (
+            "motor_homer.home must receive stop_event=self.stop_client"
+        )
+    finally:
+        client.stop()
+
+
+def test_motor_loop_failure_park_stays_open_loop(transport, dummy_cfg):
+    """With ``home_after_scan: true``, the FAILURE/recovery park path
+    must use the open-loop ``motor_client.home()`` only — NOT the
+    closed-loop homer. The homer is for the healthy post-scan path."""
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_scan"] = {"repeat_count": 1}
+    cfg["home_after_scan"] = True
+    cfg["motor_homer_kwargs"] = {"settle_s": 0.0, "max_iters": 1}
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        homer_calls = []
+        open_loop_calls = []
+
+        def raising_scan(**kwargs):
+            client.stop_client.set()
+            raise TimeoutError("motor stalled")
+
+        def recording_open_home():
+            open_loop_calls.append(True)
+
+        def recording_homer_home(stop_event=None):
+            homer_calls.append(True)
+
+        _arm_status_reader(client)
+        with (
+            patch.object(
+                client.motor_client, "scan", side_effect=raising_scan
+            ),
+            patch.object(
+                client.motor_client, "home", side_effect=recording_open_home
+            ),
+            patch.object(
+                client.motor_homer, "home", side_effect=recording_homer_home
+            ),
+        ):
+            client.motor_loop()
+
+        assert open_loop_calls, (
+            "failure park must call the open-loop motor_client.home()"
+        )
+        assert not homer_calls, (
+            "failure park must NOT call the closed-loop motor_homer.home()"
+        )
+    finally:
+        client.stop()
+
+
 # ``tempctrl_loop`` mirrors ``motor_loop``: periodic action gated by a
 # ``use_*`` flag. Unit tests for the command dispatch + emulator state
 # live in tests/test_tempctrl_client.py; these tests cover the

--- a/tests/test_el_sensor.py
+++ b/tests/test_el_sensor.py
@@ -1,0 +1,42 @@
+import logging
+
+from eigsep_observing.el_sensor import ElEstimate, read_el_estimate
+
+
+class _Reader:
+    def __init__(self, snap):
+        self._snap = snap
+
+    def get(self, key):
+        return self._snap.get(key, {})
+
+
+def test_prefers_signed_imu_el():
+    r = _Reader({"imu_el": {"el_deg": -12.0}, "imu_az": {"el_deg": 12.0}})
+    est = read_el_estimate(r)
+    assert est == ElEstimate(-12.0, False, "imu_el")
+
+
+def test_failover_to_imu_az_magnitude():
+    r = _Reader({"imu_az": {"el_deg": 7.0}})  # imu_el absent
+    est = read_el_estimate(r)
+    assert est == ElEstimate(7.0, True, "imu_az")
+
+
+def test_both_absent_returns_none():
+    assert read_el_estimate(_Reader({})) == ElEstimate(None, False, "none")
+
+
+def test_crosscheck_warns_on_divergence(caplog):
+    r = _Reader({"imu_el": {"el_deg": -5.0}, "imu_az": {"el_deg": 40.0}})
+    with caplog.at_level(logging.WARNING):
+        est = read_el_estimate(r, logger=logging.getLogger("t"))
+    assert est.source == "imu_el"  # still trusts signed primary
+    assert any("disagree" in rec.message for rec in caplog.records)
+
+
+def test_crosscheck_silent_when_consistent(caplog):
+    r = _Reader({"imu_el": {"el_deg": -5.0}, "imu_az": {"el_deg": 5.2}})
+    with caplog.at_level(logging.WARNING):
+        read_el_estimate(r, logger=logging.getLogger("t"))
+    assert not caplog.records

--- a/tests/test_el_sensor.py
+++ b/tests/test_el_sensor.py
@@ -1,5 +1,7 @@
 import logging
 
+import redis
+
 from eigsep_observing.el_sensor import ElEstimate, read_el_estimate
 
 
@@ -40,3 +42,11 @@ def test_crosscheck_silent_when_consistent(caplog):
     with caplog.at_level(logging.WARNING):
         read_el_estimate(r, logger=logging.getLogger("t"))
     assert not caplog.records
+
+
+def test_connection_error_returns_none_sentinel():
+    class _ErrorReader:
+        def get(self, key):
+            raise redis.exceptions.ConnectionError("down")
+
+    assert read_el_estimate(_ErrorReader()) == ElEstimate(None, False, "none")

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -100,6 +100,12 @@ def test_no_slip_check_flag_parses(monkeypatch):
     assert args.no_slip_check is True
 
 
+def test_override_limits_flag_parses(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["field_zero", "--override-limits"])
+    args = field_zero._parse_args()
+    assert args.override_limits is True
+
+
 def test_write_home_ref_stores_pot_and_imu():
     t = DummyTransport()
 

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -113,6 +113,27 @@ def test_override_limits_flag_parses(monkeypatch):
     assert args.override_limits is True
 
 
+def test_prompt_override_yes(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+    assert field_zero._prompt_override(0.150, 0.050) is True
+    out = capsys.readouterr().out
+    # Operator decides with the numbers in hand.
+    assert "0.050" in out and "0.150" in out
+
+
+def test_prompt_override_default_is_no(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+    assert field_zero._prompt_override(0.150, 0.050) is False
+
+
+def test_prompt_override_eof_is_no(monkeypatch):
+    def _eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+    assert field_zero._prompt_override(0.150, 0.050) is False
+
+
 def test_write_home_ref_stores_pot_and_imu():
     t = DummyTransport()
 

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -76,3 +76,16 @@ def test_run_slip_check_uses_pot_swing():
     assert round(exp, 4) == round(30.0 / 200.0, 4)  # 0.15 V expected
     assert round(meas, 4) == 0.15  # 2.15 - 2.00
     assert verdict == "ok"
+
+
+def test_run_slip_check_aborts_without_pot():
+    class Snap:
+        def get(self, *a):
+            return {"potmon": {}}  # no pot_az_voltage
+
+    class Motor:
+        def jog_az(self, d, **k):
+            pass
+
+    with pytest.raises(SystemExit):
+        field_zero.run_slip_check(Motor(), Snap(), slope_m=200.0)

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -7,6 +7,7 @@ import pytest
 from eigsep_redis.testing import DummyTransport
 from picohost.buses import PotCalStore
 
+from eigsep_observing import MotorLimitError
 from eigsep_observing.home_ref import read_home_ref
 
 _spec = importlib.util.spec_from_file_location(
@@ -98,6 +99,26 @@ def test_run_slip_check_aborts_without_pot():
             pass
 
     with pytest.raises(SystemExit):
+        field_zero.run_slip_check(Motor(), Snap(), slope_m=200.0)
+
+
+def test_run_slip_check_probe_denied_exits_cleanly():
+    """A probe jog denied by the travel guard (or aborted by the
+    sensor fence) must surface as an actionable SystemExit, not a
+    MotorLimitError traceback."""
+
+    class Snap:
+        def get(self, *a):
+            return {"potmon": {"pot_az_voltage": 2.0}}
+
+    class Motor:
+        def jog_az(self, d, **k):
+            raise MotorLimitError(
+                "az move to 184.0 deg outside safe window "
+                "[-180.0, 180.0]; refusing to send az_move_deg."
+            )
+
+    with pytest.raises(SystemExit, match="denied by travel limit"):
         field_zero.run_slip_check(Motor(), Snap(), slope_m=200.0)
 
 

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -1,10 +1,13 @@
 import importlib.util
 import pathlib
+import sys
 
 import pytest
 
 from eigsep_redis.testing import DummyTransport
 from picohost.buses import PotCalStore
+
+from eigsep_observing.home_ref import read_home_ref
 
 _spec = importlib.util.spec_from_file_location(
     "field_zero",
@@ -89,3 +92,22 @@ def test_run_slip_check_aborts_without_pot():
 
     with pytest.raises(SystemExit):
         field_zero.run_slip_check(Motor(), Snap(), slope_m=200.0)
+
+
+def test_no_slip_check_flag_parses(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["field_zero", "--no-slip-check"])
+    args = field_zero._parse_args()
+    assert args.no_slip_check is True
+
+
+def test_write_home_ref_stores_pot_and_imu():
+    t = DummyTransport()
+
+    class FakeSnapshot:
+        def get(self):
+            return {"imu_el": {"el_deg": 0.3}}
+
+    field_zero._write_home_ref(t, FakeSnapshot(), 1.7)
+    ref = read_home_ref(t)
+    assert ref["pot_az_voltage_v0"] == 1.7
+    assert ref["imu_el_deg_home"] == pytest.approx(0.3)

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -24,10 +24,17 @@ def _make_dummy_transport():
 
 def test_slip_verdict_bands():
     assert field_zero.slip_verdict(1.0, 1.00) == "ok"
-    assert field_zero.slip_verdict(1.0, 0.96) == "ok"  # 4% off
-    assert field_zero.slip_verdict(1.0, 0.93) == "warn"  # 7% off
-    assert field_zero.slip_verdict(1.0, 0.80) == "fail"  # 20% off
+    assert field_zero.slip_verdict(1.0, 0.96) == "ok"  # 4% short
+    assert field_zero.slip_verdict(1.0, 0.93) == "warn"  # 7% short
+    assert field_zero.slip_verdict(1.0, 0.80) == "fail"  # 20% short
     assert field_zero.slip_verdict(0.0, 0.0) == "fail"  # zero expected
+    # Overshoot is never slip: slip/stall under-travels the pot. A
+    # larger-than-expected swing means the stored slope is too steep
+    # (stale cal), so it warns without blocking (field finding,
+    # 2026-07-01: a real zero was wrongly denied on overshoot).
+    assert field_zero.slip_verdict(1.0, 1.04) == "ok"  # 4% over
+    assert field_zero.slip_verdict(1.0, 1.07) == "overshoot"  # 7% over
+    assert field_zero.slip_verdict(1.0, 1.50) == "overshoot"  # gross
 
 
 def test_rezero_pot_pins_intercept():

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -1,0 +1,17 @@
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "field_zero",
+    pathlib.Path(__file__).parents[1] / "scripts" / "field_zero.py",
+)
+field_zero = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(field_zero)
+
+
+def test_slip_verdict_bands():
+    assert field_zero.slip_verdict(1.0, 1.00) == "ok"
+    assert field_zero.slip_verdict(1.0, 0.96) == "ok"  # 4% off
+    assert field_zero.slip_verdict(1.0, 0.93) == "warn"  # 7% off
+    assert field_zero.slip_verdict(1.0, 0.80) == "fail"  # 20% off
+    assert field_zero.slip_verdict(0.0, 0.0) == "fail"  # zero expected

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -1,6 +1,8 @@
 import importlib.util
 import pathlib
 
+from eigsep_redis.testing import DummyTransport
+
 _spec = importlib.util.spec_from_file_location(
     "field_zero",
     pathlib.Path(__file__).parents[1] / "scripts" / "field_zero.py",
@@ -9,9 +11,36 @@ field_zero = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(field_zero)
 
 
+def _make_dummy_transport():
+    """Fakeredis-backed transport, per the repo DummyTransport convention."""
+    return DummyTransport()
+
+
 def test_slip_verdict_bands():
     assert field_zero.slip_verdict(1.0, 1.00) == "ok"
     assert field_zero.slip_verdict(1.0, 0.96) == "ok"  # 4% off
     assert field_zero.slip_verdict(1.0, 0.93) == "warn"  # 7% off
     assert field_zero.slip_verdict(1.0, 0.80) == "fail"  # 20% off
     assert field_zero.slip_verdict(0.0, 0.0) == "fail"  # zero expected
+
+
+def test_rezero_pot_pins_intercept():
+    from picohost.buses import PotCalStore
+
+    t = _make_dummy_transport()
+    PotCalStore(t).upload({"pot_az": [200.0, -999.0]})  # stale intercept
+
+    class FakeProxy:
+        def __init__(self):
+            self.calls = []
+
+        def send_command(self, *a, **k):
+            self.calls.append((a, k))
+
+    proxy = FakeProxy()
+    m, b = field_zero.rezero_pot(t, proxy, v0=1.5)
+    assert m == 200.0
+    assert b == -200.0 * 1.5  # b = -m*v0 = -300.0
+    assert PotCalStore(t).get()["pot_az"] == [200.0, -300.0]
+    assert proxy.calls
+    assert proxy.calls[0][1]["pot_az_params"] == [200.0, -300.0]

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -1,7 +1,10 @@
 import importlib.util
 import pathlib
 
+import pytest
+
 from eigsep_redis.testing import DummyTransport
+from picohost.buses import PotCalStore
 
 _spec = importlib.util.spec_from_file_location(
     "field_zero",
@@ -25,8 +28,6 @@ def test_slip_verdict_bands():
 
 
 def test_rezero_pot_pins_intercept():
-    from picohost.buses import PotCalStore
-
     t = _make_dummy_transport()
     PotCalStore(t).upload({"pot_az": [200.0, -999.0]})  # stale intercept
 
@@ -43,4 +44,35 @@ def test_rezero_pot_pins_intercept():
     assert b == -200.0 * 1.5  # b = -m*v0 = -300.0
     assert PotCalStore(t).get()["pot_az"] == [200.0, -300.0]
     assert proxy.calls
+    assert proxy.calls[0][0][0] == "set_calibration"
     assert proxy.calls[0][1]["pot_az_params"] == [200.0, -300.0]
+
+
+def test_rezero_pot_raises_without_stored_cal():
+    t = DummyTransport()
+
+    class FakeProxy:
+        def send_command(self, *a, **k):
+            pass
+
+    with pytest.raises(RuntimeError):
+        field_zero.rezero_pot(t, FakeProxy(), v0=1.5)
+
+
+def test_run_slip_check_uses_pot_swing():
+    volts = iter([2.00, 2.15])  # pot voltage before, after a +move_deg jog
+
+    class Snap:
+        def get(self, *a):
+            return {"potmon": {"pot_az_voltage": next(volts)}}
+
+    class Motor:
+        def jog_az(self, d, **k):
+            pass
+
+    verdict, exp, meas = field_zero.run_slip_check(
+        Motor(), Snap(), slope_m=200.0, move_deg=30.0
+    )
+    assert round(exp, 4) == round(30.0 / 200.0, 4)  # 0.15 V expected
+    assert round(meas, 4) == 0.15  # 2.15 - 2.00
+    assert verdict == "ok"

--- a/tests/test_home_ref.py
+++ b/tests/test_home_ref.py
@@ -1,0 +1,21 @@
+from eigsep_redis.testing import DummyTransport
+
+from eigsep_observing.home_ref import publish_home_ref, read_home_ref
+
+
+def test_read_returns_none_when_unset():
+    assert read_home_ref(DummyTransport()) is None
+
+
+def test_round_trip():
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=1.234, imu_el_deg_home=0.5)
+    ref = read_home_ref(t)
+    assert ref["pot_az_voltage_v0"] == 1.234
+    assert ref["imu_el_deg_home"] == 0.5
+
+
+def test_imu_el_home_may_be_none():
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=2.0, imu_el_deg_home=None)
+    assert read_home_ref(t)["imu_el_deg_home"] is None

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -597,3 +597,67 @@ def test_home_and_halt_never_blocked():
     with patch.object(mc._proxy, "send_command") as send:
         mc.home()  # target steps 0 -> 0 deg, always in window
         send.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Task-3 additions: pre-move sensor fence (pot voltage / IMU el windows)
+# ---------------------------------------------------------------------------
+
+
+def _client_with_snapshot(snapshot, **kw):
+    mc = MotorClient(DummyTransport(), **kw)
+    status = {
+        "az_pos": 0,
+        "az_target_pos": 0,
+        "el_pos": 0,
+        "el_target_pos": 0,
+    }
+    mc._motor_status = lambda: status
+    mc._reader.get = lambda key: snapshot.get(key, {})
+    mc._wait_for_start = lambda *a, **k: None
+    mc._wait_for_stop = lambda *a, **k: None
+    return mc
+
+
+def test_sensor_fence_blocks_when_pot_voltage_out_of_window():
+    snap = {"potmon": {"pot_az_voltage": 3.4}}
+    mc = _client_with_snapshot(snap, pot_az_v_limits=(0.2, 3.1))
+    with patch.object(mc._proxy, "send_command") as send:
+        with pytest.raises(MotorLimitError):
+            mc.move_to(az_deg=10.0)
+        send.assert_not_called()
+
+
+def test_sensor_fence_blocks_when_imu_el_out_of_window():
+    snap = {"imu_el": {"el_deg": 40.0}}
+    mc = _client_with_snapshot(snap, imu_el_limits_deg=(-30.0, 30.0))
+    with patch.object(mc._proxy, "send_command") as send:
+        with pytest.raises(MotorLimitError):
+            mc.move_to(el_deg=5.0)
+        send.assert_not_called()
+
+
+def test_sensor_fence_passes_within_window():
+    snap = {"potmon": {"pot_az_voltage": 1.5}, "imu_el": {"el_deg": 0.0}}
+    mc = _client_with_snapshot(
+        snap, pot_az_v_limits=(0.2, 3.1), imu_el_limits_deg=(-30.0, 30.0)
+    )
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.move_to(az_deg=10.0)
+        send.assert_called_once()
+
+
+def test_sensor_fence_noop_when_limits_unset():
+    snap = {"potmon": {"pot_az_voltage": 99.0}}  # absurd, but no window set
+    mc = _client_with_snapshot(snap)  # pot_az_v_limits=None
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.move_to(az_deg=10.0)
+        send.assert_called_once()
+
+
+def test_sensor_fence_noop_when_reading_missing():
+    snap = {}  # potmon absent
+    mc = _client_with_snapshot(snap, pot_az_v_limits=(0.2, 3.1))
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.move_to(az_deg=10.0)  # no reading -> can't fence -> allowed
+        send.assert_called_once()

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -712,3 +712,37 @@ def test_reset_step_position_sends_command():
         send.assert_called_once_with(
             "reset_step_position", az_step=0, el_step=0
         )
+
+
+# ---------------------------------------------------------------------------
+# _read_fence_sensors: IMU cross-check logger suppression
+# ---------------------------------------------------------------------------
+
+
+def test_fence_sensors_passes_logger_none_to_read_el_estimate():
+    """``_read_fence_sensors`` must pass ``logger=None`` to
+    ``read_el_estimate`` so the "IMU elevation readings disagree" WARNING
+    is not emitted at ~10 Hz on the high-frequency fence-poll path.
+    ``MotorHomer._read_sensors`` keeps ``logger=self.logger`` for the
+    settle-cadence read, which surfaces disagreement at a sane rate."""
+    mc = MotorClient(DummyTransport())
+    mc._reader.get = lambda key: {}
+    captured_loggers = []
+
+    def recording_read_el(reader, *, logger=None, **kw):
+        captured_loggers.append(logger)
+        from eigsep_observing.el_sensor import ElEstimate
+
+        return ElEstimate(el_deg=None, magnitude_only=False, source=None)
+
+    with patch(
+        "eigsep_observing.motor_client.read_el_estimate",
+        side_effect=recording_read_el,
+    ):
+        mc._read_fence_sensors()
+
+    assert captured_loggers, "_read_fence_sensors must call read_el_estimate"
+    assert all(lg is None for lg in captured_loggers), (
+        "_read_fence_sensors must pass logger=None to suppress high-frequency "
+        f"IMU cross-check warnings; got: {captured_loggers}"
+    )

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -493,3 +493,43 @@ def test_scan_uses_send_and_wait_helper(client):
     # el_target_steps), so per-move serialization covers the home calls.
     assert any(a == "az_target_steps" for a, _ in calls)
     assert any(a == "el_target_steps" for a, _ in calls)
+
+
+# ---------------------------------------------------------------------------
+# Task-1 additions: MotorLimitError + per-axis limit kwargs + shared cal
+# ---------------------------------------------------------------------------
+
+
+def _client(**kw):
+    from eigsep_redis.testing import DummyTransport
+
+    return MotorClient(DummyTransport(), **kw)
+
+
+def test_motor_limit_error_is_valueerror():
+    from eigsep_observing.motor_client import MotorLimitError
+
+    assert issubclass(MotorLimitError, ValueError)
+
+
+def test_default_limits_are_symmetric_180():
+    mc = _client()
+    assert mc.az_limits_deg == (-180.0, 180.0)
+    assert mc.el_limits_deg == (-180.0, 180.0)
+    assert mc.pot_az_v_limits is None
+    assert mc.imu_el_limits_deg is None
+
+
+def test_limits_overridable():
+    mc = _client(el_limits_deg=(-30.0, 30.0), pot_az_v_limits=(0.2, 3.1))
+    assert mc.el_limits_deg == (-30.0, 30.0)
+    assert mc.pot_az_v_limits == (0.2, 3.1)
+
+
+def test_cal_motor_roundtrips_steps_deg():
+    from eigsep_observing.motor_cal import cal_motor
+
+    cal = cal_motor()
+    steps = cal.deg_to_steps(90.0)
+    assert isinstance(steps, int)
+    assert abs(cal.steps_to_deg(steps) - 90.0) < 1.0

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -14,7 +14,13 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from eigsep_observing import MotionSwitchCoordinator, MotorClient
+from eigsep_observing import (
+    MotionSwitchCoordinator,
+    MotorClient,
+    MotorLimitError,
+)
+from eigsep_observing.motor_cal import cal_motor
+from eigsep_redis.testing import DummyTransport
 
 
 SMALL_RANGE = np.array([-1.0, 0.0, 1.0])
@@ -501,14 +507,10 @@ def test_scan_uses_send_and_wait_helper(client):
 
 
 def _client(**kw):
-    from eigsep_redis.testing import DummyTransport
-
     return MotorClient(DummyTransport(), **kw)
 
 
 def test_motor_limit_error_is_valueerror():
-    from eigsep_observing.motor_client import MotorLimitError
-
     assert issubclass(MotorLimitError, ValueError)
 
 
@@ -527,8 +529,6 @@ def test_limits_overridable():
 
 
 def test_cal_motor_roundtrips_steps_deg():
-    from eigsep_observing.motor_cal import cal_motor
-
     cal = cal_motor()
     steps = cal.deg_to_steps(90.0)
     assert isinstance(steps, int)

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -661,3 +661,40 @@ def test_sensor_fence_noop_when_reading_missing():
     with patch.object(mc._proxy, "send_command") as send:
         mc.move_to(az_deg=10.0)  # no reading -> can't fence -> allowed
         send.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Task-4 additions: sensor fence polled during a move
+# ---------------------------------------------------------------------------
+
+
+def test_fence_breach_mid_move_halts_and_raises():
+    # pot voltage starts safe, then crosses the window on the 2nd poll
+    readings = [1.0, 1.0, 3.5]  # 3rd read is out of [0.2, 3.1]
+    it = iter(readings)
+
+    mc = MotorClient(DummyTransport(), pot_az_v_limits=(0.2, 3.1))
+    moving = {
+        "az_pos": 0,
+        "az_target_pos": 100,
+        "el_pos": 0,
+        "el_target_pos": 0,
+    }  # az still moving
+    mc._motor_status = lambda: dict(moving)
+
+    def fake_get(key):
+        if key == "potmon":
+            try:
+                return {"pot_az_voltage": next(it)}
+            except StopIteration:
+                return {"pot_az_voltage": 3.5}
+        return {}
+
+    mc._reader.get = fake_get
+
+    halted = []
+    mc.halt = lambda: halted.append(True)
+
+    with pytest.raises(MotorLimitError):
+        mc._wait_for_stop(timeout=5.0, axis="az")
+    assert halted, "breach must halt the motor before raising"

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -698,3 +698,17 @@ def test_fence_breach_mid_move_halts_and_raises():
     with pytest.raises(MotorLimitError):
         mc._wait_for_stop(timeout=5.0, axis="az")
     assert halted, "breach must halt the motor before raising"
+
+
+# ---------------------------------------------------------------------------
+# MotorClient.reset_step_position
+# ---------------------------------------------------------------------------
+
+
+def test_reset_step_position_sends_command():
+    mc = MotorClient(DummyTransport())
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.reset_step_position(az_step=0, el_step=0)
+        send.assert_called_once_with(
+            "reset_step_position", az_step=0, el_step=0
+        )

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -746,3 +746,67 @@ def test_fence_sensors_passes_logger_none_to_read_el_estimate():
         "_read_fence_sensors must pass logger=None to suppress high-frequency "
         f"IMU cross-check warnings; got: {captured_loggers}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Task D2: K/V limit loading + enforce_limits flag
+# ---------------------------------------------------------------------------
+
+from eigsep_observing.motor_limits import publish_motor_limits  # noqa: E402
+
+
+def test_limits_load_from_kv_when_kwargs_unset():
+    t = DummyTransport()
+    publish_motor_limits(
+        t,
+        az_limits_deg=[-90.0, 90.0],
+        el_limits_deg=[-30.0, 30.0],
+        pot_az_v_limits=[0.2, 3.1],
+        imu_el_limits_deg=None,
+    )
+    mc = MotorClient(t)
+    assert mc.az_limits_deg == [-90.0, 90.0]
+    assert mc.el_limits_deg == [-30.0, 30.0]
+    assert mc.pot_az_v_limits == [0.2, 3.1]
+    assert mc.imu_el_limits_deg is None
+
+
+def test_explicit_kwarg_overrides_kv():
+    t = DummyTransport()
+    publish_motor_limits(
+        t,
+        az_limits_deg=[-90.0, 90.0],
+        el_limits_deg=[-90.0, 90.0],
+        pot_az_v_limits=None,
+        imu_el_limits_deg=None,
+    )
+    mc = MotorClient(t, az_limits_deg=(-45.0, 45.0))
+    assert mc.az_limits_deg == (-45.0, 45.0)  # explicit wins
+    assert mc.el_limits_deg == [-90.0, 90.0]  # K/V
+
+
+def test_hardcoded_default_when_no_kv_no_kwarg():
+    mc = MotorClient(DummyTransport())  # nothing published
+    assert mc.az_limits_deg == (-180.0, 180.0)
+    assert mc.el_limits_deg == (-180.0, 180.0)
+    assert mc.pot_az_v_limits is None
+    assert mc.imu_el_limits_deg is None
+
+
+def test_enforce_limits_false_skips_commanded_guard():
+    mc = _client_seeded(el_limits_deg=(-30.0, 30.0), enforce_limits=False)
+    mc._wait_for_start = lambda *a, **k: None
+    mc._wait_for_stop = lambda *a, **k: None
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.move_to(el_deg=120.0)  # way out of window, but enforcement off
+        send.assert_called_once()
+
+
+def test_enforce_limits_false_skips_sensor_fence():
+    snap = {"potmon": {"pot_az_voltage": 99.0}}
+    mc = _client_with_snapshot(
+        snap, pot_az_v_limits=(0.2, 3.1), enforce_limits=False
+    )
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.move_to(az_deg=10.0)
+        send.assert_called_once()

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -822,3 +822,15 @@ def test_explicit_none_kwarg_disables_fence_over_kv():
     )
     mc = MotorClient(t, pot_az_v_limits=None)
     assert mc.pot_az_v_limits is None  # explicit None wins over K/V value
+
+
+def test_load_stored_limits_malformed_payload_degrades_to_empty():
+    """A non-dict K/V payload (corrupt/hand-edited key) must not raise
+    AttributeError out of MotorClient.__init__ — degrade to {} and fall
+    back to the hardcoded safe defaults."""
+    from eigsep_observing._redis_json_kv import publish_json
+
+    t = DummyTransport()
+    publish_json(t, "motor_limits", ["not", "a", "dict"])
+    mc = MotorClient(t)
+    assert mc.az_limits_deg == (-180.0, 180.0)

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -533,3 +533,67 @@ def test_cal_motor_roundtrips_steps_deg():
     steps = cal.deg_to_steps(90.0)
     assert isinstance(steps, int)
     assert abs(cal.steps_to_deg(steps) - 90.0) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Task-2 additions: commanded-target guard in _send_and_wait
+# ---------------------------------------------------------------------------
+
+
+def _client_seeded(az_target=0, el_target=0, **kw):
+    """Client whose snapshot reports a known at-rest target on both axes."""
+    mc = MotorClient(DummyTransport(), **kw)
+    status = {
+        "az_pos": az_target,
+        "az_target_pos": az_target,
+        "el_pos": el_target,
+        "el_target_pos": el_target,
+    }
+    mc._motor_status = lambda: status
+    return mc
+
+
+def test_absolute_target_deg_beyond_limit_raises_before_send():
+    mc = _client_seeded()
+    with patch.object(mc._proxy, "send_command") as send:
+        with pytest.raises(MotorLimitError):
+            mc.move_to(az_deg=200.0)
+        send.assert_not_called()
+
+
+def test_absolute_target_deg_within_limit_sends():
+    mc = _client_seeded()
+    # short-circuit the wait so the test only exercises the guard + send
+    mc._wait_for_start = lambda *a, **k: None
+    mc._wait_for_stop = lambda *a, **k: None
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.move_to(az_deg=170.0)
+        send.assert_called_once()
+
+
+def test_relative_jog_past_limit_uses_absolute_result():
+    # current target 175 deg -> a +10 jog lands at 185 -> blocked
+    cal = MotorClient(DummyTransport())._cal
+    steps_175 = cal.deg_to_steps(175.0)
+    mc = _client_seeded(az_target=steps_175)
+    with patch.object(mc._proxy, "send_command") as send:
+        with pytest.raises(MotorLimitError):
+            mc.jog_az(10.0)
+        send.assert_not_called()
+
+
+def test_el_window_narrowed_by_config():
+    mc = _client_seeded(el_limits_deg=(-30.0, 30.0))
+    with patch.object(mc._proxy, "send_command") as send:
+        with pytest.raises(MotorLimitError):
+            mc.move_to(el_deg=45.0)
+        send.assert_not_called()
+
+
+def test_home_and_halt_never_blocked():
+    mc = _client_seeded(az_target=999999, el_target=999999)  # absurd count
+    mc._wait_for_start = lambda *a, **k: None
+    mc._wait_for_stop = lambda *a, **k: None
+    with patch.object(mc._proxy, "send_command") as send:
+        mc.home()  # target steps 0 -> 0 deg, always in window
+        send.assert_called()

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -20,6 +20,7 @@ from eigsep_observing import (
     MotorLimitError,
 )
 from eigsep_observing.motor_cal import cal_motor
+from eigsep_observing.motor_limits import publish_motor_limits
 from eigsep_redis.testing import DummyTransport
 
 
@@ -752,8 +753,6 @@ def test_fence_sensors_passes_logger_none_to_read_el_estimate():
 # Task D2: K/V limit loading + enforce_limits flag
 # ---------------------------------------------------------------------------
 
-from eigsep_observing.motor_limits import publish_motor_limits  # noqa: E402
-
 
 def test_limits_load_from_kv_when_kwargs_unset():
     t = DummyTransport()
@@ -810,3 +809,16 @@ def test_enforce_limits_false_skips_sensor_fence():
     with patch.object(mc._proxy, "send_command") as send:
         mc.move_to(az_deg=10.0)
         send.assert_called_once()
+
+
+def test_explicit_none_kwarg_disables_fence_over_kv():
+    t = DummyTransport()
+    publish_motor_limits(
+        t,
+        az_limits_deg=[-180.0, 180.0],
+        el_limits_deg=[-180.0, 180.0],
+        pot_az_v_limits=[0.2, 3.1],
+        imu_el_limits_deg=None,
+    )
+    mc = MotorClient(t, pot_az_v_limits=None)
+    assert mc.pot_az_v_limits is None  # explicit None wins over K/V value

--- a/tests/test_motor_home.py
+++ b/tests/test_motor_home.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from eigsep_observing.home_ref import publish_home_ref
 from eigsep_redis.testing import DummyTransport
 
 
@@ -45,3 +46,26 @@ def test_active_driver_listed():
     mod = _ilu.module_from_spec(spec)
     spec.loader.exec_module(mod)
     assert "motor_home.py" in mod.ACTIVE_DRIVER_SCRIPTS
+
+
+def test_override_limits_disables_enforcement(monkeypatch):
+    """run(..., override_limits=True) builds MotorHomer with enforce_limits=False."""
+    import eigsep_observing
+
+    motor_home = _load("motor_home")
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=1.0, imu_el_deg_home=0.0)
+
+    captured = {}
+    orig_homer = eigsep_observing.MotorHomer
+
+    def _spy(transport, **kw):
+        captured.update(kw)
+        return orig_homer(transport, **kw)
+
+    monkeypatch.setattr(motor_home, "MotorHomer", _spy)
+    monkeypatch.setattr(motor_home, "require_pico", lambda _proxy: None)
+    # dry_run=True so we don't actually move; override_limits threads through
+    motor_home.run(t, dry_run=True, override_limits=True)
+
+    assert captured.get("enforce_limits") is False

--- a/tests/test_motor_home.py
+++ b/tests/test_motor_home.py
@@ -1,0 +1,47 @@
+"""Tests for scripts/motor_home.py."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eigsep_redis.testing import DummyTransport
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_DIRS = (
+    _REPO_ROOT / "scripts",
+    _REPO_ROOT / "src" / "eigsep_observing" / "scripts",
+)
+
+
+def _load(name):
+    for base in _SCRIPT_DIRS:
+        path = base / f"{name}.py"
+        if path.exists():
+            spec = importlib.util.spec_from_file_location(name, path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+    raise FileNotFoundError(f"{name}.py not found in {_SCRIPT_DIRS}")
+
+
+def test_errors_without_home_ref():
+    """run() raises SystemExit when no home_ref has been published."""
+    motor_home = _load("motor_home")
+    t = DummyTransport()
+    with pytest.raises(SystemExit):
+        motor_home.run(t, dry_run=True)
+
+
+def test_active_driver_listed():
+    """motor_home.py must be in the ACTIVE_DRIVER_SCRIPTS partition."""
+    import importlib.util as _ilu
+
+    spec = _ilu.spec_from_file_location(
+        "test_obs_config_uploaders",
+        _REPO_ROOT / "tests" / "test_obs_config_uploaders.py",
+    )
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert "motor_home.py" in mod.ACTIVE_DRIVER_SCRIPTS

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -1,0 +1,48 @@
+import math
+import pytest
+from eigsep_redis.testing import DummyTransport
+from eigsep_observing.motor_homer import MotorHomer, HomeResult
+
+
+def _homer(**kw):
+    return MotorHomer(DummyTransport(), motor_client=object(), **kw)
+
+
+def test_az_residual_volts_times_gain():
+    h = _homer(az_gain_deg_per_volt=100.0)
+    ref = {"pot_az_voltage_v0": 1.0, "imu_el_deg_home": 0.0}
+    # pot reads 1.1 V, home is 1.0 V -> -0.1 V -> -10 deg residual
+    assert h._az_residual_deg(ref, 1.1) == pytest.approx(-10.0)
+
+
+def test_az_residual_none_when_pot_missing():
+    h = _homer(az_gain_deg_per_volt=100.0)
+    ref = {"pot_az_voltage_v0": 1.0, "imu_el_deg_home": 0.0}
+    assert h._az_residual_deg(ref, None) is None
+
+
+def test_el_residual_signed_when_primary():
+    from eigsep_observing.el_sensor import ElEstimate
+    h = _homer()
+    ref = {"pot_az_voltage_v0": 1.0, "imu_el_deg_home": 0.0}
+    res, mag_only = h._el_residual(ref, ElEstimate(-8.0, False, "imu_el"))
+    assert res == pytest.approx(8.0)   # home(0) - (-8) = +8
+    assert mag_only is False
+
+
+def test_el_residual_magnitude_only_failover():
+    from eigsep_observing.el_sensor import ElEstimate
+    h = _homer()
+    ref = {"pot_az_voltage_v0": 1.0, "imu_el_deg_home": 0.0}
+    res, mag_only = h._el_residual(ref, ElEstimate(8.0, True, "imu_az"))
+    # magnitude-only: drive |el| toward |home|(0): residual magnitude 8
+    assert abs(res) == pytest.approx(8.0)
+    assert mag_only is True
+
+
+def test_within_tol():
+    h = _homer(tol_az_deg=3.0, tol_el_deg=2.0)
+    assert h._within_tol(2.0, 1.0) is True
+    assert h._within_tol(4.0, 1.0) is False
+    assert h._within_tol(2.0, 3.0) is False
+    assert h._within_tol(None, 1.0) is True   # axis with no reading: skip

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -194,3 +194,13 @@ def test_az_sign_autodetect_flips_when_residual_grows():
     h = _homer_with_fake(t, fake)
     res = h.home()
     assert res.converged is True
+
+
+# ---------------------------------------------------------------------------
+# Task D2: enforce_limits threading
+# ---------------------------------------------------------------------------
+
+
+def test_homer_passes_enforce_limits_to_motor_client():
+    h = MotorHomer(DummyTransport(), enforce_limits=False)
+    assert h.motor_client.enforce_limits is False

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -1,6 +1,10 @@
+import logging
+
 import pytest
 from eigsep_redis.testing import DummyTransport
-from eigsep_observing.motor_homer import MotorHomer, HomeResult
+
+from eigsep_observing.home_ref import publish_home_ref
+from eigsep_observing.motor_homer import HomeResult, MotorHomer
 
 
 def _homer(**kw):
@@ -59,3 +63,103 @@ def test_home_result_constructible():
         reset_count=True,
     )
     assert r.converged is True
+
+
+# ---------------------------------------------------------------------------
+# Task C5: home() loop tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeMotor:
+    """In-process motor whose jogs move a simulated pot voltage / el toward
+    home, so the homer's loop actually converges. gain matches the homer's
+    az gain so a damped jog shrinks the residual."""
+
+    def __init__(self, pot=1.30, el=10.0, deg_per_volt=100.0):
+        self.pot = pot
+        self.el = el
+        self.dpv = deg_per_volt
+        self.homed = 0
+        self.reset = []
+
+    def home(self, stop_event=None):
+        self.homed += 1
+
+    def jog_az(self, delta_deg, stop_event=None):
+        self.pot += delta_deg / self.dpv  # +deg lowers residual toward v0
+
+    def jog_el(self, delta_deg, stop_event=None):
+        self.el += delta_deg  # +deg moves el toward home(0)
+
+    def reset_step_position(self, az_step=0, el_step=0):
+        self.reset.append((az_step, el_step))
+
+
+def _homer_with_fake(t, fake, **kw):
+    h = MotorHomer(
+        t,
+        motor_client=fake,
+        az_gain_deg_per_volt=fake.dpv,
+        settle_s=0.0,
+        damping=1.0,
+        max_iters=10,
+        **kw,
+    )
+    # snapshot reflects the fake's live state
+    h.snapshot.get = lambda key: (
+        {"pot_az_voltage": fake.pot}
+        if key == "potmon"
+        else {"el_deg": fake.el}
+        if key == "imu_el"
+        else {}
+    )
+    return h
+
+
+def test_home_raises_without_reference():
+    h = MotorHomer(DummyTransport(), motor_client=_FakeMotor())
+    with pytest.raises(RuntimeError, match="home"):
+        h.home()
+
+
+def test_home_converges_and_resets_count():
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=1.0, imu_el_deg_home=0.0)
+    fake = _FakeMotor(pot=1.30, el=10.0)
+    h = _homer_with_fake(t, fake)
+    res = h.home()
+    assert res.converged is True
+    assert abs(res.residual_az_deg) <= h.tol_az_deg
+    assert abs(res.residual_el_deg) <= h.tol_el_deg
+    assert fake.reset == [(0, 0)]  # re-zeroed on convergence
+    assert fake.homed >= 1  # coarse approach happened
+
+
+def test_home_degrades_when_sensors_down(caplog):
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=1.0, imu_el_deg_home=0.0)
+    fake = _FakeMotor()
+    h = MotorHomer(t, motor_client=fake)
+    h.snapshot.get = lambda key: {}  # nothing published
+    with caplog.at_level(logging.WARNING):
+        res = h.home()
+    assert res.degraded is True
+    assert res.converged is False
+    assert fake.homed == 1  # open-loop fallback park
+    assert any("open-loop" in r.message for r in caplog.records)
+
+
+def test_az_sign_autodetect_flips_when_residual_grows():
+    # fake where +az jog INCREASES the residual (wrong initial sign) until
+    # the homer flips; convergence proves the flip happened.
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=1.0, imu_el_deg_home=0.0)
+
+    class _Reversed(_FakeMotor):
+        def jog_az(self, delta_deg, stop_event=None):
+            self.pot -= delta_deg / self.dpv  # opposite sign
+
+    fake = _Reversed(pot=1.20, el=0.0)
+    h = _homer_with_fake(t, fake)
+    res = h.home()
+    assert res.converged is True

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -1,4 +1,3 @@
-import math
 import pytest
 from eigsep_redis.testing import DummyTransport
 from eigsep_observing.motor_homer import MotorHomer, HomeResult
@@ -23,15 +22,17 @@ def test_az_residual_none_when_pot_missing():
 
 def test_el_residual_signed_when_primary():
     from eigsep_observing.el_sensor import ElEstimate
+
     h = _homer()
     ref = {"pot_az_voltage_v0": 1.0, "imu_el_deg_home": 0.0}
     res, mag_only = h._el_residual(ref, ElEstimate(-8.0, False, "imu_el"))
-    assert res == pytest.approx(8.0)   # home(0) - (-8) = +8
+    assert res == pytest.approx(8.0)  # home(0) - (-8) = +8
     assert mag_only is False
 
 
 def test_el_residual_magnitude_only_failover():
     from eigsep_observing.el_sensor import ElEstimate
+
     h = _homer()
     ref = {"pot_az_voltage_v0": 1.0, "imu_el_deg_home": 0.0}
     res, mag_only = h._el_residual(ref, ElEstimate(8.0, True, "imu_az"))
@@ -45,4 +46,16 @@ def test_within_tol():
     assert h._within_tol(2.0, 1.0) is True
     assert h._within_tol(4.0, 1.0) is False
     assert h._within_tol(2.0, 3.0) is False
-    assert h._within_tol(None, 1.0) is True   # axis with no reading: skip
+    assert h._within_tol(None, 1.0) is True  # axis with no reading: skip
+
+
+def test_home_result_constructible():
+    r = HomeResult(
+        converged=True,
+        iterations=2,
+        residual_az_deg=1.0,
+        residual_el_deg=0.5,
+        degraded=False,
+        reset_count=True,
+    )
+    assert r.converged is True

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 from eigsep_redis.testing import DummyTransport
 
+from eigsep_observing.el_sensor import ElEstimate
 from eigsep_observing.home_ref import publish_home_ref
 from eigsep_observing.motor_homer import HomeResult, MotorHomer
 
@@ -147,6 +148,36 @@ def test_home_degrades_when_sensors_down(caplog):
     assert res.converged is False
     assert fake.homed == 1  # open-loop fallback park
     assert any("open-loop" in r.message for r in caplog.records)
+
+
+def test_mid_loop_sensor_loss_aborts_without_rezero(caplog):
+    """If all sensors go silent inside the loop, abort with degraded=True and
+    no re-zero — re-zeroing at an unverified position is a silent wrong-success."""
+    t = DummyTransport()
+    publish_home_ref(t, pot_az_voltage_v0=1.0, imu_el_deg_home=0.0)
+    fake = _FakeMotor(pot=1.30, el=10.0)
+    h = _homer_with_fake(t, fake)
+    # Override _read_sensors so it returns valid data on the first pre-loop
+    # call (which happens before the main loop) and then all-None thereafter,
+    # triggering the mid-loop guard on iteration 1.
+    call_count = 0
+
+    def _read_sensors_stub():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # first call: pre-loop check — sensors look fine, proceed to loop
+            return fake.pot, ElEstimate(fake.el, False, "imu_el")
+        # subsequent calls (inside loop): all sensors lost
+        return None, ElEstimate(None, False, "none")
+
+    h._read_sensors = _read_sensors_stub
+    with caplog.at_level(logging.WARNING):
+        result = h.home()
+    assert result.converged is False
+    assert result.degraded is True
+    assert fake.reset == []  # step counter must NOT be re-zeroed
+    assert any("mid-loop" in r.message for r in caplog.records)
 
 
 def test_az_sign_autodetect_flips_when_residual_grows():

--- a/tests/test_motor_limits.py
+++ b/tests/test_motor_limits.py
@@ -1,0 +1,25 @@
+from eigsep_redis.testing import DummyTransport
+from eigsep_observing.motor_limits import (
+    publish_motor_limits,
+    read_motor_limits,
+)
+
+
+def test_read_none_when_unset():
+    assert read_motor_limits(DummyTransport()) is None
+
+
+def test_round_trip():
+    t = DummyTransport()
+    publish_motor_limits(
+        t,
+        az_limits_deg=[-180.0, 180.0],
+        el_limits_deg=[-30.0, 30.0],
+        pot_az_v_limits=[0.2, 3.1],
+        imu_el_limits_deg=None,
+    )
+    v = read_motor_limits(t)
+    assert v["az_limits_deg"] == [-180.0, 180.0]
+    assert v["el_limits_deg"] == [-30.0, 30.0]
+    assert v["pot_az_v_limits"] == [0.2, 3.1]
+    assert v["imu_el_limits_deg"] is None

--- a/tests/test_motor_scripts.py
+++ b/tests/test_motor_scripts.py
@@ -16,6 +16,8 @@ import time
 from argparse import Namespace
 from pathlib import Path
 
+from eigsep_redis.testing import DummyTransport
+
 import numpy as np
 import pytest
 import yaml
@@ -273,6 +275,31 @@ def test_motor_manual_helpers_exist():
     assert callable(mm._curses_main)
     assert callable(mm._parse_args)
     assert callable(mm._render)
+    assert callable(mm._build_zeroer)
+
+
+def test_motor_manual_build_zeroer_override_limits():
+    """_build_zeroer with override_limits=True builds enforce_limits=False."""
+    mm = _load("motor_manual")
+    ns = Namespace(override_limits=True)
+    zeroer = mm._build_zeroer(DummyTransport(), ns)
+    assert zeroer._motor_client.enforce_limits is False
+
+
+def test_motor_manual_build_zeroer_default_enforces_limits():
+    """_build_zeroer with override_limits=False preserves enforce_limits=True."""
+    mm = _load("motor_manual")
+    ns = Namespace(override_limits=False)
+    zeroer = mm._build_zeroer(DummyTransport(), ns)
+    assert zeroer._motor_client.enforce_limits is True
+
+
+def test_motor_manual_parse_args_accepts_override_limits(monkeypatch):
+    """_parse_args recognises --override-limits flag."""
+    mm = _load("motor_manual")
+    monkeypatch.setattr(sys, "argv", ["motor_manual", "--override-limits"])
+    args = mm._parse_args()
+    assert args.override_limits is True
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -4,7 +4,10 @@ import time
 
 import pytest
 
+from eigsep_redis.testing import DummyTransport
+
 from eigsep_observing import MotorZeroer
+from eigsep_observing.motor_client import MotorClient, MotorLimitError
 from eigsep_observing.motor_zeroer import _CAL_MOTOR, _format_pos
 
 
@@ -432,3 +435,20 @@ def test_format_pos_renders_axis_degrees():
     # Non-numeric sentinels (e.g. a missing position key) pass through
     # verbatim so a partial status dict never crashes the UI.
     assert _format_pos("?") == "?"
+
+
+def test_zeroer_jog_inherits_travel_limit():
+    # inject a MotorClient pinned near the +az edge; a further +jog must raise
+    transport = DummyTransport()
+    cal = MotorClient(transport)._cal
+    mc = MotorClient(transport)
+    steps = cal.deg_to_steps(179.0)
+    mc._motor_status = lambda: {
+        "az_pos": steps,
+        "az_target_pos": steps,
+        "el_pos": 0,
+        "el_target_pos": 0,
+    }
+    zeroer = MotorZeroer(transport, motor_client=mc)
+    with pytest.raises(MotorLimitError):
+        zeroer.jog_az(5.0)  # 179 + 5 = 184 -> outside ±180

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -462,3 +462,67 @@ def test_zeroer_jog_inherits_travel_limit():
 def test_zeroer_passes_enforce_limits_to_motor_client():
     z = MotorZeroer(DummyTransport(), enforce_limits=False)
     assert z._motor_client.enforce_limits is False
+
+
+# ---------------------------------------------------------------------------
+# Limit denials must not crash the curses loop (field finding, 2026-07-01)
+# ---------------------------------------------------------------------------
+
+
+class _LimitTrippingHomeClient:
+    """Stand-in ``MotorClient`` whose ``home`` trips the sensor fence."""
+
+    def home(self, stop_event=None):
+        raise MotorLimitError(
+            "pot_az_voltage 2.900 V outside safe window [0.500, 2.500]; "
+            "refusing az move."
+        )
+
+
+def test_handle_key_swallows_limit_error_and_sets_notice(client):
+    """A jog denied by the travel guard must not escape handle_key —
+    the curses loop stays alive — and the denial must be surfaced via
+    ``notice`` (console logging is off in the manual scripts, so a
+    log-only warning is invisible mid-session)."""
+    zeroer = _zeroer(client.transport)
+    motor = client._manager.picos["motor"]
+    before = motor._emulator.azimuth.target_pos
+    # 200 deg from home is outside the ±180 default window.
+    new_deg, should_exit, zeroed = zeroer.handle_key(ord("l"), 200.0)
+    assert (new_deg, should_exit, zeroed) == (200.0, False, False)
+    assert "outside safe window" in zeroer.notice
+    assert motor._emulator.azimuth.target_pos == before  # move refused
+
+
+def test_handle_key_successful_jog_clears_notice(client):
+    zeroer = _zeroer(client.transport)
+    zeroer.handle_key(ord("l"), 200.0)  # denied — notice set
+    assert zeroer.notice is not None
+    zeroer.handle_key(ord("l"), 1.0)  # in-window jog succeeds
+    assert zeroer.notice is None
+
+
+def test_handle_key_jog_failure_sets_notice(client, monkeypatch):
+    """Non-limit jog failures (already swallowed today) must also
+    surface on screen, not just in the invisible log file."""
+    zeroer = _zeroer(client.transport)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("unrelated firmware error")
+
+    monkeypatch.setattr(zeroer._motor_client._proxy, "send_command", boom)
+    _, should_exit, _ = zeroer.handle_key(ord("l"), 1.0)
+    assert should_exit is False
+    assert "unrelated firmware error" in zeroer.notice
+
+
+def test_start_home_survives_limit_error(client):
+    """A sensor-fence trip mid-home must unwind the background thread
+    cleanly (no traceback splatted over the curses screen) and surface
+    the denial via ``notice``."""
+    zeroer = MotorZeroer(
+        client.transport, motor_client=_LimitTrippingHomeClient()
+    )
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
+    assert "outside safe window" in zeroer.notice

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -452,3 +452,13 @@ def test_zeroer_jog_inherits_travel_limit():
     zeroer = MotorZeroer(transport, motor_client=mc)
     with pytest.raises(MotorLimitError):
         zeroer.jog_az(5.0)  # 179 + 5 = 184 -> outside ±180
+
+
+# ---------------------------------------------------------------------------
+# Task D2: enforce_limits threading
+# ---------------------------------------------------------------------------
+
+
+def test_zeroer_passes_enforce_limits_to_motor_client():
+    z = MotorZeroer(DummyTransport(), enforce_limits=False)
+    assert z._motor_client.enforce_limits is False

--- a/tests/test_obs_config_uploaders.py
+++ b/tests/test_obs_config_uploaders.py
@@ -34,6 +34,7 @@ UPLOADER_SCRIPTS = {
 # read snapshots and must coexist, so they live in RUN_TAG_EXEMPT.
 ACTIVE_DRIVER_SCRIPTS = {
     "field_zero.py",
+    "motor_home.py",
     "vna_manual.py",
     "rfswitch_manual.py",
     "tempctrl_manual.py",

--- a/tests/test_obs_config_uploaders.py
+++ b/tests/test_obs_config_uploaders.py
@@ -70,6 +70,12 @@ ACTIVE_DRIVER_SCRIPTS = {
 #     K/V to the local Redis, drives no hardware, and must keep
 #     running through manual sessions and corr-only operation — the
 #     same coexistence reasoning as the dashboards.
+#   - set_motor_limits.py: rig-wide motor-limit admin tool. Writes a
+#     dedicated MotorLimitStore K/V (not obs_config), drives no motor,
+#     and writes no files, so it changes none of the always-recording
+#     physical state and has no provenance to record. A one-shot config
+#     tool that must coexist with whatever is running, so it must not
+#     claim the refuse-on-conflict tag.
 RUN_TAG_EXEMPT = {
     "live_status.py",
     "live_plotter.py",
@@ -87,6 +93,7 @@ RUN_TAG_EXEMPT = {
     "pico_preflight.py",
     "clear_run_tag.py",
     "host_health.py",
+    "set_motor_limits.py",
 }
 
 

--- a/tests/test_obs_config_uploaders.py
+++ b/tests/test_obs_config_uploaders.py
@@ -33,6 +33,7 @@ UPLOADER_SCRIPTS = {
 # alt-mode vna_position_sweep). Passive readouts are NOT here; they only
 # read snapshots and must coexist, so they live in RUN_TAG_EXEMPT.
 ACTIVE_DRIVER_SCRIPTS = {
+    "field_zero.py",
     "vna_manual.py",
     "rfswitch_manual.py",
     "tempctrl_manual.py",

--- a/tests/test_set_motor_limits.py
+++ b/tests/test_set_motor_limits.py
@@ -66,3 +66,54 @@ def test_run_no_pot_fence_maps_to_none():
     v = read_motor_limits(t)
     assert v["pot_az_v_limits"] is None
     assert v["imu_el_limits_deg"] is None
+
+
+def test_partial_set_preserves_other_fields():
+    """A partial run() call merges with existing limits; unspecified fields
+    are preserved from the K/V store rather than reverted to defaults."""
+    sml = _load("set_motor_limits")
+    t = DummyTransport()
+    # Establish a full set first.
+    sml.publish_from_args(
+        t,
+        az_limits=[-180.0, 180.0],
+        el_limits=[-30.0, 30.0],
+        pot_az_v=[0.1, 3.0],
+        imu_el=[-25.0, 25.0],
+    )
+    # Partial update: only pot_az_v changes; az/el/imu_el must survive.
+    sml.run(
+        t,
+        Namespace(
+            show=False,
+            az_limits=None,
+            el_limits=None,
+            pot_az_v=[0.2, 3.1],
+            no_pot_fence=False,
+            imu_el=None,
+            no_imu_fence=False,
+        ),
+    )
+    v = read_motor_limits(t)
+    assert v["el_limits_deg"] == [-30.0, 30.0]  # unchanged
+    assert v["pot_az_v_limits"] == [0.2, 3.1]  # updated
+
+
+def test_set_path_prints(capsys):
+    """run() on a set path must print the confirmation to stdout."""
+    sml = _load("set_motor_limits")
+    t = DummyTransport()
+    sml.run(
+        t,
+        Namespace(
+            show=False,
+            az_limits=[-180.0, 180.0],
+            el_limits=[-30.0, 30.0],
+            pot_az_v=None,
+            no_pot_fence=False,
+            imu_el=None,
+            no_imu_fence=False,
+        ),
+    )
+    out = capsys.readouterr().out
+    assert "Published motor limits:" in out

--- a/tests/test_set_motor_limits.py
+++ b/tests/test_set_motor_limits.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+
+from eigsep_redis.testing import DummyTransport
+from eigsep_observing.motor_limits import read_motor_limits
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name):
+    path = _REPO / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_publishes_limits():
+    sml = _load("set_motor_limits")
+    t = DummyTransport()
+    sml.publish_from_args(
+        t,
+        az_limits=[-180.0, 180.0],
+        el_limits=[-30.0, 30.0],
+        pot_az_v=[0.2, 3.1],
+        imu_el=None,
+    )
+    v = read_motor_limits(t)
+    assert v["el_limits_deg"] == [-30.0, 30.0]
+    assert v["pot_az_v_limits"] == [0.2, 3.1]
+    assert v["imu_el_limits_deg"] is None

--- a/tests/test_set_motor_limits.py
+++ b/tests/test_set_motor_limits.py
@@ -1,4 +1,5 @@
 import importlib.util
+from argparse import Namespace
 from pathlib import Path
 
 from eigsep_redis.testing import DummyTransport
@@ -28,4 +29,40 @@ def test_publishes_limits():
     v = read_motor_limits(t)
     assert v["el_limits_deg"] == [-30.0, 30.0]
     assert v["pot_az_v_limits"] == [0.2, 3.1]
+    assert v["imu_el_limits_deg"] is None
+
+
+def test_run_show_prints_limits(capsys):
+    sml = _load("set_motor_limits")
+    t = DummyTransport()
+    sml.publish_from_args(
+        t,
+        az_limits=[-180.0, 180.0],
+        el_limits=[-30.0, 30.0],
+        pot_az_v=[0.2, 3.1],
+        imu_el=[-30.0, 30.0],
+    )
+    sml.run(t, Namespace(show=True))
+    out = capsys.readouterr().out
+    assert "Current motor limits:" in out
+    assert "unset" not in out
+
+
+def test_run_no_pot_fence_maps_to_none():
+    sml = _load("set_motor_limits")
+    t = DummyTransport()
+    sml.run(
+        t,
+        Namespace(
+            show=False,
+            az_limits=[-180.0, 180.0],
+            el_limits=[-30.0, 30.0],
+            pot_az_v=[0.2, 3.1],
+            no_pot_fence=True,
+            imu_el=None,
+            no_imu_fence=True,
+        ),
+    )
+    v = read_motor_limits(t)
+    assert v["pot_az_v_limits"] is None
     assert v["imu_el_limits_deg"] is None


### PR DESCRIPTION
## Summary

Field-zero / motor-safety / homing work for the suspended antenna, in three layers that build on each other:

1. **`field_zero` operator script** — verify the pot tracks, set the operational az/el zero interactively, re-pin the pot calibration intercept in the hanging pose.
2. **Motor travel-limit guard** — make it *structurally* impossible for any mover to drive an axis outside a safe window.
3. **Closed-loop homing** — drive the antenna back to a known home using pot/IMU feedback, settling between moves, and re-zero the open-loop step counter on convergence.

All three are hardware-free testable (`Dummy*` + `DummyTransport`); constants that need a rig are documented and defaulted.

## 1. `field_zero` operator script

Slip-check probe (there-and-back move, 5% warn / 10% fail verdict bands) → interactive jog-to-zero (curses) → motor-origin reset + pot intercept re-pin (`angle(v0)=0`, BGSAVE + live push). Self-contained active driver: claims `run_tag`, talks to hardware only via `PicoProxy`/`MotorClient`, requires `pico-manager`.

## 2. Motor travel-limit guard (every mover inherits it)

Two layers, both wired into `MotorClient`'s single move funnel (`_send_and_wait` / `_wait_for_stop`), so `move_to`/`home`/`jog`/`scan` and the homer's jogs all inherit them:

- **Commanded-target guard** — rejects a move whose *resulting absolute* position leaves `[-180, 180]°` (revolution-aware via step count), raising `MotorLimitError` **before** the command is sent.
- **Sensor fence** — pre-move + polled mid-move, against a raw **pot-voltage window** (az) and an **IMU `el_deg` window** (el); a breach halts the motor, then raises. Catches open-loop step drift the commanded guard can't see.

Limits are per-axis `MotorClient` kwargs flowing through the existing `motor_client_kwargs` config path; defaults ±180 / null pot fence. `MotorLimitError` is a `ValueError`, re-exported from the package.

**Asymmetry (deliberate):** elevation does a full 360° sweep, so any single-sample angle sensor folds at ±180 — the **commanded-target guard is the real el over-rotation protection**; the IMU el fence is a consistency cross-check. Azimuth's pot is bounded/non-wrapping, so the pot fence *is* true absolute az protection.

## 3. Closed-loop homing

- **`home_ref` Redis K/V** (`_redis_json_kv` sibling) — az home = raw pot voltage `v0` (slope-independent), el home = signed `imu_el`. Written by `field_zero` on a confirmed zero (new `--no-slip-check` flag skips step 1).
- **`read_el_estimate`** — signed `imu_el` primary, `imu_az` `|θ|` magnitude-only failover; never averaged; cross-check warns on divergence.
- **`MotorHomer`** — coarse open-loop approach → interruptible settle → measure → damped corrective jog (az then el, one motor at a time) with az/el **sign auto-detect** → converge → `reset_step_position` (self-healing zero). Degrades to open-loop `home()` + loud WARNING if sensors are down; guards mid-loop total-sensor-loss (no false convergence / no re-zero at an unverified pose).
- **`scripts/motor_home.py`** — standalone active driver (claims `run_tag`); errors if no `home_ref` (run `field_zero` first).
- **`PandaClient.motor_loop`** — closed-loop homer on the **healthy** post-scan park (config `home_after_scan`); the failure/recovery park stays open-loop (sensors may be the fault).

## 4. Rig-wide limits + recovery override

The travel limits are a property of the **rig**, not of one process, so they live in a dedicated `MotorLimitStore` Redis K/V that **every** `MotorClient` reads — the autonomous observer *and* every bring-up script (`motor_manual`, `motor_scan`, `field_zero`, `motor_home`). (Previously the limits lived in observer-owned `obs_config`, so bring-up tools were bounded only by the hardcoded ±180 default and had no sensor fence.)

- **`MotorLimitStore` K/V** (`motor_limits.py`) — single source of truth; `MotorClient.__init__` loads it by default. Precedence: explicit kwarg > K/V value > hardcoded default (`±180` / `None` fences). A Redis `ConnectionError` or a malformed (non-dict) payload → safe defaults; construction never crashes.
- **`scripts/set_motor_limits.py`** — operator tool to set/inspect the K/V. **Read-modify-write** (a partial set only changes the windows you specify — no silent widening of unspecified limits), `--no-pot-fence` / `--no-imu-fence` to disable a fence, prints the full resulting window to stdout. Writes the dedicated K/V, not obs_config. On a fresh rig (K/V unset) the safe `±180` / no-fence defaults apply everywhere until it's run once.
- **`enforce_limits` + `--override-limits`** — a **per-session** recovery flag on `motor_manual`, `motor_home`, and `field_zero` builds that run's driver with both guard layers off (loud WARNING), so an operator can jog back from an out-of-window pose. Nothing is persisted — enforcement auto-restores when the tool exits (a persistent global disable was deliberately rejected as too dangerous).
- obs_config drops the four limit keys (`motor_client_kwargs: {}`).

## Design notes

- **Az homing is calibration-slope-independent by design:** home = pot returns to raw `v0`; the known ~30%-off pot cal slope is used *only* as a corrective gain magnitude, with damping < 1 + sign-auto-detect absorbing it. The cal still needs fixing upstream, but homing doesn't wait on it.
- **No firmware change:** the rig kinematics (el = whole box on a hanging axis, full 360° sweep, both IMUs feel it; az = turntable on top, only `imu_az` rides it) make `imu_el` an azimuth-invariant signed-el source and `imu_az` sign-degenerate (`|θ|`). A single accelerometer can't recover el sign over a 360° sweep (and fused pitch/roll is ±90°-capped), so `imu_az` can only ever be a magnitude-only failover — which is sufficient for symmetric-fence + homing-to-zero.

## Final whole-feature review fix

A whole-branch review caught one cross-cutting bug the per-task reviews missed: `MotorLimitError` (a `ValueError`) was escaping `motor_loop`'s `(TimeoutError, RuntimeError)` handlers, which would silently kill the autonomous motor thread the moment an operator narrows a limit. Fixed by absorbing it loudly (`_MOTOR_LOOP_ERRORS`) and parking, plus symmetric `motor_homer_kwargs` validation and silencing the IMU cross-check warning on the high-frequency fence path.

## Testing

TDD throughout, dummies over mocks, `caplog` for warnings. New/extended: `test_motor_client`, `test_motor_zeroer`, `test_motor_homer`, `test_home_ref`, `test_el_sensor`, `test_field_zero`, `test_motor_home`, `test_client`, `test_obs_config_uploaders` (motor_home registered as an active driver). Each task's targeted tests were run green; full suite runs in CI.

## Hardware tuning / follow-ups (not blocking)

- `settle_s`, `damping`, tolerances, and `max_iters` ship with documented defaults and need on-rig tuning. The **rig limits** (commanded windows + pot-voltage / IMU-el fence endpoints) are set once per rig via `scripts/set_motor_limits.py` (measure pot V at the safe az extremes); until set, the safe ±180 commanded guard applies everywhere and the sensor fences are off.
- Minor follow-ups noted in review: a relative-jog limit check falls back to position 0 when motor status is momentarily absent; the sensor fence has no move-direction notion (refuses a corrective move out of an out-of-window pose — moot at the default null/±180 windows); a couple of cosmetic test-coverage/docstring gaps.

## Field-test hardening (2026-07-01)

First on-rig session with this branch surfaced three issues, fixed in the last four commits:

- **Denied moves crashed the curses UIs** (`c6e95eb`): `MotorLimitError` is a `ValueError`, so it escaped `handle_key`'s `(RuntimeError, TimeoutError)` catch and killed `motor_manual` / `field_zero` — the same class of escape the whole-branch review caught in `motor_loop`. Now caught in the keystroke jog path and the background home thread, with a new `zeroer.notice` line rendered on-screen (both scripts log with `console=False`, so log-only warnings are invisible mid-session).
- **Slip verdict mis-diagnosed overshoot as slip** (`fe74245`): the symmetric `|measured−expected|` band denied a real field zero whose pot swing was *larger* than expected. Slip/stall can only under-travel the pot; overshoot means the stored slope is stale. Shortfall keeps the warn=5%/fail=10% slip bands; overshoot ≥5% is a new non-blocking `"overshoot"` verdict pointing at `calibrate-pot`.
- **Operator override on failed slip check** (`a0f0eb6`): pot coupling often can't be fixed in the field and the zero itself is slope-independent (raw `v0` + intercept re-pin), so a `"fail"` now shows the numbers and asks `[y/N]` instead of hard-exiting; explicit yes proceeds with a loud OPERATOR OVERRIDE log line, EOF/non-tty aborts.
- **Probe-move denials exit cleanly** (`16f8153`): `run_slip_check`'s there-and-back jogs ride the travel guard too; a denial now raises an actionable `SystemExit` with recovery options (`motor_manual`, `--override-limits`, `--no-slip-check`) instead of a raw traceback, noting the rig may be left off-position mid-probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

