### PR TITLE
feat: consume rfswitch_therm (PCB thermistors) + PATHS rename [gated on picohost release]

### DIFF
--- a/docs/superpowers/plans/2026-07-02-rfswitch-eeprom-thermistors.md
+++ b/docs/superpowers/plans/2026-07-02-rfswitch-eeprom-thermistors.md
@@ -14,7 +14,8 @@
 - Python **3.9+** compatibility (no 3.10+ syntax).
 - **Contract-based:** every producer stream in `SENSOR_SCHEMAS` must have a matching `SENSOR_EMULATORS` entry (enforced by `test_every_schema_has_conforming_emulator`).
 - **Corr data is sacred:** never let non-corr processing changes touch the corr path.
-- Datasheet thermistor constants (verbatim): 10k NTC, **R₀ = 10000 Ω @ 25 °C**, **B = 3380** (25–50 °C), divider = **10 kΩ pullup to 5.0 V**, thermistor to GND. Firmware `volt_therm` is the **3.3 V-referenced** ADC-pin voltage.
+- Datasheet thermistor constants (verbatim): 10k NTC, **R₀ = 10000 Ω @ 25 °C**, **B = 3380** (25–50 °C), divider = **10 kΩ pullup to 5.0 V**, thermistor to GND. Firmware `volt_therm` is the ADC-pin voltage referenced to the RP2040's **internal 3.3 V ADC full-scale** (the external harness is 5 V-only; there is no 3.3 V rail in the sensor circuit).
+- **Post-execution addendum (circuit confirmed 2026-07-02):** the 5 V pullup on a 3.3 V ADC saturates below **~8.5 °C** (R≈19.4 kΩ, pin=3.3 V). `_therm_temp_c` gained `THERM_ADC_MAX_VOLTS = 3.3` and returns **`None`** at/above it (saturated → untrustworthy) rather than a fake ~8.5 °C floor (picohost commit `aca2f45`, io.py comment `8d49797`). Hardware caveat flagged to operator: RP2040 ADC pin is not 5 V-tolerant.
 - **Two repos, coordinated:** the picohost change (Phase A) must be installed into the `eigsep_observing` venv before its tests can pass. The two must land together.
 
 ### Environments / commands

--- a/docs/superpowers/plans/2026-07-02-rfswitch-eeprom-thermistors.md
+++ b/docs/superpowers/plans/2026-07-02-rfswitch-eeprom-thermistors.md
@@ -1,0 +1,712 @@
+# RF switch EEPROM paths + PCB thermistors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reflect the `pico-firmware` `feat/rfswitch-eeprom-paths` branch in `eigsep_observing`: follow the `PicoRFSwitch.path_str`→`PATHS` rename, and surface the three RF-switch PCB thermistors (raw volts + host-derived °C) in `watch_sensors` and the live-status dashboard.
+
+**Architecture:** The thermistors ride a **new `rfswitch_therm` metadata stream** fanned out of the switch-state line in `PicoRFSwitch._rfswitch_redis_handler` (the `PicoLidar`→`system_current` pattern), keeping the categorical rfswitch stream pure. Voltage→temperature conversion is done host-side in that handler with hardcoded datasheet Beta constants. On the consumer side the change is purely additive: a `SENSOR_SCHEMAS` entry, a contract-test fixture, three dashboard signals, and a fold-in of three rows into the existing rfswitch pane.
+
+**Tech Stack:** Python 3.9+, pytest, ruff (line length 79), Redis (fakeredis in tests), Flask + vanilla JS dashboard, picohost (sibling repo), uv-managed venvs.
+
+## Global Constraints
+
+- Ruff line length **79**; run `ruff check` and `ruff format --check` before every commit.
+- Python **3.9+** compatibility (no 3.10+ syntax).
+- **Contract-based:** every producer stream in `SENSOR_SCHEMAS` must have a matching `SENSOR_EMULATORS` entry (enforced by `test_every_schema_has_conforming_emulator`).
+- **Corr data is sacred:** never let non-corr processing changes touch the corr path.
+- Datasheet thermistor constants (verbatim): 10k NTC, **R₀ = 10000 Ω @ 25 °C**, **B = 3380** (25–50 °C), divider = **10 kΩ pullup to 5.0 V**, thermistor to GND. Firmware `volt_therm` is the **3.3 V-referenced** ADC-pin voltage.
+- **Two repos, coordinated:** the picohost change (Phase A) must be installed into the `eigsep_observing` venv before its tests can pass. The two must land together.
+
+### Environments / commands
+
+- `eigsep_observing` tests: **`.venv/bin/pytest`** from `/home/eigsep/eigsep/eigsep_observing` (do **not** use `uv run pytest` — it re-syncs from the lock and clobbers the editable picohost).
+- `eigsep_observing` lint: `.venv/bin/ruff check .` and `.venv/bin/ruff format --check .`
+- picohost tests: from `/home/eigsep/eigsep/pico-firmware/picohost`, run **`.venv/bin/pytest tests/`**.
+- Install branch picohost into the eigsep venv (Phase A → B bridge): from `/home/eigsep/eigsep/eigsep_observing`, `uv pip install -e /home/eigsep/eigsep/pico-firmware/picohost`.
+- pico-firmware branch: `feat/rfswitch-eeprom-paths`. eigsep_observing branch: `feat/rfswitch-eeprom-thermistors` (already created).
+
+---
+
+## Task 1: picohost — fan thermistors into `rfswitch_therm` with host-side °C
+
+**Repo:** `/home/eigsep/eigsep/pico-firmware` (branch `feat/rfswitch-eeprom-paths`)
+
+**Files:**
+- Modify: `picohost/src/picohost/base.py` (`PicoRFSwitch`, ~lines 441–546; add `import math` if absent)
+- Modify: `picohost/src/picohost/emulators/rfswitch.py` (`DEFAULT_THERM_VOLTS` 1.65→2.5, ~line 44)
+- Modify: `README.md` (thermistor note, RF Switch Wiring section)
+- Test: `picohost/tests/test_base.py` (new `TestRFSwitchThermistorFanout`)
+- Test: `picohost/tests/test_emulators.py` (update any `1.65`/`DEFAULT_THERM_VOLTS` assertion to `2.5`)
+
+**Interfaces:**
+- Produces: `PicoRFSwitch._rfswitch_redis_handler(data)` now emits **two** publishes when `volt_therm*` present — `{sensor_name:"rfswitch", …, sw_state_name}` (thermistor keys removed) then `{sensor_name:"rfswitch_therm", status:"update", volt_therm0/1/2: float, temp_therm0/1/2: float|None}`. One publish when no `volt_therm*`.
+- Produces: `PicoRFSwitch._therm_temp_c(v) -> float|None` (classmethod) and class constants `THERM_SUPPLY_VOLTS=5.0`, `THERM_PULLUP_OHMS=10000.0`, `THERM_R0_OHMS=10000.0`, `THERM_T0_KELVIN=298.15`, `THERM_B=3380.0`, `THERM_NUM=3`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `picohost/tests/test_base.py` (after the existing `TestRFSwitchRedisHandler` class):
+
+```python
+class TestRFSwitchThermistorFanout:
+    """The three PCB thermistors fan out of the switch-state line into a
+    separate rfswitch_therm stream (mirrors PicoLidar -> system_current),
+    carrying raw volts + host-derived degrees C. The switch-state line
+    stays a pure categorical signal (no thermistor keys)."""
+
+    def _capture(self, switch, data):
+        published = []
+        switch._base_redis_handler = lambda d: published.append(dict(d))
+        switch._rfswitch_redis_handler(data)
+        return published
+
+    def test_fans_thermistors_into_separate_stream(self):
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            pub = self._capture(
+                switch,
+                {
+                    "sensor_name": "rfswitch",
+                    "status": "update",
+                    "app_id": 5,
+                    "sw_state": switch.PATHS["RFANT"],
+                    "volt_therm0": 2.5,
+                    "volt_therm1": 2.5,
+                    "volt_therm2": 2.5,
+                },
+            )
+            assert [p["sensor_name"] for p in pub] == [
+                "rfswitch",
+                "rfswitch_therm",
+            ]
+            # switch-state line is pure: thermistor keys stripped
+            assert "volt_therm0" not in pub[0]
+            assert pub[0]["sw_state_name"] == "RFANT"
+            therm = pub[1]
+            assert therm["status"] == "update"
+            assert "app_id" not in therm  # fanned/derived stream, cf. system_current
+            for i in range(3):
+                assert therm[f"volt_therm{i}"] == 2.5
+                # 2.5 V over the 5 V / 10k divider -> R = 10k -> 25 C
+                assert therm[f"temp_therm{i}"] == pytest.approx(25.0, abs=0.05)
+        finally:
+            switch.disconnect()
+
+    def test_out_of_range_voltage_maps_to_none_temp(self):
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            pub = self._capture(
+                switch,
+                {
+                    "sensor_name": "rfswitch",
+                    "sw_state": switch.PATHS["RFANT"],
+                    "volt_therm0": 0.0,   # v <= 0  -> None
+                    "volt_therm1": 5.0,   # v >= SUPPLY -> None
+                    "volt_therm2": 2.5,   # valid -> 25 C
+                },
+            )
+            therm = pub[1]
+            assert therm["temp_therm0"] is None
+            assert therm["temp_therm1"] is None
+            assert therm["temp_therm2"] == pytest.approx(25.0, abs=0.05)
+            # raw volts always pass through, even when temp is None
+            assert therm["volt_therm0"] == 0.0
+        finally:
+            switch.disconnect()
+
+    def test_no_thermistor_fields_publishes_only_rfswitch(self):
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            pub = self._capture(
+                switch,
+                {"sensor_name": "rfswitch", "sw_state": switch.PATHS["RFANT"]},
+            )
+            assert [p["sensor_name"] for p in pub] == ["rfswitch"]
+        finally:
+            switch.disconnect()
+
+    def test_therm_temp_c_known_points(self):
+        # 2.5 V -> R=10k -> exactly 25 C; monotonic: lower V (hotter) -> higher C
+        assert PicoRFSwitch._therm_temp_c(2.5) == pytest.approx(25.0, abs=0.05)
+        assert PicoRFSwitch._therm_temp_c(1.169) == pytest.approx(60.0, abs=1.0)
+        assert PicoRFSwitch._therm_temp_c(0.0) is None
+        assert PicoRFSwitch._therm_temp_c(5.0) is None
+        assert PicoRFSwitch._therm_temp_c(None) is None
+```
+
+Confirm `DummyPicoRFSwitch` and `PicoRFSwitch` are already imported at the top of `test_base.py` (they are — used by `TestRFSwitchRedisHandler`); `pytest` is imported too.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eigsep/eigsep/pico-firmware/picohost && .venv/bin/pytest tests/test_base.py::TestRFSwitchThermistorFanout -v`
+Expected: FAIL — `AttributeError: … has no attribute '_therm_temp_c'` and single-publish assertion mismatches.
+
+- [ ] **Step 3: Implement the conversion + fan-out**
+
+In `picohost/src/picohost/base.py`, ensure `import math` is present near the top (add it if not). Then in `class PicoRFSwitch`, add the constants and helper (place after `SW_STATE_UNKNOWN_NAME`), and rewrite `_rfswitch_redis_handler`:
+
+```python
+    # --- PCB thermistor conversion (host-side) --------------------------
+    # Three 10k NTC thermistors on the RF switch PCB (ADC0-2). The C
+    # firmware reports the raw ADC-pin voltage (counts * 3.3/4095,
+    # referenced to the 3.3V ADC rail). The divider is powered from 5.0V
+    # with a 10k pullup and the thermistor to GND, so
+    #   v = SUPPLY * R / (PULLUP + R)  =>  R = PULLUP * v / (SUPPLY - v).
+    # Datasheet Beta model R = R0*exp(B*(1/T - 1/T0)), hardcoded like
+    # tempctrl's Steinhart-Hart constants: 10k NTC, R0 = 10k @ 25C,
+    # B = 3380 (25-50C). Nominal ~+/-1-2C; refine with a measured cal
+    # later without changing the stream shape.
+    THERM_SUPPLY_VOLTS = 5.0        # divider pullup rail (NOT the 3.3V ADC ref)
+    THERM_PULLUP_OHMS = 10_000.0
+    THERM_R0_OHMS = 10_000.0        # at 25 C
+    THERM_T0_KELVIN = 298.15
+    THERM_B = 3380.0
+    THERM_NUM = 3
+
+    @classmethod
+    def _therm_temp_c(cls, v):
+        """Convert one thermistor ADC-pin voltage (volts) to degrees C.
+
+        Returns None when ``v`` is None, non-finite, or outside
+        ``(0, THERM_SUPPLY_VOLTS)`` (open / shorted / ADC-clipped
+        channel) — mirrors potmon's None-when-invalid derived field.
+        """
+        if (
+            v is None
+            or not math.isfinite(v)
+            or v <= 0.0
+            or v >= cls.THERM_SUPPLY_VOLTS
+        ):
+            return None
+        r = cls.THERM_PULLUP_OHMS * v / (cls.THERM_SUPPLY_VOLTS - v)
+        inv_t = (
+            1.0 / cls.THERM_T0_KELVIN
+            + math.log(r / cls.THERM_R0_OHMS) / cls.THERM_B
+        )
+        return 1.0 / inv_t - 273.15
+```
+
+Replace the body of `_rfswitch_redis_handler` with:
+
+```python
+    def _rfswitch_redis_handler(self, data):
+        """Add sw_state_name and fan the PCB thermistors into their own stream.
+
+        Firmware reports ``sw_state`` as an EEPROM path address (or
+        :attr:`SW_STATE_UNKNOWN` while settling) plus the three raw PCB
+        thermistor voltages ``volt_therm0/1/2`` on the same status line.
+        The switch-state entry stays categorical (thermistor keys
+        removed); the thermistors are re-published on a separate
+        ``rfswitch_therm`` stream carrying raw volts + host-derived degrees
+        C — the same two-publish fan-out as PicoLidar -> system_current.
+        """
+        data = data.copy()
+        sw_state = data.get("sw_state")
+        if sw_state == self.SW_STATE_UNKNOWN:
+            data["sw_state_name"] = self.SW_STATE_UNKNOWN_NAME
+        else:
+            data["sw_state_name"] = self._name_by_state.get(sw_state)
+        volts = [data.pop(f"volt_therm{i}", None) for i in range(self.THERM_NUM)]
+        self._base_redis_handler(data)
+        if any(v is not None for v in volts):
+            therm = {"sensor_name": "rfswitch_therm", "status": "update"}
+            for i, v in enumerate(volts):
+                therm[f"volt_therm{i}"] = v
+                therm[f"temp_therm{i}"] = self._therm_temp_c(v)
+            self._base_redis_handler(therm)
+```
+
+- [ ] **Step 4: Bump the emulator placeholder**
+
+In `picohost/src/picohost/emulators/rfswitch.py`, change `DEFAULT_THERM_VOLTS = 1.65` to:
+
+```python
+    # 2.5 V over the 5.0 V / 10k-pullup divider inverts to R = 10k = R0,
+    # i.e. exactly 25 C at the emulator's default, so tests read a clean
+    # midpoint. (Was 1.65, chosen for a 3.3 V midpoint before the 5 V rail
+    # was confirmed.)
+    DEFAULT_THERM_VOLTS = 2.5
+```
+
+Update any assertion in `picohost/tests/test_emulators.py` that expects `1.65` (or `DEFAULT_THERM_VOLTS == 1.65`) to `2.5` (grep: `grep -n "1.65\|DEFAULT_THERM_VOLTS" picohost/tests/test_emulators.py`).
+
+- [ ] **Step 5: Run the picohost suite to verify pass**
+
+Run: `cd /home/eigsep/eigsep/pico-firmware/picohost && .venv/bin/pytest tests/test_base.py tests/test_emulators.py -q`
+Expected: PASS (new fanout tests + existing rfswitch handler tests + emulator parity).
+
+Then the full picohost suite: `.venv/bin/pytest tests/ -q` — Expected: PASS.
+
+- [ ] **Step 6: Update the firmware README**
+
+In `README.md`, in the RF Switch Wiring section, replace the "Thermistors" bullet with:
+
+```markdown
+- **Thermistors**: firmware reports the raw averaged ADC pin voltage (`volt_therm<i>`, volts, 3.3V-referenced). Voltage→temperature is done host-side in `PicoRFSwitch._rfswitch_redis_handler`, which re-publishes the three channels on a separate `rfswitch_therm` metadata stream carrying `volt_therm<i>` plus derived `temp_therm<i>` (°C). Conversion uses a datasheet Beta model (10k NTC, R0=10k@25°C, B=3380) over a 10kΩ-pullup-to-5.0V divider; swap in measured constants when characterized (no firmware change).
+```
+
+- [ ] **Step 7: Lint + commit (pico-firmware)**
+
+Run: `cd /home/eigsep/eigsep/pico-firmware/picohost && .venv/bin/ruff check src/ tests/ && .venv/bin/ruff format --check src/ tests/` (fix if the repo's ruff config flags anything).
+
+```bash
+cd /home/eigsep/eigsep/pico-firmware
+git add picohost/src/picohost/base.py picohost/src/picohost/emulators/rfswitch.py picohost/tests/test_base.py picohost/tests/test_emulators.py README.md
+git commit -m "feat(rfswitch): fan PCB thermistors into rfswitch_therm stream with host-side degC
+
+Split volt_therm0/1/2 out of the switch-state line into a separate
+rfswitch_therm publish (PicoLidar->system_current pattern), adding
+host-side Beta conversion to temp_therm0/1/2 (5V/10k divider, R0=10k@25C,
+B=3380). Keeps the rfswitch stream a pure categorical signal. Emulator
+default 1.65->2.5V (=25C)."
+```
+
+---
+
+## Bridge: install the branch picohost into the eigsep venv
+
+- [ ] **Step 1: Editable-install picohost from the branch**
+
+Run: `cd /home/eigsep/eigsep/eigsep_observing && uv pip install -e /home/eigsep/eigsep/pico-firmware/picohost`
+
+- [ ] **Step 2: Verify the new API + handler are live**
+
+Run:
+```bash
+cd /home/eigsep/eigsep/eigsep_observing
+.venv/bin/python -c "from picohost.base import PicoRFSwitch as P; print('PATHS', hasattr(P,'PATHS'), 'path_str', hasattr(P,'path_str')); print('temp@2.5V', round(P._therm_temp_c(2.5),3))"
+```
+Expected: `PATHS True path_str False` and `temp@2.5V 25.0`.
+
+Do **not** run `uv run pytest` / `uv sync` after this (they re-resolve from the lock and revert to PyPI picohost 3.11.0). Use `.venv/bin/pytest` for all eigsep tests.
+
+---
+
+## Task 2: eigsep_observing — follow the `path_str`→`PATHS` rename
+
+**Repo:** `/home/eigsep/eigsep/eigsep_observing` (branch `feat/rfswitch-eeprom-thermistors`)
+
+**Files:**
+- Modify: `src/eigsep_observing/client.py:26` (and docstring at `:285`)
+- Modify: `scripts/rfswitch_manual.py:37`
+- Modify: `tests/test_io.py:1336, 3070` (fixture expressions)
+
+**Interfaces:**
+- Produces: `client.VALID_SWITCH_STATES = set(PicoRFSwitch.PATHS)` (16 states incl. new `VNAAMB`, `VNASP1/2`, `RFAMB`, `RFSP1/2`).
+
+- [ ] **Step 1: Confirm the breakage (test as spec)**
+
+Run: `.venv/bin/pytest tests/test_client.py -q --co`
+Expected: FAIL — collection error `AttributeError: type object 'PicoRFSwitch' has no attribute 'path_str'` (from `client.py:26` at import).
+
+- [ ] **Step 2: Fix `client.py`**
+
+`src/eigsep_observing/client.py:26` — change:
+
+```python
+VALID_SWITCH_STATES = set(PicoRFSwitch.PATHS)
+```
+
+Also fix the stale docstring example at `src/eigsep_observing/client.py:285` — replace `sw("RFLOAD")` (never a valid state) with a real path:
+
+```python
+        ...     sw("RFAMB")
+```
+
+- [ ] **Step 3: Fix `rfswitch_manual.py`**
+
+`scripts/rfswitch_manual.py:37` — change:
+
+```python
+STATES = list(PicoRFSwitch.PATHS)
+```
+
+- [ ] **Step 4: Fix the `test_io.py` fixtures**
+
+At `tests/test_io.py:1336` and `tests/test_io.py:3070`, replace:
+
+```python
+                    "sw_state": PicoRFSwitch.rbin(PicoRFSwitch.path_str[name]),
+```
+
+with (the address is already the int — no `rbin`):
+
+```python
+                    "sw_state": PicoRFSwitch.PATHS[name],
+```
+
+- [ ] **Step 5: Run the affected tests**
+
+Run:
+```bash
+.venv/bin/pytest tests/test_client.py -q
+.venv/bin/pytest tests/test_io.py -k "rfswitch or metadata_end_to_end or switch" -q
+```
+Expected: PASS (import restored; rfswitch round-trip still asserts the state-name string, which is unchanged).
+
+- [ ] **Step 6: Lint + commit**
+
+Run: `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
+
+```bash
+git add src/eigsep_observing/client.py scripts/rfswitch_manual.py tests/test_io.py
+git commit -m "fix(rfswitch): follow PicoRFSwitch.path_str -> PATHS rename
+
+path_str/rbin removed upstream (EEPROM path addressing). Swap the three
+call sites to PATHS (address int, no binary conversion); fix stale
+sw(\"RFLOAD\") docstring example. No public-API change: state names are
+sourced from the firmware class."
+```
+
+---
+
+## Task 3: eigsep_observing — `rfswitch_therm` schema + producer-contract fixture
+
+**Files:**
+- Modify: `src/eigsep_observing/io.py` (`SENSOR_SCHEMAS`, after the `rfswitch` entry ~line 881)
+- Modify: `src/eigsep_observing/contract_tests/test_producer_contracts.py` (`_rfswitch_post_handler_reading` ~line 143 → two-publish; `SENSOR_EMULATORS` ~line 252)
+
+**Interfaces:**
+- Consumes: `PicoRFSwitch._rfswitch_redis_handler` two-publish behavior (Task 1).
+- Produces: `SENSOR_SCHEMAS["rfswitch_therm"]` with `sensor_name, status: str` and `volt_therm0/1/2, temp_therm0/1/2: float`; `SENSOR_EMULATORS["rfswitch_therm"]`.
+
+- [ ] **Step 1: Show the contract test fails (emulator now fans out)**
+
+Run: `.venv/bin/pytest "src/eigsep_observing/contract_tests/test_producer_contracts.py::test_every_schema_has_conforming_emulator[rfswitch]" -q`
+Expected: FAIL — the current single-dict `_rfswitch_post_handler_reading` merges both publishes via `.update`, so `sensor_name` becomes `"rfswitch_therm"` and validation reports extra/missing keys.
+
+- [ ] **Step 2: Add the schema**
+
+In `src/eigsep_observing/io.py`, immediately after the `"rfswitch": { … }` entry in `SENSOR_SCHEMAS`, add:
+
+```python
+    # `rfswitch_therm`: three PCB thermistors on the RF switch board,
+    # fanned out of the switch-state line by
+    # PicoRFSwitch._rfswitch_redis_handler (the system_current pattern) so
+    # the categorical rfswitch stream stays pure. Like system_current it is
+    # a derived stream with no `app_id`. `volt_therm<i>` is the raw
+    # 3.3V-referenced ADC-pin voltage; `temp_therm<i>` is the host-side
+    # datasheet-Beta conversion in degrees C (None when the channel reads
+    # out of range). All six floats reduce via the standard float->mean
+    # path and land in the corr file (PCB temperature affects the cal
+    # network); None short-circuits in _validate_metadata / _avg_sensor_values.
+    "rfswitch_therm": {
+        "sensor_name": str,
+        "status": str,
+        "volt_therm0": float,
+        "volt_therm1": float,
+        "volt_therm2": float,
+        "temp_therm0": float,
+        "temp_therm1": float,
+        "temp_therm2": float,
+    },
+```
+
+- [ ] **Step 3: Refactor the contract fixture to two publishes**
+
+In `src/eigsep_observing/contract_tests/test_producer_contracts.py`, replace `_rfswitch_post_handler_reading` (~line 143) with a two-publish version (mirrors `_lidar_post_handler_readings`):
+
+```python
+def _rfswitch_post_handler_readings():
+    """Return [rfswitch, rfswitch_therm] after _rfswitch_redis_handler.
+
+    The rfswitch producer fans the three PCB thermistors out of the
+    switch-state line into a separate rfswitch_therm stream (raw volts +
+    host-derived degrees C), the same two-publish shape as
+    PicoLidar -> system_current. Compose RFSwitchEmulator.get_status()
+    through the real handler and capture both publishes in order. Mirrors
+    _lidar_post_handler_readings.
+    """
+    sw = PicoRFSwitch.__new__(PicoRFSwitch)
+    sw._name_by_state = {v: k for k, v in sw.__class__.paths.fget(sw).items()}
+    captured = []
+    sw._base_redis_handler = lambda d: captured.append(dict(d))
+    sw._rfswitch_redis_handler(RFSwitchEmulator().get_status())
+    assert len(captured) == 2, (
+        f"expected rfswitch + rfswitch_therm publishes, got {len(captured)}"
+    )
+    return captured[0], captured[1]
+```
+
+- [ ] **Step 4: Register both streams in `SENSOR_EMULATORS`**
+
+In the `SENSOR_EMULATORS` dict (~line 252), replace the line
+`"rfswitch": _rfswitch_post_handler_reading,` with:
+
+```python
+    "rfswitch": lambda: _rfswitch_post_handler_readings()[0],
+    "rfswitch_therm": lambda: _rfswitch_post_handler_readings()[1],
+```
+
+- [ ] **Step 5: Run the contract + io tests**
+
+Run:
+```bash
+.venv/bin/pytest src/eigsep_observing/contract_tests/test_producer_contracts.py -q
+.venv/bin/pytest tests/test_io.py -q
+```
+Expected: PASS — both `[rfswitch]` and `[rfswitch_therm]` parametrizations validate (2.5 V → 25.0 °C float), and rfswitch schema still validates the pure switch-state line.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check .
+git add src/eigsep_observing/io.py src/eigsep_observing/contract_tests/test_producer_contracts.py
+git commit -m "feat(io): add rfswitch_therm schema + two-publish producer contract
+
+New rfswitch_therm sensor stream (volt_therm0/1/2 + host-derived
+temp_therm0/1/2, no app_id) fanned out of the rfswitch line. Refactor the
+rfswitch contract fixture to capture both publishes (lidar pattern) and
+register both in SENSOR_EMULATORS."
+```
+
+---
+
+## Task 4: eigsep_observing — register three dashboard thermistor signals
+
+**Files:**
+- Modify: `src/eigsep_observing/live_status/signals.py` (`SIGNAL_REGISTRY`, after `system_current`/host signals ~line 171)
+- Test: `tests/test_live_status_thresholds.py` (new registration + classify test)
+
+**Interfaces:**
+- Produces: signals `rfswitch_therm.temp_therm0/1/2` (`unit="C"`, `enabled_by=None`, `max_age_s=30.0`, no derived/YAML band → classifies `"unknown"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_live_status_thresholds.py` (near the `system_current` block ~line 322). It reuses that file's existing imports (`SIGNAL_REGISTRY`, `enabled_signals`, `Thresholds`, `OBS_CFG_TEMPCTRL_OFF`, `CORR_HEADER`):
+
+```python
+# rfswitch_therm PCB thermistor signals
+# ---------------------------------------------------------------------
+
+
+def test_rfswitch_therm_signals_registered_and_always_enabled():
+    for i in range(3):
+        name = f"rfswitch_therm.temp_therm{i}"
+        sig = SIGNAL_REGISTRY[name]
+        assert sig.unit == "C"
+        assert sig.enabled_by is None  # board vital, never gated
+        # present even with optional subsystems off
+        assert name in enabled_signals(OBS_CFG_TEMPCTRL_OFF)
+
+
+def test_rfswitch_therm_classifies_unknown_without_band():
+    # No config-derived and no bundled-YAML band -> grey "unknown" tile.
+    th = Thresholds(OBS_CFG_TEMPCTRL_OFF, CORR_HEADER)
+    assert th.classify("rfswitch_therm.temp_therm0", 30.0) == "unknown"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_live_status_thresholds.py -k rfswitch_therm -v`
+Expected: FAIL — `KeyError: 'rfswitch_therm.temp_therm0'` (not registered).
+
+- [ ] **Step 3: Register the signals**
+
+In `src/eigsep_observing/live_status/signals.py`, add to `SIGNAL_REGISTRY` (after the `host_panda.temp_c` entry, before the site-geometry block):
+
+```python
+    # RF switch PCB thermistors — three 10k NTC on the switch board, fanned
+    # out of the switch-state line into the rfswitch_therm stream. Host-side
+    # datasheet-Beta conversion (~+/-1-2C), so no config-derived band —
+    # grey "unknown" tiles until an empirical band is added to the YAML
+    # override. Always enabled (a board vital, like system_current).
+    "rfswitch_therm.temp_therm0": Signal(
+        "rfswitch_therm.temp_therm0",
+        "RF switch PCB temp 0",
+        unit="C",
+    ),
+    "rfswitch_therm.temp_therm1": Signal(
+        "rfswitch_therm.temp_therm1",
+        "RF switch PCB temp 1",
+        unit="C",
+    ),
+    "rfswitch_therm.temp_therm2": Signal(
+        "rfswitch_therm.temp_therm2",
+        "RF switch PCB temp 2",
+        unit="C",
+    ),
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/test_live_status_thresholds.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check .
+git add src/eigsep_observing/live_status/signals.py tests/test_live_status_thresholds.py
+git commit -m "feat(live_status): register rfswitch_therm PCB thermistor signals
+
+Three temp_therm0/1/2 signals (degC), always enabled, no derived band ->
+grey 'unknown' tiles until an empirical band is tuned in the YAML override."
+```
+
+---
+
+## Task 5: eigsep_observing — fold thermistor rows into the rfswitch pane
+
+**Files:**
+- Modify: `src/eigsep_observing/live_status/static/js/dashboard.js` (`renderRfswitch` ~line 916; call site ~line 1013)
+- Test: `tests/test_live_status_app.py` (new `_metadata_payload` test)
+
+**Interfaces:**
+- Consumes: `SENSOR_SCHEMAS["rfswitch_therm"]` (Task 3), signals (Task 4), the generic `/api/metadata` projection.
+- Produces: three °C rows in the `#rfswitch` pane.
+
+- [ ] **Step 1: Write the backend projection guard test**
+
+Add to `tests/test_live_status_app.py` (after `test_metadata_payload_classifies_system_current` ~line 1567). This is a **regression guard** proving the generic `/api/metadata` projection already serves `rfswitch_therm` with a per-channel classify tag once the schema (Task 3) and signals (Task 4) exist — there is no `app.py`/backend change in this task. The JS render is the real deliverable, verified end-to-end in Step 5 (no JS unit harness exists). It reuses that file's `_payload_thresholds()` helper and `StateSnapshot`/`_metadata_payload` imports:
+
+```python
+def test_metadata_payload_classifies_rfswitch_therm():
+    """rfswitch_therm rides the generic /api/metadata projection: each
+    temp_therm* field is classified against its registered signal (no band
+    -> 'unknown'), and the raw volts pass through in `value`."""
+    from eigsep_observing.live_status.app import _metadata_payload
+    from eigsep_observing.live_status.aggregator import StateSnapshot
+
+    now = 1000.0
+    state = StateSnapshot()
+    state.metadata_snapshot = {
+        "rfswitch_therm": {
+            "sensor_name": "rfswitch_therm",
+            "status": "update",
+            "volt_therm0": 2.5,
+            "volt_therm1": 2.5,
+            "volt_therm2": 2.5,
+            "temp_therm0": 25.0,
+            "temp_therm1": 25.0,
+            "temp_therm2": 25.0,
+        },
+        "rfswitch_therm_ts": now,
+    }
+    state.metadata_snapshot_read_unix = now
+    payload = _metadata_payload(state, _payload_thresholds())
+    entry = payload["rfswitch_therm"]
+    assert entry["status"] == "update"
+    assert entry["value"]["temp_therm0"] == 25.0
+    assert entry["classify"]["rfswitch_therm.temp_therm0"] == "unknown"
+```
+
+- [ ] **Step 2: Run the guard test**
+
+Run: `.venv/bin/pytest tests/test_live_status_app.py -k rfswitch_therm -v`
+Expected: **PASS** — with Task 3 (schema) and Task 4 (signals) already merged, the generic projection serves `rfswitch_therm` and classifies `temp_therm0` as `"unknown"` (no band). This confirms no backend change is needed; the JS fold-in below is verified manually in Step 5. (If it fails with `KeyError`/classify-missing, Task 3 or Task 4 was not applied — fix that first.)
+
+- [ ] **Step 3: Extend `renderRfswitch` in `dashboard.js`**
+
+In `src/eigsep_observing/live_status/static/js/dashboard.js`, change the `renderRfswitch` signature and append thermistor rows before `el.append(row1, row2);`. Replace the function's signature line and the final `el.append(row1, row2);`:
+
+```javascript
+function renderRfswitch(rf, metaEntry, thermEntry) {
+```
+
+and, immediately before `el.append(row1, row2);`, insert:
+
+```javascript
+  // PCB thermistors (rfswitch_therm stream): three °C rows, raw V in
+  // parens, classify tile per channel (grey "unknown" until a band is set).
+  const rows = [row1, row2];
+  const tv = (thermEntry && thermEntry.value) || null;
+  const tc = (thermEntry && thermEntry.classify) || {};
+  if (tv) {
+    for (let i = 0; i < 3; i++) {
+      const t = tv[`temp_therm${i}`];
+      const v = tv[`volt_therm${i}`];
+      const label = t !== null && t !== undefined
+        ? `${fmt(t, 1)}°C (${fmt(v, 3)} V)`
+        : `— (${fmt(v, 3)} V)`;
+      const cls = tc[`rfswitch_therm.temp_therm${i}`] || "unknown";
+      const trow = document.createElement("div");
+      trow.className = "metadata-row";
+      trow.append(
+        makeSpan("label", `PCB temp ${i}`),
+        makeSpan(tileClass(cls), label),
+        makeSpan("value", "")
+      );
+      rows.push(trow);
+    }
+  }
+  el.append(...rows);
+```
+
+Remove the now-redundant original `el.append(row1, row2);` line (replaced by `el.append(...rows);`).
+
+- [ ] **Step 4: Update the call site**
+
+At `dashboard.js:1013`, change:
+
+```javascript
+    renderRfswitch(rfswitch.data, metadata.data["rfswitch"], metadata.data["rfswitch_therm"]);
+```
+
+- [ ] **Step 5: Run backend test + verify the app renders**
+
+Run: `.venv/bin/pytest tests/test_live_status_app.py -q`
+Expected: PASS.
+
+Then drive the dashboard end-to-end (the JS has no unit harness) using the project's run pattern:
+```bash
+.venv/bin/python scripts/live_status.py --dummy   # or the documented dummy/live invocation
+```
+Load the dashboard, confirm the RF switch card shows three "PCB temp N" rows at ~25 °C (dummy emulator default 2.5 V). Stop the app. (If `live_status.py` needs specific flags, check `scripts/CLAUDE.md` / `--help`.)
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check .
+git add src/eigsep_observing/live_status/static/js/dashboard.js tests/test_live_status_app.py
+git commit -m "feat(live_status): show RF switch PCB thermistor temps in the rfswitch pane
+
+Fold three temp_therm rows (degC, raw V in parens, per-channel classify
+tile) into renderRfswitch from the rfswitch_therm metadata stream. Backend
+/api/metadata projection is already generic; no app.py change."
+```
+
+---
+
+## Task 6: Full-suite verification + watch_sensors spot-check + follow-up note
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-02-rfswitch-eeprom-thermistors.md` (append a "picohost release follow-up" note) — optional
+- No source changes expected; this task is the integration gate.
+
+- [ ] **Step 1: Full eigsep_observing suite**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (whole suite, including coverage). Investigate any failure before proceeding.
+
+- [ ] **Step 2: `watch_sensors` renders the new stream (no code change expected)**
+
+Confirm `rfswitch_therm` is discoverable and displays all six fields:
+```bash
+.venv/bin/python -c "from eigsep_observing.io import SENSOR_SCHEMAS; print('rfswitch_therm' in SENSOR_SCHEMAS, list(SENSOR_SCHEMAS['rfswitch_therm']))"
+```
+Expected: `True ['sensor_name', 'status', 'volt_therm0', 'volt_therm1', 'volt_therm2', 'temp_therm0', 'temp_therm1', 'temp_therm2']`.
+Optionally run `.venv/bin/python scripts/watch_sensors.py --dummy` and confirm an `=== rfswitch_therm ===` block appears with `volt_therm*` and `temp_therm*`.
+
+- [ ] **Step 3: Lint gate (whole repo)**
+
+Run: `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
+Expected: clean.
+
+- [ ] **Step 4: Record the picohost release follow-up**
+
+The eigsep_observing venv currently runs the branch picohost via editable install; `pyproject.toml` still pins `picohost>=3.11.0` and `uv.lock` resolves PyPI 3.11.0. **Do not** bump the floor or re-lock in this branch — that happens once picohost cuts the release containing the fan-out (e.g. 3.12.0). Add a one-line reminder to the PR description: "Depends on picohost >= <release with rfswitch_therm fan-out>; bump the floor + `uv lock` when it publishes."
+
+- [ ] **Step 5: Commit (if the plan note was edited)**
+
+```bash
+git add docs/superpowers/plans/2026-07-02-rfswitch-eeprom-thermistors.md
+git commit -m "docs: note picohost release follow-up for rfswitch_therm dependency"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Item 2 rename → Task 2. Item 1 producer fan-out + conversion → Task 1. Schema + contract → Task 3. `watch_sensors` (zero code) → Task 6 Step 2. Dashboard signals → Task 4. Dashboard pane fold-in → Task 5. Cross-repo lockstep + version-floor → Bridge + Task 6 Step 4.
+- **Corr file:** `rfswitch_therm` floats flow through `_avg_sensor_values` automatically (no task needed beyond the schema in Task 3); covered by `tests/test_io.py` running green in Task 3 Step 5.
+- **Type consistency:** `_therm_temp_c` returns `float|None`; schema types `temp_therm*`/`volt_therm*` as `float` (None tolerated by `_validate_metadata`'s None short-circuit). `renderRfswitch(rf, metaEntry, thermEntry)` arity matches the updated call site.

--- a/docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md
+++ b/docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md
@@ -118,33 +118,40 @@ values as a second metadata entry — the two-publish shape of
 }
 ```
 
-**Conversion (new picohost helper + constants on `PicoRFSwitch`).** The C
-firmware reports `volt_therm` as the absolute ADC-pin voltage (counts × 3.3/4095,
-referenced to the 3.3V ADC rail). The divider is powered from **5.0V** with a
-**10k pullup** and the thermistor to GND, so:
+**Conversion (new picohost helper + constants on `PicoRFSwitch`).**
+Confirmed circuit: `5.0V —[10k pullup]— ADC pin —[NTC]— GND`; the external
+harness runs on 5V only (no 3.3V rail). The C firmware reports `volt_therm` as
+the absolute ADC-pin voltage (counts × 3.3/4095) — the **3.3V is the RP2040's
+internal ADC full-scale reference**, distinct from the 5V divider rail. So:
 
 ```python
 # constants (datasheet, hardcoded with provenance — cf. tempctrl's hardcoded SH)
-THERM_SUPPLY_VOLTS = 5.0     # divider pullup rail (distinct from the 3.3V ADC ref)
-THERM_PULLUP_OHMS  = 10_000.0
-THERM_R0_OHMS      = 10_000.0  # at 25 °C
-THERM_T0_K         = 298.15
-THERM_B            = 3380.0    # 25–50 °C beta
+THERM_SUPPLY_VOLTS  = 5.0     # divider pullup rail (the 5V external circuit)
+THERM_ADC_MAX_VOLTS = 3.3     # RP2040 internal ADC full-scale ref; >= this saturates
+THERM_PULLUP_OHMS   = 10_000.0
+THERM_R0_OHMS       = 10_000.0  # at 25 °C
+THERM_T0_K          = 298.15
+THERM_B             = 3380.0    # 25–50 °C beta
 
 def _therm_temp_c(v):
     # v = ADC-pin volts (0..3.3). Divider: 5V -[10k]- pin -[NTC]- GND
     #   v = SUPPLY * R/(PULLUP + R)  =>  R = PULLUP * v/(SUPPLY - v)
-    if v is None or not math.isfinite(v) or v <= 0.0 or v >= THERM_SUPPLY_VOLTS:
+    # v >= 3.3 is ADC-saturated (true voltage unknown) -> None.
+    if v is None or not math.isfinite(v) or v <= 0.0 or v >= THERM_ADC_MAX_VOLTS:
         return None
     r = THERM_PULLUP_OHMS * v / (THERM_SUPPLY_VOLTS - v)
     inv_t = 1.0 / THERM_T0_K + math.log(r / THERM_R0_OHMS) / THERM_B  # beta eqn
     return 1.0 / inv_t - 273.15
 ```
 
-Checks: v=2.5 → R=10k → **25.0 °C**. Range note: with the 5V pullup the pin
-crosses the 3.3V ADC ceiling near **~8.5 °C**, so temps below that clip to the
-floor (a hardware consequence; irrelevant for operating PCB temps ~15–50 °C).
-Recorded as a known limitation, not handled specially.
+Checks: v=2.5 → R=10k → **25.0 °C**. **ADC saturation:** with a 5V pullup on a
+3.3V ADC, the pin crosses the 3.3V ceiling at R≈19.4kΩ → **~8.5 °C**; below that
+the ADC clips and the true voltage is unknown, so `temp_therm` is reported as
+**`None`** (not a fake ~8.5 °C floor) — matches the "enforce loudly, don't
+paper over" philosophy. **Hardware caveat (flagged to the operator):** the
+RP2040 ADC pin is not 5V-tolerant; below ~8.5 °C, and up to 5V if a thermistor
+opens/disconnects, the pin is over-driven past its 3.3V max — a clamp or a 3.3V
+pullup is the hardware fix (out of scope for this software).
 
 - The C firmware / `RFSwitchEmulator.get_status()` still emit raw `volt_therm`
   on the status line — no C firmware change; the handler adds the temps

--- a/docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md
+++ b/docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md
@@ -1,0 +1,229 @@
+# RF switch EEPROM paths + PCB thermistors — consumer-side design
+
+**Date:** 2026-07-02
+**Repos:** `eigsep_observing` (primary), `pico-firmware` branch `feat/rfswitch-eeprom-paths` (coordinated producer change)
+**Status:** approved design, pending plan
+
+## Motivation
+
+The `pico-firmware` branch `feat/rfswitch-eeprom-paths` reworks the RF switch
+Pico in two ways that reach `eigsep_observing`:
+
+1. **EEPROM path addressing.** `PicoRFSwitch.path_str` (name → binary GPIO
+   string) and the `rbin()` helper are gone, replaced by `PicoRFSwitch.PATHS`
+   (name → EEPROM address int, `0x00`–`0x0F`). `sw_state` now means "EEPROM
+   path address" instead of "raw 8-bit GPIO bitmask." 10 legacy path names are
+   retained; 6 new ones are added (`VNAAMB`, `VNASP1`, `VNASP2`, `RFAMB`,
+   `RFSP1`, `RFSP2`).
+2. **Three PCB thermistors** on the RF switch board (ADC0–2 / GP26–28),
+   reported as raw averaged pin voltages `volt_therm0/1/2` (volts). Not yet
+   calibrated — voltage→temperature conversion is deferred to host-side once
+   the divider + Steinhart–Hart constants are measured. Firmware currently
+   emits them on the rfswitch status line.
+
+Goal: reflect both on the consumer side with the **smallest public-API change
+on the `eigsep_observing` side**, surfacing the thermistors in `watch_sensors`
+and the live-status dashboard.
+
+## Decision summary
+
+- **Item 2 (PATHS rename):** follow the firmware rename mechanically. No
+  firmware conform needed; `eigsep_observing` already sources state names from
+  the firmware class.
+- **Item 1 (thermistors):** **make firmware conform** — fan the thermistors
+  into a **separate `rfswitch_therm` metadata stream** (the established
+  `system_current` fan-out pattern). This keeps the consumer change purely
+  additive and keeps the rfswitch stream a pure categorical (switch-state)
+  stream. Surface the three temps **folded into the existing rfswitch pane** on
+  the dashboard.
+
+Both decisions confirmed with the operator on 2026-07-02.
+
+---
+
+## Item 2 — EEPROM path rename (eigsep_observing only)
+
+`PicoRFSwitch.path_str` / `rbin()` are removed upstream. Three call sites break
+at import with `AttributeError`:
+
+| File:line | Current | Change |
+|-----------|---------|--------|
+| `src/eigsep_observing/client.py:26` | `VALID_SWITCH_STATES = set(PicoRFSwitch.path_str)` | `set(PicoRFSwitch.PATHS)` |
+| `scripts/rfswitch_manual.py:37` | `STATES = list(PicoRFSwitch.path_str)` | `list(PicoRFSwitch.PATHS)` |
+| `tests/test_io.py:1336, 3070` | `PicoRFSwitch.rbin(PicoRFSwitch.path_str[name])` | `PicoRFSwitch.PATHS[name]` |
+
+Notes:
+
+- `client.py:26` is the load-bearing break: it runs at import and takes all of
+  `PandaClient` down. Fixing it restores switching end-to-end.
+- The `sw_state` *numeric* semantics change (bitmask → address) is **inert** on
+  the consumer side — a repo-wide sweep confirms nothing reads the raw
+  `sw_state` int; only `sw_state_name` (the string) is consumed
+  (`client._read_switch_mode_from_redis`, `io._avg_rfswitch_metadata`,
+  `aggregator` rfswitch-transition latch). The test-fixture `sw_state` values
+  change automatically because they are derived from the paths dict.
+- No path names were removed, so nothing referencing a specific state name
+  breaks; the 6 new names simply widen `VALID_SWITCH_STATES` and the
+  `rfswitch_manual` menu.
+- **Opportunistic fix:** `client.py:285` docstring example `sw("RFLOAD")`
+  references a state that has never existed in `PATHS`. Correct it to a real
+  path (e.g. `RFAMB`, the LNA→Amb/Hot-Load path) while touching the file.
+
+After these swaps, `rfswitch_manual.py` and the production switching path work
+unchanged.
+
+---
+
+## Item 1 — thermistors as a separate `rfswitch_therm` stream
+
+### Why not ride on the rfswitch stream
+
+The rfswitch stream has a **bespoke** consumer: `io.avg_metadata` dispatches
+`rfswitch` to `_avg_rfswitch_metadata`, which returns only the switch-state
+**name string**, discarding every numeric field. Consequences of leaving
+`volt_therm` on the rfswitch line:
+
+- Thermistors never reach the corr HDF5 file (dropped by the string reducer).
+- `io._validate_metadata` flags **extra keys** → "extra keys" WARNING at the
+  corr loop's ~4 Hz drain, and the producer-contract test fails.
+- Carrying them would force `_avg_rfswitch_metadata` to return a dict — a
+  **breaking** change to the rfswitch-as-string contract (corr file field,
+  `read_hdf5`, `EigObserver` transition-window logic, `File._insert_sample`,
+  and downstream analysis).
+
+A separate stream avoids all of this and mirrors how `system_current` is fanned
+out of the lidar line and how `tempctrl_lna` / `tempctrl_load` are per-channel
+streams.
+
+### Producer contract (pico-firmware)
+
+In `picohost.base.PicoRFSwitch._rfswitch_redis_handler`, after adding
+`sw_state_name`, **pop** `volt_therm0/1/2` from the rfswitch payload and
+re-publish them as a second metadata entry — exactly the two-publish shape of
+`PicoLidar._lidar_redis_handler`:
+
+```python
+# rfswitch entry (unchanged shape): {sensor_name: "rfswitch", status,
+#   app_id, sw_state, sw_state_name}
+# fanned entry:
+{
+    "sensor_name": "rfswitch_therm",
+    "status": "update",
+    "volt_therm0": float,
+    "volt_therm1": float,
+    "volt_therm2": float,
+}
+```
+
+- The C firmware / `RFSwitchEmulator.get_status()` still emit `volt_therm` on
+  the raw status line — no emulator change (mirrors lidar, whose emulator emits
+  `current_voltage` merged and the handler splits it).
+- `rfswitch_therm` carries **no `app_id`**, matching `system_current` (a
+  fanned/derived stream whose sensor key is not the pico's canonical app name).
+- picohost's rfswitch redis-handler test updates to expect **two** publishes
+  and assert the rfswitch line no longer carries `volt_therm`.
+
+This firmware change and the `eigsep_observing` schema change **must land
+together** — the `eigsep_observing` producer-contract test composes the locally
+installed picohost emulator + handler, so a mismatch fails CI.
+
+### Consumer changes (eigsep_observing)
+
+**A. Schema — `src/eigsep_observing/io.py` (`SENSOR_SCHEMAS`, ~line 861).**
+Add, mirroring `system_current`:
+
+```python
+"rfswitch_therm": {
+    "sensor_name": str,
+    "status": str,
+    "volt_therm0": float,
+    "volt_therm1": float,
+    "volt_therm2": float,
+},
+```
+
+Flows through the generic `_avg_sensor_values` (float→mean) path — no
+`_avg_rfswitch_metadata` change — so the three voltages land in the corr file
+automatically (desirable: PCB temperature affects the calibration network).
+`None`-when-a-read-fails is handled by the existing None short-circuit.
+
+**B. Producer-contract test —
+`src/eigsep_observing/contract_tests/test_producer_contracts.py`.**
+Refactor `_rfswitch_post_handler_reading` into a two-publish
+`_rfswitch_post_handler_readings()` (capture a *list*, like
+`_lidar_post_handler_readings`), then register both in `SENSOR_EMULATORS`
+(~line 252):
+
+```python
+"rfswitch":       lambda: _rfswitch_post_handler_readings()[0],
+"rfswitch_therm": lambda: _rfswitch_post_handler_readings()[1],
+```
+
+This satisfies `test_every_schema_has_conforming_emulator`, which parametrizes
+over `SENSOR_SCHEMAS` and fails CI for any schema key lacking an emulator.
+
+**C. `watch_sensors` — no code change.** `_PANDA_STREAMS` derives from
+`SENSOR_SCHEMAS`, `_render` prints all fields, and `--plot` traces the three
+`volt_therm*` floats via the all-float fallback in `_plot_fields_for`.
+(Optional: add `"rfswitch_therm": ("volt_therm0","volt_therm1","volt_therm2")`
+to `_PLOT_FIELDS` for an explicit label — not required.)
+
+**D. Live-status dashboard — fold into the rfswitch pane.**
+
+Backend is already generic (`_metadata_payload` at `app.py:326` iterates the
+snapshot hash and matches registered signals by dotted domain; `/api/metadata`
+serves it). No `app.py`, `aggregator.py`, or `thresholds.py` change.
+
+1. `src/eigsep_observing/live_status/signals.py` (`SIGNAL_REGISTRY`): register
+   three signals `rfswitch_therm.volt_therm0/1/2`, `enabled_by=None`,
+   `unit="V"`, `max_age_s≈30`. With no threshold band (uncalibrated) they
+   classify as `"unknown"` → grey info tiles, exactly like uncalibrated potmon.
+   No YAML entry required.
+2. `static/js/dashboard.js`: extend `renderRfswitch(rf, metaEntry)` to accept
+   the `rfswitch_therm` metadata entry and append three rows (value + classify
+   tile) below the existing `state` / `next change` rows. Update the call site
+   `dashboard.js:1013` to pass `metadata.data["rfswitch_therm"]`.
+3. `templates/index.html`: no new `<section>` — reuse the existing `#rfswitch`
+   pane. CSS already provides `.tile.unknown` / `.metadata-row`; no change.
+
+**E. Tests (additive, nothing existing breaks).** Mirror the `system_current`
+cases: a `signals`/`classify → "unknown"` test in
+`tests/test_live_status_thresholds.py` and a `_metadata_payload` test in
+`tests/test_live_status_app.py`. Update the two `test_io.py` rfswitch fixtures
+per Item 2; add an end-to-end averaging assertion for `rfswitch_therm` if
+convenient (round-trip pattern in `test_io.py`).
+
+### Forward compatibility
+
+When the thermistors are calibrated, firmware adds derived `temp_c0/1/2` (and
+optionally cal scalars) to the `rfswitch_therm` publish, the schema grows
+additively (floats, `None` when uncalibrated — the potmon/system_current
+precedent), the dashboard rows switch to showing °C, and a healthy/danger band
+is added in `live_status_thresholds.yaml`. No structural change.
+
+---
+
+## Scope / non-goals
+
+- No change to `_avg_rfswitch_metadata` or the rfswitch-as-string contract.
+- No change to the corr data path, VNA path, or any other sensor stream.
+- The picohost fan-out change lives in `pico-firmware`; this repo consumes it.
+  It is a hard prerequisite for thermistor data to appear and must land in
+  lockstep with the schema change to keep the contract test green.
+
+## Files touched (eigsep_observing)
+
+- `src/eigsep_observing/client.py` (rename + docstring)
+- `scripts/rfswitch_manual.py` (rename)
+- `src/eigsep_observing/io.py` (`rfswitch_therm` schema)
+- `src/eigsep_observing/contract_tests/test_producer_contracts.py` (two-publish
+  fixture + registry)
+- `src/eigsep_observing/live_status/signals.py` (3 signals)
+- `src/eigsep_observing/live_status/static/js/dashboard.js` (rfswitch pane +
+  call site)
+- `tests/test_io.py` (fixtures), `tests/test_live_status_*.py` (additive)
+
+## Coordinated files (pico-firmware, `feat/rfswitch-eeprom-paths`)
+
+- `picohost/src/picohost/base.py` (`_rfswitch_redis_handler` fan-out)
+- `picohost/tests/…` (rfswitch redis-handler two-publish assertions)

--- a/docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md
+++ b/docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md
@@ -15,11 +15,13 @@ Pico in two ways that reach `eigsep_observing`:
    path address" instead of "raw 8-bit GPIO bitmask." 10 legacy path names are
    retained; 6 new ones are added (`VNAAMB`, `VNASP1`, `VNASP2`, `RFAMB`,
    `RFSP1`, `RFSP2`).
-2. **Three PCB thermistors** on the RF switch board (ADC0–2 / GP26–28),
-   reported as raw averaged pin voltages `volt_therm0/1/2` (volts). Not yet
-   calibrated — voltage→temperature conversion is deferred to host-side once
-   the divider + Steinhart–Hart constants are measured. Firmware currently
-   emits them on the rfswitch status line.
+2. **Three PCB thermistors** on the RF switch board (ADC0–2 / GP26–28).
+   The C firmware reports raw averaged ADC-pin voltages `volt_therm0/1/2`
+   (`adc_read_avg_voltage`, referenced to the 3.3V ADC rail, 0–3.3V) on the
+   rfswitch status line. Voltage→temperature conversion is done **host-side**
+   in the picohost redis handler (the potmon/system_current pattern), using
+   fixed datasheet constants: 10k NTC (R₀=10k @ 25°C, B=3380, 25–50°C) in a
+   divider with a **10k pullup to 5.0V** and the thermistor to GND.
 
 Goal: reflect both on the consumer side with the **smallest public-API change
 on the `eigsep_observing` side**, surfacing the thermistors in `watch_sensors`
@@ -98,9 +100,11 @@ streams.
 ### Producer contract (pico-firmware)
 
 In `picohost.base.PicoRFSwitch._rfswitch_redis_handler`, after adding
-`sw_state_name`, **pop** `volt_therm0/1/2` from the rfswitch payload and
-re-publish them as a second metadata entry — exactly the two-publish shape of
-`PicoLidar._lidar_redis_handler`:
+`sw_state_name`, **pop** `volt_therm0/1/2` from the rfswitch payload, compute a
+temperature for each channel host-side, and re-publish both raw and derived
+values as a second metadata entry — the two-publish shape of
+`PicoLidar._lidar_redis_handler`, with the raw+derived pairing of potmon
+(voltage + angle):
 
 ```python
 # rfswitch entry (unchanged shape): {sensor_name: "rfswitch", status,
@@ -109,19 +113,53 @@ re-publish them as a second metadata entry — exactly the two-publish shape of
 {
     "sensor_name": "rfswitch_therm",
     "status": "update",
-    "volt_therm0": float,
-    "volt_therm1": float,
-    "volt_therm2": float,
+    "volt_therm0": float, "volt_therm1": float, "volt_therm2": float,  # raw ADC-pin volts
+    "temp_therm0": float, "temp_therm1": float, "temp_therm2": float,  # derived °C (None if out of range)
 }
 ```
 
-- The C firmware / `RFSwitchEmulator.get_status()` still emit `volt_therm` on
-  the raw status line — no emulator change (mirrors lidar, whose emulator emits
-  `current_voltage` merged and the handler splits it).
+**Conversion (new picohost helper + constants on `PicoRFSwitch`).** The C
+firmware reports `volt_therm` as the absolute ADC-pin voltage (counts × 3.3/4095,
+referenced to the 3.3V ADC rail). The divider is powered from **5.0V** with a
+**10k pullup** and the thermistor to GND, so:
+
+```python
+# constants (datasheet, hardcoded with provenance — cf. tempctrl's hardcoded SH)
+THERM_SUPPLY_VOLTS = 5.0     # divider pullup rail (distinct from the 3.3V ADC ref)
+THERM_PULLUP_OHMS  = 10_000.0
+THERM_R0_OHMS      = 10_000.0  # at 25 °C
+THERM_T0_K         = 298.15
+THERM_B            = 3380.0    # 25–50 °C beta
+
+def _therm_temp_c(v):
+    # v = ADC-pin volts (0..3.3). Divider: 5V -[10k]- pin -[NTC]- GND
+    #   v = SUPPLY * R/(PULLUP + R)  =>  R = PULLUP * v/(SUPPLY - v)
+    if v is None or not math.isfinite(v) or v <= 0.0 or v >= THERM_SUPPLY_VOLTS:
+        return None
+    r = THERM_PULLUP_OHMS * v / (THERM_SUPPLY_VOLTS - v)
+    inv_t = 1.0 / THERM_T0_K + math.log(r / THERM_R0_OHMS) / THERM_B  # beta eqn
+    return 1.0 / inv_t - 273.15
+```
+
+Checks: v=2.5 → R=10k → **25.0 °C**. Range note: with the 5V pullup the pin
+crosses the 3.3V ADC ceiling near **~8.5 °C**, so temps below that clip to the
+floor (a hardware consequence; irrelevant for operating PCB temps ~15–50 °C).
+Recorded as a known limitation, not handled specially.
+
+- The C firmware / `RFSwitchEmulator.get_status()` still emit raw `volt_therm`
+  on the status line — no C firmware change; the handler adds the temps
+  (mirrors lidar, whose emulator emits `current_voltage` and the handler
+  derives `current_a`). **Bump `RFSwitchEmulator.DEFAULT_THERM_VOLTS` 1.65 → 2.5**
+  so the emulator sits at a clean 25 °C under the 5V divider (was chosen for a
+  3.3V midpoint).
 - `rfswitch_therm` carries **no `app_id`**, matching `system_current` (a
   fanned/derived stream whose sensor key is not the pico's canonical app name).
-- picohost's rfswitch redis-handler test updates to expect **two** publishes
-  and assert the rfswitch line no longer carries `volt_therm`.
+- picohost's rfswitch redis-handler test updates to expect **two** publishes,
+  assert the rfswitch line no longer carries `volt_therm`, and assert the
+  derived `temp_therm*` (e.g. 2.5V → 25 °C, an out-of-range v → `None`).
+- `README.md` (pico-firmware): update the thermistor note — conversion is now
+  implemented host-side with datasheet Beta constants (refine with measured
+  constants later); record the 5V/10k divider.
 
 This firmware change and the `eigsep_observing` schema change **must land
 together** — the `eigsep_observing` producer-contract test composes the locally
@@ -136,16 +174,18 @@ Add, mirroring `system_current`:
 "rfswitch_therm": {
     "sensor_name": str,
     "status": str,
-    "volt_therm0": float,
-    "volt_therm1": float,
-    "volt_therm2": float,
+    "volt_therm0": float, "volt_therm1": float, "volt_therm2": float,
+    "temp_therm0": float, "temp_therm1": float, "temp_therm2": float,
 },
 ```
 
-Flows through the generic `_avg_sensor_values` (float→mean) path — no
-`_avg_rfswitch_metadata` change — so the three voltages land in the corr file
-automatically (desirable: PCB temperature affects the calibration network).
-`None`-when-a-read-fails is handled by the existing None short-circuit.
+All six floats flow through the generic `_avg_sensor_values` (float→mean) path —
+no `_avg_rfswitch_metadata` change — so both the raw voltages and the derived
+temperatures land in the corr file automatically (desirable: PCB temperature
+affects the calibration network). `temp_therm*` is `None` when a channel reads
+out of range; the existing None short-circuit in `_validate_metadata` /
+`_avg_sensor_values` handles it (the potmon/system_current
+None-when-uncalibrated precedent).
 
 **B. Producer-contract test —
 `src/eigsep_observing/contract_tests/test_producer_contracts.py`.**
@@ -163,10 +203,10 @@ This satisfies `test_every_schema_has_conforming_emulator`, which parametrizes
 over `SENSOR_SCHEMAS` and fails CI for any schema key lacking an emulator.
 
 **C. `watch_sensors` — no code change.** `_PANDA_STREAMS` derives from
-`SENSOR_SCHEMAS`, `_render` prints all fields, and `--plot` traces the three
-`volt_therm*` floats via the all-float fallback in `_plot_fields_for`.
-(Optional: add `"rfswitch_therm": ("volt_therm0","volt_therm1","volt_therm2")`
-to `_PLOT_FIELDS` for an explicit label — not required.)
+`SENSOR_SCHEMAS`, `_render` prints all fields (both volts and °C), and `--plot`
+traces all six floats via the all-float fallback in `_plot_fields_for`.
+(Optional: add `"rfswitch_therm": ("temp_therm0","temp_therm1","temp_therm2")`
+to `_PLOT_FIELDS` to plot just the three temperatures — not required.)
 
 **D. Live-status dashboard — fold into the rfswitch pane.**
 
@@ -175,14 +215,18 @@ snapshot hash and matches registered signals by dotted domain; `/api/metadata`
 serves it). No `app.py`, `aggregator.py`, or `thresholds.py` change.
 
 1. `src/eigsep_observing/live_status/signals.py` (`SIGNAL_REGISTRY`): register
-   three signals `rfswitch_therm.volt_therm0/1/2`, `enabled_by=None`,
-   `unit="V"`, `max_age_s≈30`. With no threshold band (uncalibrated) they
-   classify as `"unknown"` → grey info tiles, exactly like uncalibrated potmon.
-   No YAML entry required.
+   three signals `rfswitch_therm.temp_therm0/1/2`, `enabled_by=None`, `unit="C"`,
+   `max_age_s≈30`. No derived band is computed (datasheet-nominal, not a
+   config-derived setpoint), so they classify as `"unknown"` → grey info tiles
+   until an optional empirical healthy/danger band is added to
+   `live_status_thresholds.yaml`. (The raw `volt_therm*` fields are shown on the
+   card as diagnostics but need not be registered as classified signals — same
+   as `system_current.current_voltage`.)
 2. `static/js/dashboard.js`: extend `renderRfswitch(rf, metaEntry)` to accept
-   the `rfswitch_therm` metadata entry and append three rows (value + classify
-   tile) below the existing `state` / `next change` rows. Update the call site
-   `dashboard.js:1013` to pass `metadata.data["rfswitch_therm"]`.
+   the `rfswitch_therm` metadata entry and append three rows showing each
+   channel's °C (raw V in parens, like potmon's `angle (voltage)`) with the
+   classify tile, below the existing `state` / `next change` rows. Update the
+   call site `dashboard.js:1013` to pass `metadata.data["rfswitch_therm"]`.
 3. `templates/index.html`: no new `<section>` — reuse the existing `#rfswitch`
    pane. CSS already provides `.tile.unknown` / `.metadata-row`; no change.
 
@@ -195,11 +239,13 @@ convenient (round-trip pattern in `test_io.py`).
 
 ### Forward compatibility
 
-When the thermistors are calibrated, firmware adds derived `temp_c0/1/2` (and
-optionally cal scalars) to the `rfswitch_therm` publish, the schema grows
-additively (floats, `None` when uncalibrated — the potmon/system_current
-precedent), the dashboard rows switch to showing °C, and a healthy/danger band
-is added in `live_status_thresholds.yaml`. No structural change.
+The conversion uses datasheet constants (part-level, ~±1–2 °C), hardcoded on
+`PicoRFSwitch`. If per-unit calibration is ever wanted, the constants can move
+to a Redis cal store with a `calibrate-*` script (the potmon/current pattern)
+without touching the stream shape or schema — `temp_therm*` stays float,
+`None`-when-unavailable. Adding an empirical healthy/danger band later is a
+YAML-only change (`live_status_thresholds.yaml`). No structural change either
+way.
 
 ---
 
@@ -225,5 +271,9 @@ is added in `live_status_thresholds.yaml`. No structural change.
 
 ## Coordinated files (pico-firmware, `feat/rfswitch-eeprom-paths`)
 
-- `picohost/src/picohost/base.py` (`_rfswitch_redis_handler` fan-out)
-- `picohost/tests/…` (rfswitch redis-handler two-publish assertions)
+- `picohost/src/picohost/base.py` (`_rfswitch_redis_handler` fan-out +
+  `_therm_temp_c` helper + `THERM_*` constants on `PicoRFSwitch`)
+- `picohost/src/picohost/emulators/rfswitch.py` (`DEFAULT_THERM_VOLTS` 1.65→2.5)
+- `picohost/tests/…` (rfswitch redis-handler: two publishes, no `volt_therm` on
+  the rfswitch line, `temp_therm*` conversion assertions)
+- `README.md` (thermistor note: host-side Beta conversion, 5V/10k divider)

--- a/scripts/rfswitch_manual.py
+++ b/scripts/rfswitch_manual.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Canonical state list — sourced from the firmware-side class so a
 # new state added in firmware shows up here without a code change.
-STATES = list(PicoRFSwitch.path_str)
+STATES = list(PicoRFSwitch.PATHS)
 
 
 def _print_menu():

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 # Valid RF switch state names, sourced from the firmware-side class so
 # that a pico firmware change flows through automatically.
-VALID_SWITCH_STATES = set(PicoRFSwitch.path_str)
+VALID_SWITCH_STATES = set(PicoRFSwitch.PATHS)
 
 
 class PandaClient:
@@ -282,7 +282,7 @@ class PandaClient:
         Examples
         --------
         >>> with panda.switch_session() as sw:
-        ...     sw("RFLOAD")
+        ...     sw("RFAMB")
         ...     take_measurement()
         # rfswitch auto-restored to the mode that was active on entry
         """

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -140,22 +140,25 @@ def _peltier_post_handler_reading(stream_name):
     return tempctrl_post_handler_reading(stream_name)
 
 
-def _rfswitch_post_handler_reading():
-    """Return an rfswitch reading after _rfswitch_redis_handler.
+def _rfswitch_post_handler_readings():
+    """Return [rfswitch, rfswitch_therm] after _rfswitch_redis_handler.
 
-    The actual ``rfswitch`` producer is the composition
-    ``RFSwitchEmulator.get_status()`` + ``PicoRFSwitch._rfswitch_redis_handler``
-    — the emulator only emits the raw ``sw_state`` int, and the device
-    handler is where ``sw_state_name`` is added. The contract this test
-    enforces is the *post-handler* shape (what reaches Redis), so the
-    fixture has to compose the two. Mirrors ``_potmon_post_handler_reading``.
+    The rfswitch producer fans the three PCB thermistors out of the
+    switch-state line into a separate rfswitch_therm stream (raw volts +
+    host-derived degrees C), the same two-publish shape as
+    PicoLidar -> system_current. Compose RFSwitchEmulator.get_status()
+    through the real handler and capture both publishes in order. Mirrors
+    _lidar_post_handler_readings.
     """
     sw = PicoRFSwitch.__new__(PicoRFSwitch)
     sw._name_by_state = {v: k for k, v in sw.__class__.paths.fget(sw).items()}
-    captured = {}
-    sw._base_redis_handler = lambda d: captured.update(d)
+    captured = []
+    sw._base_redis_handler = lambda d: captured.append(dict(d))
     sw._rfswitch_redis_handler(RFSwitchEmulator().get_status())
-    return captured
+    assert len(captured) == 2, (
+        f"expected rfswitch + rfswitch_therm publishes, got {len(captured)}"
+    )
+    return captured[0], captured[1]
 
 
 def _lidar_post_handler_readings():
@@ -168,7 +171,7 @@ def _lidar_post_handler_readings():
     derived current_a). The contract these tests enforce is the
     post-handler shape of each, so compose ``LidarEmulator.get_status()``
     through the real handler and capture both publishes in order. Mirrors
-    ``_rfswitch_post_handler_reading`` / ``_motor_post_handler_reading``.
+    ``_rfswitch_post_handler_readings`` / ``_motor_post_handler_reading``.
     ``_current_cal`` is normally set in ``PicoLidar.__init__`` (two-point
     current cal, picohost); ``__new__`` bypasses that, so set a measured cal
     here to exercise the calibrated system_current shape — same bypass pattern
@@ -252,7 +255,8 @@ def _imu_post_handler_reading(name, app_id):
 SENSOR_EMULATORS = {
     "imu_el": lambda: _imu_post_handler_reading("imu_el", 3),
     "imu_az": lambda: _imu_post_handler_reading("imu_az", 6),
-    "rfswitch": _rfswitch_post_handler_reading,
+    "rfswitch": lambda: _rfswitch_post_handler_readings()[0],
+    "rfswitch_therm": lambda: _rfswitch_post_handler_readings()[1],
     "tempctrl_lna": lambda: _peltier_post_handler_reading("tempctrl_lna"),
     "tempctrl_load": lambda: _peltier_post_handler_reading("tempctrl_load"),
     "lidar": lambda: _lidar_post_handler_readings()[0],

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -879,6 +879,26 @@ SENSOR_SCHEMAS = {
         "sw_state": int,
         "sw_state_name": str,
     },
+    # `rfswitch_therm`: three PCB thermistors on the RF switch board,
+    # fanned out of the switch-state line by
+    # PicoRFSwitch._rfswitch_redis_handler (the system_current pattern) so
+    # the categorical rfswitch stream stays pure. Like system_current it is
+    # a derived stream with no `app_id`. `volt_therm<i>` is the raw
+    # 3.3V-referenced ADC-pin voltage; `temp_therm<i>` is the host-side
+    # datasheet-Beta conversion in degrees C (None when the channel reads
+    # out of range). All six floats reduce via the standard float->mean
+    # path and land in the corr file (PCB temperature affects the cal
+    # network); None short-circuits in _validate_metadata / _avg_sensor_values.
+    "rfswitch_therm": {
+        "sensor_name": str,
+        "status": str,
+        "volt_therm0": float,
+        "volt_therm1": float,
+        "volt_therm2": float,
+        "temp_therm0": float,
+        "temp_therm1": float,
+        "temp_therm2": float,
+    },
     "lidar": {
         "sensor_name": str,
         "status": str,

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -883,12 +883,15 @@ SENSOR_SCHEMAS = {
     # fanned out of the switch-state line by
     # PicoRFSwitch._rfswitch_redis_handler (the system_current pattern) so
     # the categorical rfswitch stream stays pure. Like system_current it is
-    # a derived stream with no `app_id`. `volt_therm<i>` is the raw
-    # 3.3V-referenced ADC-pin voltage; `temp_therm<i>` is the host-side
-    # datasheet-Beta conversion in degrees C (None when the channel reads
-    # out of range). All six floats reduce via the standard float->mean
-    # path and land in the corr file (PCB temperature affects the cal
-    # network); None short-circuits in _validate_metadata / _avg_sensor_values.
+    # a derived stream with no `app_id`. `volt_therm<i>` is the raw ADC-pin
+    # voltage (0-3.3V, referenced to the RP2040's internal ADC full-scale;
+    # the external divider is a 5V pullup, so there is no 3.3V in the
+    # sensor harness). `temp_therm<i>` is the host-side datasheet-Beta
+    # conversion in degrees C, `None` when the channel is dead/shorted or
+    # ADC-saturated (below ~8.5C the 5V divider drives the pin past the 3.3V
+    # ADC ceiling). All six floats reduce via the standard float->mean path
+    # and land in the corr file (PCB temperature affects the cal network);
+    # None short-circuits in _validate_metadata / _avg_sensor_values.
     "rfswitch_therm": {
         "sensor_name": str,
         "status": str,

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -169,6 +169,26 @@ SIGNAL_REGISTRY: dict[str, Signal] = {
         unit="C",
         max_age_s=60.0,
     ),
+    # RF switch PCB thermistors — three 10k NTC on the switch board, fanned
+    # out of the switch-state line into the rfswitch_therm stream. Host-side
+    # datasheet-Beta conversion (~+/-1-2C), so no config-derived band —
+    # grey "unknown" tiles until an empirical band is added to the YAML
+    # override. Always enabled (a board vital, like system_current).
+    "rfswitch_therm.temp_therm0": Signal(
+        "rfswitch_therm.temp_therm0",
+        "RF switch PCB temp 0",
+        unit="C",
+    ),
+    "rfswitch_therm.temp_therm1": Signal(
+        "rfswitch_therm.temp_therm1",
+        "RF switch PCB temp 1",
+        unit="C",
+    ),
+    "rfswitch_therm.temp_therm2": Signal(
+        "rfswitch_therm.temp_therm2",
+        "RF switch PCB temp 2",
+        unit="C",
+    ),
     # Site-geometry signals — YAML override only (TODO after deploy).
     "lidar.distance_m": Signal(
         "lidar.distance_m",

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -913,7 +913,7 @@ function renderAdcInCorr(adc) {
   container.appendChild(grid);
 }
 
-function renderRfswitch(rf, metaEntry) {
+function renderRfswitch(rf, metaEntry, thermEntry) {
   const el = document.getElementById("rfswitch");
   el.replaceChildren();
   if (metaEntry) {
@@ -959,7 +959,30 @@ function renderRfswitch(rf, metaEntry) {
     makeSpan("value", nextStr, "grid-column: span 2;")
   );
 
-  el.append(row1, row2);
+  // PCB thermistors (rfswitch_therm stream): three °C rows, raw V in
+  // parens, classify tile per channel (grey "unknown" until a band is set).
+  const rows = [row1, row2];
+  const tv = (thermEntry && thermEntry.value) || null;
+  const tc = (thermEntry && thermEntry.classify) || {};
+  if (tv) {
+    for (let i = 0; i < 3; i++) {
+      const t = tv[`temp_therm${i}`];
+      const v = tv[`volt_therm${i}`];
+      const label = t !== null && t !== undefined
+        ? `${fmt(t, 1)}°C (${fmt(v, 3)} V)`
+        : `— (${fmt(v, 3)} V)`;
+      const cls = tc[`rfswitch_therm.temp_therm${i}`] || "unknown";
+      const trow = document.createElement("div");
+      trow.className = "metadata-row";
+      trow.append(
+        makeSpan("label", `PCB temp ${i}`),
+        makeSpan(tileClass(cls), label),
+        makeSpan("value", "")
+      );
+      rows.push(trow);
+    }
+  }
+  el.append(...rows);
 }
 
 function renderStatusLog(entries) {
@@ -1010,7 +1033,7 @@ async function tick() {
     renderPotmon(metadata.data);
     renderLidar(metadata.data);
     renderSystemCurrent(metadata.data);
-    renderRfswitch(rfswitch.data, metadata.data["rfswitch"]);
+    renderRfswitch(rfswitch.data, metadata.data["rfswitch"], metadata.data["rfswitch_therm"]);
     renderAdcInCorr(adc.data);
     renderStatusLog(status.data);
     updateVna(vna.data);

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1517,6 +1517,123 @@ def test_potmon_uncalibrated_end_to_end_round_trip(caplog):
             assert row["status"] == "update"
 
 
+def test_rfswitch_therm_end_to_end_round_trip():
+    """Round-trip the rfswitch_therm PCB-thermistor stream, including a
+    saturated/dead channel within an integration.
+
+    ``rfswitch_therm`` (three PCB thermistors fanned out of the
+    switch-state line, see the schema comment in ``io.py``) goes through
+    the GENERIC ``_avg_sensor_values`` reduction like ``system_current`` —
+    NOT the special string-valued ``_avg_rfswitch_metadata`` path used by
+    the sibling ``rfswitch`` stream. This test asserts the averaged output
+    is a dict (not a bare state-name string) and survives the JSON round
+    trip with the right float values.
+
+    Each integration feeds THREE raw pushes for channel 0
+    (``temp_therm0``): two real readings and one ``None`` — the
+    producer's documented saturated/dead-channel value (io.py's
+    ``rfswitch_therm`` schema comment: "``None`` when the channel is
+    dead/shorted or ADC-saturated below ~8.5C"). ``_avg_sensor_values``'s
+    float branch filters ``None`` survivors before averaging::
+
+        floats = [s for s in survivors if isinstance(s, float)]
+        avg[data_key] = float(np.mean(floats)) if floats else None
+
+    (see ``_avg_sensor_values`` in ``src/eigsep_observing/io.py``), so the
+    averaged ``temp_therm0`` must equal the mean of the two REAL pushes —
+    not a pass-through of a single sample and not ``None``. Channels 1
+    and 2 stay fully healthy across all three pushes as a control, and
+    ``volt_therm0`` (the raw ADC voltage) stays real for all three pushes
+    even on the push where the derived temperature is None — matching
+    the documented saturation contract (voltage pinned near the rail,
+    temperature undefined).
+    """
+    n = 4
+
+    def _rfswitch_therm_payload(i):
+        return {
+            "stream:rfswitch_therm": [
+                {
+                    "sensor_name": "rfswitch_therm",
+                    "status": "update",
+                    "volt_therm0": 2.5,
+                    "volt_therm1": 2.5,
+                    "volt_therm2": 2.5,
+                    "temp_therm0": 25.0 + i,
+                    "temp_therm1": 25.0 + 0.1 * i,
+                    "temp_therm2": 25.0 + 0.2 * i,
+                },
+                {
+                    "sensor_name": "rfswitch_therm",
+                    "status": "update",
+                    "volt_therm0": 2.5,
+                    "volt_therm1": 2.5,
+                    "volt_therm2": 2.5,
+                    "temp_therm0": 27.0 + i,
+                    "temp_therm1": 25.0 + 0.1 * i,
+                    "temp_therm2": 25.0 + 0.2 * i,
+                },
+                {
+                    # Channel 0 saturated/dead on this push: the raw ADC
+                    # pin voltage is still a real float (pinned near the
+                    # 3.3V rail), but the host-side Beta conversion
+                    # emits None per the documented saturation contract.
+                    "sensor_name": "rfswitch_therm",
+                    "status": "update",
+                    "volt_therm0": 3.3,
+                    "volt_therm1": 2.5,
+                    "volt_therm2": 2.5,
+                    "temp_therm0": None,
+                    "temp_therm1": 25.0 + 0.1 * i,
+                    "temp_therm2": 25.0 + 0.2 * i,
+                },
+            ],
+        }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_dir = Path(tmpdir)
+        pairs = ["0"]
+        cfg = HEADER.copy()
+        cfg["integration_time"] = 0.1
+        f = io.File(save_dir, pairs, n, cfg)
+
+        dtype = np.dtype(HEADER["dtype"])
+        spec_len = io.data_shape(1, HEADER["acc_bins"], HEADER["nchan"])[1]
+        d = {"0": np.full(spec_len, 1, dtype=dtype)}
+
+        for i in range(n):
+            f.add_data(i + 1, 0.0, d, metadata=_rfswitch_therm_payload(i))
+        f.close()
+
+        files = glob.glob(str(save_dir / "*.h5"))
+        assert len(files) == 1, f"expected one file, got {files}"
+        _data, _hdr, read_meta = io.read_hdf5(files[0])
+
+        assert "rfswitch_therm" in read_meta
+        rows = read_meta["rfswitch_therm"]
+        assert len(rows) == n
+        for i, row in enumerate(rows):
+            # Generic dict path, not the special rfswitch string path.
+            assert isinstance(row, dict)
+            assert row["sensor_name"] == "rfswitch_therm"
+            assert row["status"] == "update"
+            # temp_therm0's None-survivor push is filtered; the average
+            # is the mean of the two REAL pushes, not a pass-through of
+            # one sample and not None.
+            assert row["temp_therm0"] == pytest.approx(
+                np.mean([25.0 + i, 27.0 + i])
+            )
+            # Healthy channels 1/2 average normally across all 3 pushes.
+            assert row["temp_therm1"] == pytest.approx(25.0 + 0.1 * i)
+            assert row["temp_therm2"] == pytest.approx(25.0 + 0.2 * i)
+            # Raw voltage stays float and averages across all 3 pushes,
+            # including the saturated one (voltage is real even though
+            # the derived temperature is None).
+            assert row["volt_therm0"] == pytest.approx(
+                np.mean([2.5, 2.5, 3.3])
+            )
+
+
 def test_write_error_surfaced():
     """Verify _write_error is set on failure and logged on next write."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1333,7 +1333,7 @@ def test_metadata_end_to_end_round_trip():
                     "sensor_name": "rfswitch",
                     "status": "update",
                     "app_id": 5,
-                    "sw_state": PicoRFSwitch.rbin(PicoRFSwitch.path_str[name]),
+                    "sw_state": PicoRFSwitch.PATHS[name],
                     "sw_state_name": name,
                 },
             ],
@@ -3067,7 +3067,7 @@ def _make_rfswitch_md(name):
                 "sensor_name": "rfswitch",
                 "status": "update",
                 "app_id": 5,
-                "sw_state": PicoRFSwitch.rbin(PicoRFSwitch.path_str[name]),
+                "sw_state": PicoRFSwitch.PATHS[name],
                 "sw_state_name": name,
             }
         ]

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1595,6 +1595,37 @@ def test_metadata_payload_classifies_rfswitch_therm():
     assert entry["value"]["temp_therm0"] == 25.0
     assert entry["classify"]["rfswitch_therm.temp_therm0"] == "unknown"
 
+    # Saturated/dead channel: the producer emits None for temp_therm0
+    # per the documented ADC-saturation contract (io.py's rfswitch_therm
+    # schema comment: None below ~8.5C or on a dead/shorted channel).
+    # thresholds.classify() short-circuits `value is None` -> "unknown"
+    # (see Thresholds.classify in thresholds.py); this guards that the
+    # dashboard degrades gracefully — no exception — when one channel
+    # is saturated while its neighbors stay healthy.
+    saturated_state = StateSnapshot()
+    saturated_state.metadata_snapshot = {
+        "rfswitch_therm": {
+            "sensor_name": "rfswitch_therm",
+            "status": "update",
+            "volt_therm0": 3.3,
+            "volt_therm1": 2.5,
+            "volt_therm2": 2.5,
+            "temp_therm0": None,
+            "temp_therm1": 25.0,
+            "temp_therm2": 25.0,
+        },
+        "rfswitch_therm_ts": now,
+    }
+    saturated_state.metadata_snapshot_read_unix = now
+    saturated_payload = _metadata_payload(
+        saturated_state, _payload_thresholds()
+    )
+    saturated_entry = saturated_payload["rfswitch_therm"]
+    assert saturated_entry["value"]["temp_therm0"] is None
+    assert (
+        saturated_entry["classify"]["rfswitch_therm.temp_therm0"] == "unknown"
+    )
+
 
 def client_for(agg):
     """Helper: build a Flask test_client for a primed aggregator."""

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1566,6 +1566,36 @@ def test_metadata_payload_classifies_system_current():
     assert uncal_entry["classify"]["system_current.current_a"] == "unknown"
 
 
+def test_metadata_payload_classifies_rfswitch_therm():
+    """rfswitch_therm rides the generic /api/metadata projection: each
+    temp_therm* field is classified against its registered signal (no band
+    -> 'unknown'), and the raw volts pass through in `value`."""
+    from eigsep_observing.live_status.app import _metadata_payload
+    from eigsep_observing.live_status.aggregator import StateSnapshot
+
+    now = 1000.0
+    state = StateSnapshot()
+    state.metadata_snapshot = {
+        "rfswitch_therm": {
+            "sensor_name": "rfswitch_therm",
+            "status": "update",
+            "volt_therm0": 2.5,
+            "volt_therm1": 2.5,
+            "volt_therm2": 2.5,
+            "temp_therm0": 25.0,
+            "temp_therm1": 25.0,
+            "temp_therm2": 25.0,
+        },
+        "rfswitch_therm_ts": now,
+    }
+    state.metadata_snapshot_read_unix = now
+    payload = _metadata_payload(state, _payload_thresholds())
+    entry = payload["rfswitch_therm"]
+    assert entry["status"] == "update"
+    assert entry["value"]["temp_therm0"] == 25.0
+    assert entry["classify"]["rfswitch_therm.temp_therm0"] == "unknown"
+
+
 def client_for(agg):
     """Helper: build a Flask test_client for a primed aggregator."""
     app = create_app(agg)

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -335,3 +335,23 @@ def test_system_current_band_from_bundled_yaml():
     assert th.classify("system_current.current_a", 3.0) == "ok"
     assert th.classify("system_current.current_a", 6.0) == "warn"
     assert th.classify("system_current.current_a", 9.0) == "danger"
+
+
+# rfswitch_therm PCB thermistor signals
+# ---------------------------------------------------------------------
+
+
+def test_rfswitch_therm_signals_registered_and_always_enabled():
+    for i in range(3):
+        name = f"rfswitch_therm.temp_therm{i}"
+        sig = SIGNAL_REGISTRY[name]
+        assert sig.unit == "C"
+        assert sig.enabled_by is None  # board vital, never gated
+        # present even with optional subsystems off
+        assert name in enabled_signals(OBS_CFG_TEMPCTRL_OFF)
+
+
+def test_rfswitch_therm_classifies_unknown_without_band():
+    # No config-derived and no bundled-YAML band -> grey "unknown" tile.
+    th = Thresholds(OBS_CFG_TEMPCTRL_OFF, CORR_HEADER)
+    assert th.classify("rfswitch_therm.temp_therm0", 30.0) == "unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -400,7 +400,7 @@ requires-dist = [
     { name = "ipython", marker = "extra == 'interactive'" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "picohost", specifier = ">=3.10.0" },
+    { name = "picohost", specifier = ">=3.11.0" },
     { name = "plotly" },
     { name = "pyserial-mock", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1289,7 +1289,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.10.0"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eigsep-redis" },
@@ -1298,9 +1298,9 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyserial" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/53/50b3c27412d5fbcde9ae55c0f5c7be303b5e1545123c0289a9ad6d01fb19/picohost-3.10.0.tar.gz", hash = "sha256:24afd0adfd737ed2db5749ea5aec19651c0bf691b9501074d1e8f7815c682600", size = 167070, upload-time = "2026-06-29T06:03:39.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/02/39962bddcf2556efbbc8addf08e46bb9595c3cfb42c2549cf4454e74f017/picohost-3.11.0.tar.gz", hash = "sha256:3313b4690337bfc147b4862c4150db92d8961449395a9df8a5ad1320deac5be9", size = 173863, upload-time = "2026-07-01T21:38:44.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/47/9ae68204d0198c9f9964708da213682bf2dfc0557f1c18b8ca2714d5cef8/picohost-3.10.0-py3-none-any.whl", hash = "sha256:84f9fd4674a4d80dea82a3a70ac520249195dc11aa88b9dd0c72deebadaa86b0", size = 99450, upload-time = "2026-06-29T06:03:38.498Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/473b6fb4a8a57c833341bb4150212b05bbde73dfd6f1b3304011e5722b9a/picohost-3.11.0-py3-none-any.whl", hash = "sha256:193ce7d1c7134336ac388408ace6bb29910a54c7fc2f1f7ab3096ec6296f740d", size = 102667, upload-time = "2026-07-01T21:38:43.628Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> ⛔ **DRAFT — do not merge until the picohost release lands.** This branch consumes the `rfswitch_therm` fan-out from pico-firmware PR EIGSEP/pico-firmware#138. `pyproject.toml` still pins `picohost>=3.11.0` and `uv.lock` resolves PyPI 3.11.0 (which lacks the fan-out); the branch is green only against an editable branch-picohost. **Before un-drafting:** (1) merge/release pico-firmware #138 → publish picohost with the fan-out (e.g. 3.12.0); (2) bump the `picohost` floor here + `uv lock`; (3) then the producer-contract test resolves from the lock and CI passes.

## Consumer-side support for RF-switch EEPROM paths + PCB thermistors

Reflects pico-firmware #138 in `eigsep_observing`. Two parts.

### 1. Follow the `path_str` → `PATHS` rename
`PicoRFSwitch.path_str`/`rbin()` were removed upstream (EEPROM path addressing). Swapped the three call sites to `PicoRFSwitch.PATHS` (`client.py`, `scripts/rfswitch_manual.py`, two `test_io.py` fixtures) + fixed a stale `sw("RFLOAD")` docstring. No public-API change — state names are sourced from the firmware class; nothing consumes the raw `sw_state` int.

### 2. New `rfswitch_therm` metadata stream (additive)
The producer fans the three PCB thermistors into a separate `rfswitch_therm` stream (raw `volt_therm0/1/2` + host-derived `temp_therm0/1/2` °C). Consumer side is **purely additive** — the categorical `rfswitch` string stream and its `_avg_rfswitch_metadata` path are unchanged:

- **Schema** (`io.py`): new `rfswitch_therm` entry (6 floats, no `app_id`, mirroring `system_current`). Flows through the generic `_avg_sensor_values` float→mean path → lands in the corr file automatically.
- **Producer contract** (`test_producer_contracts.py`): refactored the rfswitch fixture to the two-publish shape (lidar pattern) and registered both `rfswitch` and `rfswitch_therm` in `SENSOR_EMULATORS`.
- **`watch_sensors`**: zero code change — auto-discovers the new stream and renders all six fields.
- **Live-status dashboard**: three `rfswitch_therm.temp_therm*` signals registered; three °C rows folded into the existing rfswitch pane (`renderRfswitch`). `None` (saturated/uncalibrated) channels render `—` and classify `"unknown"`.

**`None`-on-saturation semantics:** `temp_therm` is `None` when a channel is dead/shorted or ADC-saturated (below ~8.5 °C, where the 5 V divider exceeds the 3.3 V ADC ceiling) — an honest gap rather than a fake floor, matching the repo's "enforce loudly, don't paper over" philosophy.

### Testing
- Full suite: **847 passed, 1 skipped** (against the editable branch-picohost). Includes a new end-to-end `rfswitch_therm` round-trip (drain → avg → write_hdf5 → read_hdf5, with a `None`/saturated sample) and a saturated-channel dashboard classify guard.
- ⚠️ The `renderRfswitch` JS fold-in was verified by review + the backend projection test, **not** in a browser (no node/browser in the dev env). One visual pass on a live dashboard is worth doing before release.

### Design docs
`docs/superpowers/specs/2026-07-02-rfswitch-eeprom-thermistors-design.md` and the implementation plan under `docs/superpowers/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
