### PR TITLE
feat(live_status): Antenna pointing panel with sensor-spread drift/stall alarm

### DIFF
--- a/src/eigsep_observing/config/live_status_thresholds.yaml
+++ b/src/eigsep_observing/config/live_status_thresholds.yaml
@@ -50,6 +50,15 @@ lidar.distance_m:
 potmon.pot_az_angle:
   healthy: null  # TODO
 
+# Antenna orientation — motor/pot/IMU sensor spread (consensus is
+# display-only, no band).
+orientation.az_spread_deg:
+  healthy: [0.0, 3.0]
+  danger:  [0.0, 10.0]
+orientation.el_spread_deg:
+  healthy: [0.0, 3.0]
+  danger:  [0.0, 10.0]
+
 # Escape hatch: any entry here overrides the derived default for that
 # signal. Example:
 # tempctrl_lna.T_now:

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -12,6 +12,7 @@ Flask-Login problem.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import math
 import time
@@ -19,6 +20,7 @@ from typing import Any, Optional
 
 import numpy as np
 from flask import Flask, Response, jsonify, render_template, request
+from picohost.motor import PicoMotor
 from plotly.offline import get_plotlyjs
 
 from .aggregator import (
@@ -33,6 +35,7 @@ from .calibration import (
 )
 from ..io import pair_label
 from ..vna_calibration import VnaCache, calibrate_s11
+from .orientation import compute_orientation
 from .signals import enabled_signals
 from .thresholds import Thresholds
 
@@ -42,6 +45,24 @@ logger = logging.getLogger(__name__)
 
 CELSIUS_TO_KELVIN = 273.15
 T_REF_K = 290.0  # IEEE ENR reference temperature
+
+
+def _default_ori_motor():
+    """Serial-less :class:`~picohost.motor.PicoMotor` for steps→degrees.
+
+    Mirrors :func:`eigsep_observing.motor_zeroer._default_cal_motor`:
+    ``PicoMotor.__new__`` bypass (no serial I/O) + constructor-default
+    geometry attributes so ``steps_to_deg`` matches the firmware's own
+    ``deg_to_steps`` exactly without duplicating the gear constants here.
+    """
+    sig = inspect.signature(PicoMotor.__init__)
+    motor = PicoMotor.__new__(PicoMotor)
+    for attr in ("step_angle_deg", "gear_teeth", "microstep"):
+        setattr(motor, attr, sig.parameters[attr].default)
+    return motor
+
+
+_ORI_MOTOR = _default_ori_motor()
 
 
 def _envelope(data: Any, warnings: Optional[list] = None) -> dict:
@@ -358,6 +379,21 @@ def _metadata_payload(state: StateSnapshot, thresholds: Thresholds) -> dict:
             "status": status,
             "classify": classify_by_sig,
         }
+    ori = compute_orientation(out, _ORI_MOTOR.steps_to_deg)
+    out["orientation"] = {
+        "value": ori,
+        "ts_unix": None,
+        "age_s": None,
+        "status": None,
+        "classify": {
+            "orientation.az_spread_deg": thresholds.classify(
+                "orientation.az_spread_deg", ori["az"].get("spread")
+            ),
+            "orientation.el_spread_deg": thresholds.classify(
+                "orientation.el_spread_deg", ori["el"].get("spread")
+            ),
+        },
+    }
     return out
 
 

--- a/src/eigsep_observing/live_status/orientation.py
+++ b/src/eigsep_observing/live_status/orientation.py
@@ -1,0 +1,51 @@
+"""Antenna pointing: per-sensor az/el consensus for the live-status panel.
+
+Pure computation (no Flask/Redis). Turns the /api/metadata per-sensor payload
+into az/el degrees for each sensor that reports them, plus a median consensus
+and the max-min spread. The spread is the live drift/stall signal; the
+consensus is display-only (the authoritative weighted estimate is a
+post-processing concern, not a live decision).
+"""
+
+import numpy as np
+
+
+def _val(metadata, sensor, field):
+    entry = metadata.get(sensor)
+    if not entry:
+        return None
+    v = (entry.get("value") or {}).get(field)
+    return float(v) if isinstance(v, (int, float)) else None
+
+
+def _reduce(values):
+    pts = {k: v for k, v in values.items() if v is not None}
+    if not pts:
+        return {}
+    out = dict(pts)
+    nums = list(pts.values())
+    out["consensus"] = float(np.median(nums))
+    out["spread"] = float(max(nums) - min(nums)) if len(nums) >= 2 else None
+    return out
+
+
+def compute_orientation(metadata, steps_to_deg):
+    """Per-sensor az/el in degrees + median consensus + spread.
+
+    metadata: the /api/metadata per-sensor dict ({sensor: {"value": {...}}}).
+    steps_to_deg: callable mapping motor steps -> degrees (single source of
+    truth = the firmware geometry). Sensors absent or non-numeric are omitted.
+    """
+    az_pos = _val(metadata, "motor", "az_pos")
+    el_pos = _val(metadata, "motor", "el_pos")
+    az = {
+        "motor": steps_to_deg(az_pos) if az_pos is not None else None,
+        "potmon": _val(metadata, "potmon", "pot_az_angle"),
+        "imu_az": _val(metadata, "imu_az", "az_deg"),
+    }
+    el = {
+        "motor": steps_to_deg(el_pos) if el_pos is not None else None,
+        "imu_az": _val(metadata, "imu_az", "el_deg"),
+        "imu_el": _val(metadata, "imu_el", "el_deg"),
+    }
+    return {"az": _reduce(az), "el": _reduce(el)}

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -163,6 +163,32 @@ SIGNAL_REGISTRY: dict[str, Signal] = {
         "Potmon azimuth angle",
         unit="deg",
     ),
+    # Antenna orientation — motor/pot/IMU consensus and spread.
+    # Recomputed each tick from live metadata (no stream _ts).
+    "orientation.az_consensus_deg": Signal(
+        "orientation.az_consensus_deg",
+        "Azimuth (consensus)",
+        unit="deg",
+        max_age_s=None,
+    ),
+    "orientation.el_consensus_deg": Signal(
+        "orientation.el_consensus_deg",
+        "Elevation (consensus)",
+        unit="deg",
+        max_age_s=None,
+    ),
+    "orientation.az_spread_deg": Signal(
+        "orientation.az_spread_deg",
+        "Azimuth sensor spread",
+        unit="deg",
+        max_age_s=None,
+    ),
+    "orientation.el_spread_deg": Signal(
+        "orientation.el_spread_deg",
+        "Elevation sensor spread",
+        unit="deg",
+        max_age_s=None,
+    ),
 }
 
 

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -725,6 +725,40 @@ function renderMotor(meta) {
   }
 }
 
+function renderOrientation(meta) {
+  const container = document.getElementById("orientation-block");
+  if (!container) return;
+  container.replaceChildren();
+  const entry = meta["orientation"];
+  if (!entry) {
+    container.textContent = "no orientation data";
+    return;
+  }
+  const v = entry.value || { az: {}, el: {} };
+  const cls = entry.classify || {};
+  for (const [axis, key] of [
+    ["az", "orientation.az_spread_deg"],
+    ["el", "orientation.el_spread_deg"],
+  ]) {
+    const d = v[axis] || {};
+    for (const s of ["motor", "potmon", "imu_az", "imu_el"]) {
+      if (d[s] === undefined) continue;
+      appendValueRow(container, `${axis} ${s}`, fmt(d[s], 1) + "°");
+    }
+    if (d.consensus !== undefined) {
+      appendValueRow(
+        container, `${axis} consensus`, fmt(d.consensus, 1) + "°"
+      );
+    }
+    const spreadCls = cls[key] || "unknown";
+    const spreadTxt =
+      d.spread === null || d.spread === undefined
+        ? "—"
+        : fmt(d.spread, 1) + "°";
+    appendTileRow(container, `${axis} spread`, tileClass(spreadCls), spreadTxt);
+  }
+}
+
 function renderPotmon(meta) {
   const container = document.getElementById("potmon-block");
   if (!container) return;
@@ -934,6 +968,7 @@ async function tick() {
     renderTempctrlTiles(metadata.data, null);
     renderImu(metadata.data);
     renderMotor(metadata.data);
+    renderOrientation(metadata.data);
     renderPotmon(metadata.data);
     renderLidar(metadata.data);
     renderSystemCurrent(metadata.data);

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -98,6 +98,11 @@
     </div>
   </section>
 
+  <section class="card wide">
+    <h2>Antenna pointing</h2>
+    <div id="orientation-block"></div>
+  </section>
+
   <section class="card">
     <h2>RF switch</h2>
     <div id="rfswitch"></div>

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1377,6 +1377,74 @@ def test_vna_drain_drops_payload_with_unknown_mode(agg_primed, caplog):
     )
 
 
+def test_metadata_payload_orientation_agree_and_diverge():
+    """_metadata_payload attaches an orientation entry with classified spread.
+
+    Agreeing sensors (spread ~0.5 deg) -> az_spread classified "ok";
+    diverging sensors (~12 deg off) -> classified "danger".
+    """
+    import inspect
+
+    from picohost.motor import PicoMotor
+
+    from eigsep_observing.live_status.aggregator import StateSnapshot
+    from eigsep_observing.live_status.app import _metadata_payload
+
+    # Build a serial-less PicoMotor for geometry (same pattern as
+    # motor_zeroer._default_cal_motor) to get the real steps_to_deg.
+    sig = inspect.signature(PicoMotor.__init__)
+    cal = PicoMotor.__new__(PicoMotor)
+    for attr in ("step_angle_deg", "gear_teeth", "microstep"):
+        setattr(cal, attr, sig.parameters[attr].default)
+    # Round-trip through the real geometry: ~100 deg.
+    az_steps = int(round(100 * cal.gear_teeth / cal.step_angle_deg))
+    motor_az_deg = cal.steps_to_deg(az_steps)  # ~100.004 deg
+
+    now = 1000.0
+
+    def make_state(pot_az):
+        state = StateSnapshot()
+        state.metadata_snapshot = {
+            "motor": {
+                "sensor_name": "motor",
+                "status": "update",
+                "az_pos": az_steps,
+                "el_pos": 0,
+            },
+            "motor_ts": now,
+            "potmon": {
+                "sensor_name": "potmon",
+                "status": "update",
+                "pot_az_angle": pot_az,
+            },
+            "potmon_ts": now,
+            "imu_az": {
+                "sensor_name": "imu_az",
+                "status": "update",
+                "az_deg": 100.0,
+                "el_deg": 0.0,
+            },
+            "imu_az_ts": now,
+        }
+        state.metadata_snapshot_read_unix = now
+        return state
+
+    # Agreeing sensors: spread = 100.5 - 100.0 = 0.5 -> "ok" (< 3).
+    out = _metadata_payload(make_state(100.5), _payload_thresholds())
+    ori = out["orientation"]
+    assert "az" in ori["value"] and "el" in ori["value"]
+    assert ori["classify"]["orientation.az_spread_deg"] == "ok"
+
+    # Diverging: potmon ~12 deg off -> spread > 10 -> "danger".
+    out2 = _metadata_payload(
+        make_state(motor_az_deg + 12.0), _payload_thresholds()
+    )
+    assert (
+        out2["orientation"]["classify"]["orientation.az_spread_deg"]
+        == "danger"
+    )
+
+
 def test_metadata_payload_classifies_system_current():
     """A system_current snapshot entry is classified against the
     current_a band by the existing /api/metadata projection (no app.py

--- a/tests/test_live_status_orientation.py
+++ b/tests/test_live_status_orientation.py
@@ -3,6 +3,21 @@
 from eigsep_observing.live_status import orientation
 
 
+def test_orientation_signals_registered():
+    from eigsep_observing.live_status.signals import SIGNAL_REGISTRY
+
+    for name in (
+        "orientation.az_consensus_deg",
+        "orientation.el_consensus_deg",
+        "orientation.az_spread_deg",
+        "orientation.el_spread_deg",
+    ):
+        assert name in SIGNAL_REGISTRY
+    # spread signals disable staleness (recomputed each tick)
+    assert SIGNAL_REGISTRY["orientation.az_spread_deg"].max_age_s is None
+    assert SIGNAL_REGISTRY["orientation.el_spread_deg"].max_age_s is None
+
+
 def test_compute_orientation_consensus_and_spread():
     meta = {
         "motor": {"value": {"az_pos": 8000.0, "el_pos": 960.0}},

--- a/tests/test_live_status_orientation.py
+++ b/tests/test_live_status_orientation.py
@@ -1,0 +1,33 @@
+"""Test compute_orientation for live-status antenna pointing panel."""
+
+from eigsep_observing.live_status import orientation
+
+
+def test_compute_orientation_consensus_and_spread():
+    meta = {
+        "motor": {"value": {"az_pos": 8000.0, "el_pos": 960.0}},
+        "potmon": {"value": {"pot_az_angle": 100.5}},
+        "imu_az": {"value": {"az_deg": 100.0, "el_deg": 12.0}},
+        "imu_el": {"value": {"el_deg": 12.4}},
+    }
+    out = orientation.compute_orientation(
+        meta, steps_to_deg=lambda s: s / 80.0
+    )
+    # az sources: motor 8000/80=100.0, potmon 100.5, imu_az 100.0
+    assert out["az"]["motor"] == 100.0
+    assert out["az"]["potmon"] == 100.5
+    assert out["az"]["consensus"] == 100.0  # median([100.0,100.5,100.0])
+    assert round(out["az"]["spread"], 3) == 0.5  # 100.5 - 100.0
+    # el sources: motor 960/80=12.0, imu_az 12.0, imu_el 12.4
+    assert out["el"]["consensus"] == 12.0
+    assert round(out["el"]["spread"], 3) == 0.4
+
+
+def test_compute_orientation_omits_missing():
+    meta = {"imu_el": {"value": {"el_deg": 12.4}}}  # only one el source
+    out = orientation.compute_orientation(
+        meta, steps_to_deg=lambda s: s / 80.0
+    )
+    assert out["az"] == {}  # no az sources
+    assert out["el"]["consensus"] == 12.4
+    assert out["el"]["spread"] is None  # <2 sources


### PR DESCRIPTION
## What

Adds an **"Antenna pointing"** card to the live-status dashboard: each sensor's
azimuth/elevation in degrees, a median consensus, and an az/el **spread** tile
that goes amber/red when the sensors disagree. This implements the
previously-deferred motor/antenna **drift-stall warning**.

## Why

After calibration, motor (`az_pos`→deg), potmon (`pot_az_angle`), `imu_az`
(`az_deg`/`el_deg`), and `imu_el` (`el_deg`) all estimate the same az/el. The
live value isn't any single number — it's **whether they agree**. Disagreement
is the diagnostic for pot slip, motor stall, or a shifted IMU mount.

## Design

- **Live shows + flags disagreement only.** Consensus is display-only (median);
  the authoritative weighted estimate stays a post-processing concern, not a
  live decision.
- **Spread = max−min**, classified via the existing thresholds system
  (`[0,3]` ok, `[0,10]` danger). Missing/None sensors are omitted; an axis with
  <2 sources shows spread `—` / `unknown`.
- **Motor steps→deg** uses `PicoMotor` constructor-default geometry (the same
  constant the motor system uses), so a future geometry correction is tracked
  automatically — and any mismatch simply shows up as motor-vs-others spread.

## Notes

- **No schema or picohost-pin change** (separate from the IMU schema-split PR).
  IMU `az_deg`/`el_deg` are read opportunistically from the live snapshot —
  absent/`None` until the IMU is calibrated (picohost ≥3.10), so those rows
  just don't appear in the interim (az falls back to motor+potmon, el to
  motor-only). Consumer-safe with current picohost.
- Plotter (rolling time-series overlay) intentionally deferred to a phase 2.

## Changes
- `live_status/orientation.py` — pure `compute_orientation` (no Flask/Redis).
- 4 signals + 2 spread threshold bands.
- `_metadata_payload` attaches the classified `orientation` entry.
- `renderOrientation` + the "Antenna pointing" card.

## Tests
New `test_live_status_orientation.py` + 1 new app test; full live_status suite
green (129 passed); ruff clean; `node --check` clean on dashboard.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
