### PR TITLE
feat(io): embed IMU mount calibration in corr + VNA file headers (#176)

### DIFF
--- a/docs/field_calibration.md
+++ b/docs/field_calibration.md
@@ -155,8 +155,15 @@ unless you copy `dump.rdb`.
    `pot_az_cal_slope` / `pot_az_cal_intercept` at record time. Read them off a
    recent file and re-enter them:
    `calibrate-pot --mode manual --slope <m> --intercept <b>`.
-3. **IMU cal:** re-run `calibrate-imu` (an IMU mount matrix isn't something you
-   hand-type).
+3. **IMU cal, from file:** every recorded corr *and* VNA `.h5` embeds the full
+   `imu_calibration` blob at `header["imu_calibration"]` (and
+   `header["imu_calibration_upload_unix"]`, unix seconds, for staleness).
+   Read it off a recent file and re-upload via picohost `ImuCalStore` — this
+   is now preferred since the mount matrix isn't hand-typeable. If
+   `imu_calibration == {}` or `imu_calibration_upload_unix == 0.0` (that file
+   caught the panda down or uncalibrated), re-run `calibrate-imu` instead.
+   Note: standalone `metadata_*.h5` files do not carry this blob (no header
+   group).
 4. Then re-zero with `field_zero.py`.
 
 ---

--- a/src/eigsep_observing/_redis_json_kv.py
+++ b/src/eigsep_observing/_redis_json_kv.py
@@ -1,14 +1,16 @@
 """Shared publish/read shape for the single-key Redis JSON K/V modules.
 
-Five sibling modules ride this shape — :mod:`~eigsep_observing.run_tag`,
+Six sibling modules ride this shape — :mod:`~eigsep_observing.run_tag`,
 :mod:`~eigsep_observing.obs_config_owner`,
 :mod:`~eigsep_observing.file_heartbeat`,
 :mod:`~eigsep_observing.snap_reinit`,
-:mod:`~eigsep_observing.corr_health`: a single Redis key holds a small
-JSON blob, overwritten on each publish via ``transport.add_raw`` /
-``transport.get_raw`` — consumers only ever care about the most recent
-value. This module is the single home for the serialize/deserialize
-path so a parsing fix propagates to all siblings at once (issue #149).
+:mod:`~eigsep_observing.corr_health`,
+:mod:`~eigsep_observing.imu_calibration` (read-only; picohost writes it):
+a single Redis key holds a small JSON blob, overwritten on each publish
+via ``transport.add_raw`` / ``transport.get_raw`` — consumers only ever
+care about the most recent value. This module is the single home for the
+serialize/deserialize path so a parsing fix propagates to all siblings at
+once (issue #149).
 
 What stays per-module: the ``*_KEY`` constant, the ``_EMPTY`` sentinel,
 lifecycle semantics (``run_tag``'s ``clear``/``session``,

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -171,6 +171,43 @@ def _imu_az_avg_entry(yaw):
     }
 
 
+# Representative imu_calibration blob, matching the picohost-3.10
+# ImuCalStore shape (see picohost/imu_geometry.py
+# fit_calibration_from_sweeps + nearest_signed_permutation). mount_perm
+# is a list of 3 host-axis label strings; M is a 3x3 row-major matrix;
+# accel_bias is a 3-vector. `upload_time` is intentionally absent — it is
+# injected at write time by Transport.upload_dict, so the on-Redis blob
+# has it but a hand-authored "what calibrate-imu produced" fixture does
+# not. Both sections present (a full `--mode all` run); a partial fleet
+# would carry only one section.
+IMU_CALIBRATION = {
+    "imu_el": {
+        "accel_bias": [0.01, -0.02, 0.03],
+        "accel_scale": 1.002,
+        "M": [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        "mount_perm": ["+x", "+y", "+z"],
+        "mount_misalign_deg": 0.8,
+    },
+    "imu_az": {
+        "accel_bias": [-0.04, 0.05, -0.06],
+        "accel_scale": 0.998,
+        "M": [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        "az_sign": 1.0,
+        "az_accel_offset_deg": 12.5,
+        "theta_cross_deg": 20.0,
+        "mount_perm": ["-y", "+x", "+z"],
+        "mount_misalign_deg": 1.3,
+        "az_yaw_sign": -1.0,
+        "az_yaw_offset_deg": 47.0,
+    },
+    "metadata": {
+        "timestamp": "2026-06-29T12:00:00+00:00",
+        "mode": "all",
+        "n_samples": 200,
+    },
+}
+
+
 def _lidar_avg_entry(distance_m):
     """One per-sample lidar entry as avg_metadata would emit it."""
     return {

--- a/src/eigsep_observing/imu_calibration.py
+++ b/src/eigsep_observing/imu_calibration.py
@@ -1,0 +1,60 @@
+"""Read-only consumer of picohost's ``imu_calibration`` Redis key.
+
+The sixth single-key JSON K/V module on :mod:`_redis_json_kv`, but unlike
+the other five (run_tag, obs_config_owner, file_heartbeat, snap_reinit,
+corr_health) it has no publish path: picohost's ``calibrate-imu`` /
+:class:`picohost.buses.ImuCalStore` owns the write. ``eigsep_observing``
+only reads it, at corr/VNA file-start, to embed the IMU mount calibration
+in file headers for offline recovery (parity with the pot cal that already
+rides the metadata stream). See issue #176.
+
+The stored blob is a JSON object with optional ``imu_el`` / ``imu_az``
+mount-calibration sections, a ``metadata`` block, and an ``upload_time``
+(unix float, injected by ``Transport.upload_dict``). It is embedded
+verbatim — the consumer does not validate or transform the section shape,
+so picohost remains free to evolve it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from picohost.keys import IMU_CAL_KEY
+
+from ._redis_json_kv import read_json
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["IMU_CAL_KEY", "read_calibration", "upload_unix"]
+
+
+def read_calibration(transport) -> dict:
+    """Latest ``imu_calibration`` blob, or ``{}`` on any failure.
+
+    A missing key, transport error, malformed JSON, or a non-dict payload
+    all resolve to ``{}``. ``{}`` means "no IMU cal recoverable from this
+    file" — panda unreachable at file-open, or never calibrated. The read
+    never raises, so it is safe in the corr-sacred / VNA-best-effort write
+    paths.
+    """
+    out = read_json(
+        transport,
+        IMU_CAL_KEY,
+        label="imu_calibration",
+        logger=logger,
+        parse=lambda payload: payload if isinstance(payload, dict) else None,
+    )
+    return out if isinstance(out, dict) else {}
+
+
+def upload_unix(blob: dict) -> float:
+    """Producer publish time from ``blob["upload_time"]``, else ``0.0``.
+
+    Surfaced as the flat ``imu_calibration_upload_unix`` header field so
+    offline consumers can staleness-check without digging into the nested
+    blob; ``0.0`` mirrors the ``{}`` sentinel ("no recoverable cal").
+    """
+    try:
+        return float(blob.get("upload_time"))
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -255,11 +255,12 @@ class EigObserver:
         without this field."
         """
         out = dict(header)
-        # All three reads are defensive: run_tag.read and
-        # obs_config_owner.read_owner already log+swallow and return
-        # the empty sentinel; the explicit try/except below covers
-        # ConfigStore.get raising ValueError (no config uploaded yet)
-        # or ConnectionError (panda unreachable).
+        # All four reads are defensive: run_tag.read,
+        # obs_config_owner.read_owner, and
+        # imu_calibration.read_calibration already log+swallow and
+        # return their empty sentinel; the explicit try/except below
+        # covers ConfigStore.get raising ValueError (no config uploaded
+        # yet) or ConnectionError (panda unreachable).
         tag = run_tag.read(self.transport_panda)
         owner = obs_config_owner.read_owner(self.transport_panda)
         try:

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -10,7 +10,7 @@ from eigsep_redis import (
     StatusReader,
 )
 
-from . import io, obs_config_owner, run_tag
+from . import io, imu_calibration, obs_config_owner, run_tag
 from .corr import CorrConfigStore, CorrReader
 from .file_heartbeat import publish as publish_file_heartbeat
 from .status_log_handler import PANDA_RELAY_LOGGER, StatusStreamHandler
@@ -228,10 +228,13 @@ class EigObserver:
         Adds ``run_tag`` / ``run_started_at_unix`` (from
         :mod:`eigsep_observing.run_tag`),
         ``obs_config_owner`` / ``obs_config_owner_uploaded_unix`` (from
-        :mod:`eigsep_observing.obs_config_owner`), and ``obs_config``
-        (from :class:`eigsep_redis.ConfigStore`) so each corr file
+        :mod:`eigsep_observing.obs_config_owner`), ``obs_config``
+        (from :class:`eigsep_redis.ConfigStore`), and
+        ``imu_calibration`` / ``imu_calibration_upload_unix`` (from
+        :mod:`eigsep_observing.imu_calibration`) so each corr file
         records the active panda script, the last script to upload the
-        config, and the panda-side config snapshot at file-open time.
+        config, the panda-side config snapshot at file-open time, and
+        the IMU calibration blob at the moment the file was opened.
 
         Downstream trust check: ``obs_config_owner != "UNKNOWN"`` means
         someone legitimately uploaded the cfg at some point;
@@ -239,11 +242,14 @@ class EigObserver:
         active driver right now.
 
         All overlay reads are defensive: a missing or malformed
-        run_tag, a missing obs_config_owner, a missing obs_config, or a
-        transient transport failure all resolve to ``"UNKNOWN"`` /
-        ``0.0`` / ``{}`` rather than raising. Corr data is sacred —
-        overlay enrichment must never block a corr file from being
-        written. Sentinel values (rather than dropping the keys)
+        run_tag, a missing obs_config_owner, a missing obs_config, a
+        missing IMU calibration, or a transient transport failure all
+        resolve to ``"UNKNOWN"`` / ``0.0`` / ``{}`` rather than
+        raising. Sentinels: ``imu_calibration = {}`` when no blob is
+        stored or the panda is unreachable;
+        ``imu_calibration_upload_unix = 0.0`` likewise. Corr data is
+        sacred — overlay enrichment must never block a corr file from
+        being written. Sentinel values (rather than dropping the keys)
         guarantee every post-PR file carries the field and let
         downstream distinguish "no producer info" from "old file
         without this field."
@@ -278,6 +284,9 @@ class EigObserver:
             else 0.0
         )
         out["obs_config"] = obs_cfg
+        cal = imu_calibration.read_calibration(self.transport_panda)
+        out["imu_calibration"] = cal
+        out["imu_calibration_upload_unix"] = imu_calibration.upload_unix(cal)
         return out
 
     def record_corr_data(

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -17,7 +17,7 @@ from eigsep_redis import (
 )
 from picohost.proxy import PicoProxy
 
-from . import obs_config_owner, run_tag
+from . import imu_calibration, obs_config_owner, run_tag
 from ._scripts_util import require_pico
 from .io import _validate_vna_s11_data, _validate_vna_s11_header
 from .keys import VNA_STREAM
@@ -305,7 +305,8 @@ def measure_s11(
         Header published alongside the bundle (instrument header plus
         ``mode``, ``metadata_snapshot_unix``, ``run_tag``,
         ``run_started_at_unix``, ``obs_config_owner``,
-        ``obs_config_owner_uploaded_unix``, ``obs_config``).
+        ``obs_config_owner_uploaded_unix``, ``obs_config``,
+        ``imu_calibration``, ``imu_calibration_upload_unix``).
     metadata : dict
         Panda-side metadata snapshot captured at trigger time.
 
@@ -361,6 +362,9 @@ def measure_s11(
         else 0.0
     )
     header["obs_config"] = dict(cfg)
+    cal = imu_calibration.read_calibration(transport)
+    header["imu_calibration"] = cal
+    header["imu_calibration_upload_unix"] = imu_calibration.upload_unix(cal)
     metadata = metadata_snapshot.get()
 
     violations = _validate_vna_s11_header(header) + _validate_vna_s11_data(

--- a/tests/test_imu_calibration.py
+++ b/tests/test_imu_calibration.py
@@ -55,7 +55,9 @@ def test_read_malformed_json_returns_empty(caplog):
     t.add_raw(IMU_CAL_KEY, b"not-json")
     with caplog.at_level("WARNING"):
         assert read_calibration(t) == {}
-    assert any("malformed imu_calibration" in r.message for r in caplog.records)
+    assert any(
+        "malformed imu_calibration" in r.message for r in caplog.records
+    )
 
 
 def test_read_non_dict_payload_returns_empty():

--- a/tests/test_imu_calibration.py
+++ b/tests/test_imu_calibration.py
@@ -3,8 +3,11 @@ picohost-written ``imu_calibration`` Redis key)."""
 
 from __future__ import annotations
 
+import json
+
 from eigsep_redis.testing import DummyTransport
 from picohost.buses import ImuCalStore
+from picohost.keys import IMU_CAL_KEY
 
 from eigsep_observing._test_fixtures import IMU_CALIBRATION
 from eigsep_observing.imu_calibration import read_calibration, upload_unix
@@ -25,3 +28,55 @@ def test_fixture_survives_picohost_store_roundtrip():
     # not its value.
     assert isinstance(out["upload_time"], float)
     assert isinstance(upload_unix(out), float)
+
+
+def test_read_missing_key_returns_empty():
+    assert read_calibration(DummyTransport()) == {}
+
+
+def test_read_seeded_blob_returns_verbatim():
+    t = DummyTransport()
+    t.add_raw(IMU_CAL_KEY, json.dumps({**IMU_CALIBRATION, "upload_time": 5.0}))
+    out = read_calibration(t)
+    assert out["imu_el"] == IMU_CALIBRATION["imu_el"]
+    assert out["upload_time"] == 5.0
+
+
+def test_read_partial_section_roundtrips():
+    """A `--mode elevation` fleet stores only imu_el; must not error."""
+    t = DummyTransport()
+    t.add_raw(IMU_CAL_KEY, json.dumps({"imu_el": IMU_CALIBRATION["imu_el"]}))
+    out = read_calibration(t)
+    assert set(out) == {"imu_el"}
+
+
+def test_read_malformed_json_returns_empty(caplog):
+    t = DummyTransport()
+    t.add_raw(IMU_CAL_KEY, b"not-json")
+    with caplog.at_level("WARNING"):
+        assert read_calibration(t) == {}
+    assert any("malformed imu_calibration" in r.message for r in caplog.records)
+
+
+def test_read_non_dict_payload_returns_empty():
+    t = DummyTransport()
+    t.add_raw(IMU_CAL_KEY, json.dumps([1, 2, 3]))
+    assert read_calibration(t) == {}
+
+
+def test_read_swallows_transport_error(caplog):
+    class Boom:
+        def get_raw(self, key):
+            raise RuntimeError("redis down")
+
+    with caplog.at_level("WARNING"):
+        assert read_calibration(Boom()) == {}
+    assert any(
+        "failed to read imu_calibration" in r.message for r in caplog.records
+    )
+
+
+def test_upload_unix_present_absent_and_junk():
+    assert upload_unix({"upload_time": 12.5}) == 12.5
+    assert upload_unix({}) == 0.0
+    assert upload_unix({"upload_time": "abc"}) == 0.0

--- a/tests/test_imu_calibration.py
+++ b/tests/test_imu_calibration.py
@@ -1,0 +1,27 @@
+"""Tests for eigsep_observing.imu_calibration (read-only consumer of the
+picohost-written ``imu_calibration`` Redis key)."""
+
+from __future__ import annotations
+
+from eigsep_redis.testing import DummyTransport
+from picohost.buses import ImuCalStore
+
+from eigsep_observing._test_fixtures import IMU_CALIBRATION
+from eigsep_observing.imu_calibration import read_calibration, upload_unix
+
+
+def test_fixture_survives_picohost_store_roundtrip():
+    """The fixture interoperates with picohost's real writer: upload via
+    ImuCalStore, read back via our reader, sections unchanged. Pins the
+    cross-repo storage contract (not the fitter's field names — those are
+    sourced from picohost/imu_geometry.py and cited at the fixture)."""
+    t = DummyTransport()
+    ImuCalStore(t).upload(IMU_CALIBRATION)
+    out = read_calibration(t)
+    assert out["imu_el"] == IMU_CALIBRATION["imu_el"]
+    assert out["imu_az"] == IMU_CALIBRATION["imu_az"]
+    assert out["metadata"] == IMU_CALIBRATION["metadata"]
+    # upload_dict injects a fresh upload_time; assert present + float,
+    # not its value.
+    assert isinstance(out["upload_time"], float)
+    assert isinstance(upload_unix(out), float)

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1416,7 +1416,8 @@ def test_record_corr_data_resumes_when_panda_arrives_after_startup(
 
 
 def test_with_header_overlays_no_panda_uses_sentinels(observer_snap_only):
-    """No transport_panda → run_tag + owner sentinels + empty obs_config."""
+    """No transport_panda → run_tag + owner sentinels + empty obs_config
+    + imu_calibration sentinels."""
     observer = observer_snap_only
     out = observer._with_header_overlays({"sync_time": 12345.0})
     assert out["sync_time"] == 12345.0
@@ -1425,6 +1426,8 @@ def test_with_header_overlays_no_panda_uses_sentinels(observer_snap_only):
     assert out["obs_config_owner"] == "UNKNOWN"
     assert out["obs_config_owner_uploaded_unix"] == 0.0
     assert out["obs_config"] == {}
+    assert out["imu_calibration"] == {}
+    assert out["imu_calibration_upload_unix"] == 0.0
 
 
 def test_with_header_overlays_panda_published(observer_both, transport_panda):

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -549,6 +549,8 @@ def test_record_corr_data_transient_header_blip_uses_cache(
         "obs_config_owner": "UNKNOWN",
         "obs_config_owner_uploaded_unix": 0.0,
         "obs_config": {},
+        "imu_calibration": {},
+        "imu_calibration_upload_unix": 0.0,
     }
     mock_file.set_header.assert_any_call(header=expected_header)
     # add_data called on both iterations — corr data is sacred, the

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -12,6 +12,8 @@ from eigsep_redis import ConfigStore, HeartbeatWriter, MetadataWriter
 from eigsep_redis.status import STATUS_STREAM
 from eigsep_redis.testing import DummyTransport
 from eigsep_observing import EigObserver, run_tag
+from eigsep_observing._test_fixtures import IMU_CALIBRATION
+from picohost.buses import ImuCalStore
 from eigsep_observing.corr import CorrConfigStore
 from eigsep_observing.status_log_handler import (
     PANDA_RELAY_LOGGER,
@@ -200,6 +202,26 @@ def test_observer_init_panda_empty_config_does_not_raise(transport_snap):
         assert overlaid["run_started_at_unix"] == 0.0
         assert overlaid["obs_config_owner"] == "UNKNOWN"
         assert overlaid["obs_config_owner_uploaded_unix"] == 0.0
+        assert overlaid["imu_calibration"] == {}
+        assert overlaid["imu_calibration_upload_unix"] == 0.0
+    finally:
+        observer.close()
+
+
+def test_with_header_overlays_embeds_imu_calibration(transport_snap):
+    transport_panda = DummyTransport()
+    HeartbeatWriter(transport_panda).set(alive=True)
+    ImuCalStore(transport_panda).upload(IMU_CALIBRATION)
+    observer = EigObserver(
+        transport_snap=transport_snap, transport_panda=transport_panda
+    )
+    try:
+        overlaid = observer._with_header_overlays({})
+        assert (
+            overlaid["imu_calibration"]["imu_az"]
+            == IMU_CALIBRATION["imu_az"]
+        )
+        assert overlaid["imu_calibration_upload_unix"] > 0.0
     finally:
         observer.close()
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -218,8 +218,7 @@ def test_with_header_overlays_embeds_imu_calibration(transport_snap):
     try:
         overlaid = observer._with_header_overlays({})
         assert (
-            overlaid["imu_calibration"]["imu_az"]
-            == IMU_CALIBRATION["imu_az"]
+            overlaid["imu_calibration"]["imu_az"] == IMU_CALIBRATION["imu_az"]
         )
         assert overlaid["imu_calibration_upload_unix"] > 0.0
     finally:

--- a/tests/test_redis_json_kv.py
+++ b/tests/test_redis_json_kv.py
@@ -1,10 +1,10 @@
 """Tests for eigsep_observing._redis_json_kv (shared K/V helper).
 
-The five sibling K/V modules (``run_tag``, ``obs_config_owner``,
-``file_heartbeat``, ``snap_reinit``, ``corr_health``) share one
-publish/read shape; this module is the single home for it. Behavior
-differences (swallow-vs-raise publish, lifecycle, derived fields)
-stay in the sibling modules — see issue #149.
+The six sibling K/V modules (``run_tag``, ``obs_config_owner``,
+``file_heartbeat``, ``snap_reinit``, ``corr_health``,
+``imu_calibration``) share one publish/read shape; this module is the
+single home for it. Behavior differences (swallow-vs-raise publish,
+lifecycle, derived fields) stay in the sibling modules — see issue #149.
 """
 
 from __future__ import annotations

--- a/tests/test_vna_helper.py
+++ b/tests/test_vna_helper.py
@@ -14,8 +14,10 @@ import numpy as np
 import pytest
 from cmt_vna.testing import DummyVNA
 from eigsep_redis import MetadataSnapshotReader
+from picohost.buses import ImuCalStore
 
 from eigsep_observing import obs_config_owner, run_tag
+from eigsep_observing._test_fixtures import IMU_CALIBRATION
 from eigsep_observing.keys import VNA_STREAM
 from eigsep_observing.vna import VnaWriter, measure_s11
 
@@ -172,6 +174,8 @@ def test_measure_s11_helper_empty_redis_yields_unknown_overlays(
     assert header["obs_config_owner"] == "UNKNOWN"
     assert header["obs_config_owner_uploaded_unix"] == 0.0
     assert header["obs_config"] == dict(dummy_cfg)
+    assert header["imu_calibration"] == {}
+    assert header["imu_calibration_upload_unix"] == 0.0
 
 
 def test_measure_s11_helper_injects_published_owner(transport, dummy_cfg):
@@ -195,6 +199,26 @@ def test_measure_s11_helper_injects_published_owner(transport, dummy_cfg):
 
     assert header["obs_config_owner"] == "panda_observe"
     assert header["obs_config_owner_uploaded_unix"] == 7.5
+
+
+def test_measure_s11_helper_embeds_imu_calibration(transport, dummy_cfg):
+    """A seeded ``ImuCalStore`` blob flows into the VNA header."""
+    ImuCalStore(transport).upload(IMU_CALIBRATION)
+
+    vna = _make_vna(dummy_cfg)
+    writer, snap = _make_sinks(transport)
+
+    _, header, _ = measure_s11(
+        vna,
+        "ant",
+        cfg=dummy_cfg,
+        transport=transport,
+        vna_writer=writer,
+        metadata_snapshot=snap,
+    )
+
+    assert header["imu_calibration"]["imu_el"] == IMU_CALIBRATION["imu_el"]
+    assert header["imu_calibration_upload_unix"] > 0.0
 
 
 def test_measure_s11_helper_rejects_invalid_mode(transport, dummy_cfg):


### PR DESCRIPTION
Closes #176.

## What & why

The potentiometer azimuth calibration is recoverable from any recorded file (it rides the `potmon` metadata stream as scalars). The **IMU mount calibration had no such path** — it lived only in the panda Redis `imu_calibration` key (written by picohost `calibrate-imu` / `ImuCalStore`), so a Pi swap / Redis loss / `dump.rdb` loss lost it, with "re-run calibrate-imu" the only remedy.

This embeds the `imu_calibration` blob into recorded **corr and VNA** file headers at file-start, giving the IMU parity with the pot's in-file provenance.

## Design

A new **read-only** K/V sibling module `eigsep_observing/imu_calibration.py` (the sixth on `_redis_json_kv`) reads picohost's key — picohost owns the write; this repo only reads. Both header-overlay sites stamp two fields:

- `imu_calibration` — the picohost blob **verbatim** (`imu_el`/`imu_az` mount sections + `metadata` + `upload_time`), or `{}` sentinel.
- `imu_calibration_upload_unix` — the producer's `upload_time` (unix seconds), or `0.0` sentinel.

Both `{}` and `0.0` mean "no IMU cal recoverable from this file" (panda unreachable at file-open, or never calibrated).

### Placement rationale (differs from the issue's suggestion)
The issue proposed mirroring `sync_time`. `sync_time` is native corr-bus (published by the SNAP-side `EigsepFpga`); the IMU cal is a panda-side **per-file provenance blob**, so the right precedent is the existing `obs_config` overlay in `_with_header_overlays` — a structured panda blob read at file-open with defensive sentinels. We embed the coefficients (not rely on post-hoc recovery from the derived stream fields) so the calibration is exact and re-derivable under any future algorithm.

## Corr is sacred
`read_calibration` is non-raising (delegates to `read_json`, which maps every failure → sentinel), so there is **no try/except** at either overlay call site — a missing/unreachable blob can never block a corr or VNA write.

## Descoped (per design discussion on the issue)
The standalone `metadata_*.h5` recorder (`write_metadata_hdf5`) is **not** covered — it has no header group, so it's a separate format decision.

## Tests
- `IMU_CALIBRATION` fixture matching the picohost-3.10 `ImuCalStore` shape, pinned to the real writer by an end-to-end storage-path guard (`ImuCalStore.upload` → our reader round-trip).
- Reader unit tests: missing key / seeded-verbatim / partial-section / malformed-JSON / non-dict / transport-error; `upload_unix` present/absent/junk.
- Corr (`observer.py`) + VNA (`vna.py`) overlay tests covering both the seeded-blob and panda-down sentinel paths.
- RECOVERY appendix in `docs/field_calibration.md` updated.

Full changed-surface suite green (85 passed). No picohost version bump needed (already pinned `>=3.10.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
