### PR TITLE
feat(io): record system_current cal params in metadata (picohost 3.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=3.10.0",
+  "picohost>=3.11.0",
   "eigsep-vna>=1.3",
   "eigsep_redis>=2.3.0",
 ]

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -170,12 +170,17 @@ def _lidar_post_handler_readings():
     through the real handler and capture both publishes in order. Mirrors
     ``_rfswitch_post_handler_reading`` / ``_motor_post_handler_reading``.
     ``_current_cal`` is normally set in ``PicoLidar.__init__`` (two-point
-    current cal, picohost); ``__new__`` bypasses that, so set it to ``None``
-    to select the nominal ACS724 conversion — same pattern as
-    ``_motor_post_handler_reading`` setting ``_motor_pos_store = None``.
+    current cal, picohost); ``__new__`` bypasses that, so set a measured cal
+    here to exercise the calibrated system_current shape — same bypass pattern
+    as ``_motor_post_handler_reading`` setting ``_motor_pos_store = None``.
     """
     lidar = PicoLidar.__new__(PicoLidar)
-    lidar._current_cal = None  # bypass __init__: nominal conversion
+    # A measured two-point cal (V0, slope_VperA) so the system_current entry
+    # carries float cal scalars — the calibrated post-handler shape, mirroring
+    # _potmon_post_handler_reading. The uncalibrated (all-None) shape is
+    # covered by picohost's TestLidarRedisHandler and the reduction tests in
+    # test_io.py. (picohost >= 3.11 has no nominal fallback: None cal -> None.)
+    lidar._current_cal = (1.4871, 0.11873)
     captured = []
     lidar._base_redis_handler = lambda d: captured.append(dict(d))
     lidar._lidar_redis_handler(LidarEmulator().get_status())

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -175,12 +175,13 @@ def _lidar_post_handler_readings():
     as ``_motor_post_handler_reading`` setting ``_motor_pos_store = None``.
     """
     lidar = PicoLidar.__new__(PicoLidar)
-    # A measured two-point cal (V0, slope_VperA) so the system_current entry
-    # carries float cal scalars — the calibrated post-handler shape, mirroring
-    # _potmon_post_handler_reading. The uncalibrated (all-None) shape is
-    # covered by picohost's TestLidarRedisHandler and the reduction tests in
-    # test_io.py. (picohost >= 3.11 has no nominal fallback: None cal -> None.)
-    lidar._current_cal = (1.4871, 0.11873)
+    # A measured cal in the stored amps-vs-volts form (slope A/V, intercept A)
+    # so the system_current entry carries float cal scalars — the calibrated
+    # post-handler shape, mirroring _potmon_post_handler_reading. The
+    # uncalibrated (all-None) shape is covered by picohost's
+    # TestLidarRedisHandler and the reduction tests in test_io.py.
+    # (picohost >= 3.11 has no nominal fallback: None cal -> None.)
+    lidar._current_cal = (8.4223, -12.5248)
     captured = []
     lidar._base_redis_handler = lambda d: captured.append(dict(d))
     lidar._lidar_redis_handler(LidarEmulator().get_status())

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -891,12 +891,20 @@ SENSOR_SCHEMAS = {
     # 1:1 pico app). `status` is producer-fixed to "update" (the ADC read
     # is decoupled from lidar's I2C result). `current_a` is the meaningful
     # value (amps); `current_voltage` is the raw ADC-pin voltage diagnostic.
-    # Both floats reduce via the standard float->mean path.
+    # `current_cal_slope` (A/V) and `current_cal_intercept` (A) are the
+    # measured two-point cal projected to amps-vs-volts
+    # (current_a == slope*current_voltage + intercept), flattened to scalars
+    # like potmon's pot_az_cal_slope/intercept. All four floats reduce via
+    # the standard float->mean path; all are None for an uncalibrated stream
+    # (no nominal fallback in picohost >= 3.11), and _validate_metadata /
+    # _avg_sensor_values short-circuit None cleanly.
     "system_current": {
         "sensor_name": str,
         "status": str,
         "current_voltage": float,
         "current_a": float,
+        "current_cal_slope": float,
+        "current_cal_intercept": float,
     },
     # Motor positions are stepper counts. The C firmware emits them
     # as ints, but `PicoMotor._motor_redis_handler` coerces to float

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3455,23 +3455,37 @@ def test_corr_pair_labels_coerces_int_keys():
 
 def test_system_current_schema_registered_and_validates():
     """system_current is a fanned-out stream (no app_id, like adc_stats).
-    The schema's job is loud validation: current_a/current_voltage must be
+    The schema's job is loud validation: the four numeric fields must be
     real floats so the float->mean reducer doesn't silently drop an
-    int-emitting producer to None."""
+    int-emitting producer to None. The cal scalars (slope A/V, intercept A)
+    are flattened per the picohost scalar-only contract, like potmon."""
     schema = io.SENSOR_SCHEMAS["system_current"]
     assert schema == {
         "sensor_name": str,
         "status": str,
         "current_voltage": float,
         "current_a": float,
+        "current_cal_slope": float,
+        "current_cal_intercept": float,
     }
     good = {
         "sensor_name": "system_current",
         "status": "update",
         "current_voltage": 1.70,
-        "current_a": 2.0,
+        "current_a": 1.793,
+        "current_cal_slope": 8.4223,
+        "current_cal_intercept": -12.5248,
     }
     assert io._validate_metadata(good, schema) == []
+    # Uncalibrated: current_a + both cal scalars are None. None short-circuits
+    # the per-key type check, so the row is still schema-clean.
+    uncal = {
+        **good,
+        "current_a": None,
+        "current_cal_slope": None,
+        "current_cal_intercept": None,
+    }
+    assert io._validate_metadata(uncal, schema) == []
     # int current_a violates the strict float check (would be dropped to
     # None by the float reducer) -> must surface as a contract violation.
     bad = {**good, "current_a": 2}
@@ -3480,20 +3494,29 @@ def test_system_current_schema_registered_and_validates():
 
 
 def test_avg_metadata_system_current():
-    """Both floats reduce via the generic float->mean path; the
-    producer-fixed status='update' row stays clean."""
+    """The numeric fields reduce via the generic float->mean path; the
+    producer-fixed status='update' row stays clean. The cal scalars are
+    invariant within an integration, so the mean passes them through
+    unchanged. NOTE: current_a here is set for averaging arithmetic, not
+    derived from the cal scalars — this test exercises the reducer, not the
+    producer's slope*V+intercept invariant (covered in picohost's
+    TestLidarRedisHandler)."""
     data = [
         {
             "sensor_name": "system_current",
             "status": "update",
             "current_voltage": 1.70,
             "current_a": 2.0,
+            "current_cal_slope": 8.4223,
+            "current_cal_intercept": -12.5248,
         },
         {
             "sensor_name": "system_current",
             "status": "update",
             "current_voltage": 1.74,
             "current_a": 4.0,
+            "current_cal_slope": 8.4223,
+            "current_cal_intercept": -12.5248,
         },
     ]
     result = io.avg_metadata(data)
@@ -3501,6 +3524,36 @@ def test_avg_metadata_system_current():
     assert result["status"] == "update"
     assert result["current_a"] == pytest.approx(3.0)
     assert result["current_voltage"] == pytest.approx(1.72)
+    assert result["current_cal_slope"] == pytest.approx(8.4223)
+    assert result["current_cal_intercept"] == pytest.approx(-12.5248)
+
+
+def test_avg_metadata_system_current_uncalibrated():
+    """An uncalibrated stream (current_a + cal scalars all None) reduces to
+    None for those fields — the float reducer has no non-None survivors."""
+    data = [
+        {
+            "sensor_name": "system_current",
+            "status": "update",
+            "current_voltage": 0.7057,
+            "current_a": None,
+            "current_cal_slope": None,
+            "current_cal_intercept": None,
+        },
+        {
+            "sensor_name": "system_current",
+            "status": "update",
+            "current_voltage": 0.7061,
+            "current_a": None,
+            "current_cal_slope": None,
+            "current_cal_intercept": None,
+        },
+    ]
+    result = io.avg_metadata(data)
+    assert result["current_voltage"] == pytest.approx(0.7059)
+    assert result["current_a"] is None
+    assert result["current_cal_slope"] is None
+    assert result["current_cal_intercept"] is None
 
 
 def test_imu_schemas_field_sets():

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1460,6 +1460,8 @@ def test_metadata_payload_classifies_system_current():
             "status": "update",
             "current_voltage": 1.70,
             "current_a": 3.0,
+            "current_cal_slope": 8.4223,
+            "current_cal_intercept": -12.5248,
         },
         "system_current_ts": now,
     }
@@ -1468,6 +1470,26 @@ def test_metadata_payload_classifies_system_current():
     entry = payload["system_current"]
     assert entry["classify"]["system_current.current_a"] == "ok"
     assert entry["status"] == "update"
+
+    # Uncalibrated (picohost >= 3.11): current_a None classifies "unknown",
+    # not a band violation. classify() already short-circuits None; this is
+    # a regression guard so the live current card degrades gracefully.
+    uncal_state = StateSnapshot()
+    uncal_state.metadata_snapshot = {
+        "system_current": {
+            "sensor_name": "system_current",
+            "status": "update",
+            "current_voltage": 0.7057,
+            "current_a": None,
+            "current_cal_slope": None,
+            "current_cal_intercept": None,
+        },
+        "system_current_ts": now,
+    }
+    uncal_state.metadata_snapshot_read_unix = now
+    uncal_payload = _metadata_payload(uncal_state, _payload_thresholds())
+    uncal_entry = uncal_payload["system_current"]
+    assert uncal_entry["classify"]["system_current.current_a"] == "unknown"
 
 
 def client_for(agg):


### PR DESCRIPTION
**Draft — blocked on the picohost 3.11.0 PyPI release.** Consumer side of a two-repo change; producer is EIGSEP/pico-firmware#137.

## What

Teaches `eigsep_observing` about the two `system_current` calibration scalars that picohost 3.11's `PicoLidar` now publishes, so the applied cal is recorded in metadata files instead of having to be reverse-engineered by fitting `current_a` vs `current_voltage`:

- `SENSOR_SCHEMAS["system_current"]` gains `current_cal_slope: float` and `current_cal_intercept: float` (both `None` when uncalibrated — no nominal fallback in 3.11).
- Producer-contract helper `_lidar_post_handler_readings` loads a measured cal so `test_every_schema_has_conforming_emulator[system_current]` exercises the populated float shape.
- `pyproject.toml` pin bumped `picohost>=3.10.0` → `>=3.11.0`.
- `test_io.py`: calibrated + uncalibrated reduction tests (cal scalars pass through `float→mean`; all-`None` → `None`).
- `test_live_status_app.py`: regression guard that an uncalibrated `current_a=None` classifies as `"unknown"` (live-status was already `None`-safe), plus the populated fixture now carries the cal scalars.

The two scalars ride the generic `float→mean` reduction (not `_INVARIANT_FIELDS`), matching the potmon cal-scalar precedent.

## Why draft / what's blocking

`_validate_metadata` flags both missing **and** extra keys, so the schema, the producer, and the pin must land together. picohost 3.11.0 is not on PyPI yet, so:

- [ ] Merge EIGSEP/pico-firmware#137
- [ ] Publish `picohost==3.11.0` to PyPI
- [ ] `uv lock --upgrade-package picohost` and commit `uv.lock` (intentionally omitted here — CI stays red until then)
- [ ] Mark ready for review

Validated locally against an **editable** install of picohost 3.11.0 from the pico-firmware branch: `test_io.py` 95 passed, producer-contract 17 passed (incl. `system_current`/`lidar`), `test_live_status_app.py` 62 passed, ruff clean. Final whole-branch review: ready to merge modulo the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)