### PR TITLE
fix(tempctrl_manual): remove 5s watchdog probe key

### DIFF
--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -523,9 +523,7 @@ def _render(screen, snapshot, state):
     )
     screen.addstr(16, 0, "g/G LNA Kp  h/H LOAD Kp  i/I LNA Ki  k/K LOAD Ki")
     screen.addstr(17, 0, "z/Z reset LNA/LOAD integral")
-    screen.addstr(
-        18, 0, "r re-enable both   p plot PNG   q quit"
-    )
+    screen.addstr(18, 0, "r re-enable both   p plot PNG   q quit")
     if state.last_message:
         screen.addstr(20, 0, f"> {state.last_message}"[: curses.COLS - 1])
     screen.refresh()

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -4,9 +4,8 @@ Curses UI showing live per-channel readouts for the two tempctrl
 streams (``tempctrl_lna`` and ``tempctrl_load``) and single-key
 commands that exercise every panda-side setter on
 :class:`picohost.base.PicoPeltier`. Operator confirms that the cold
-side temperature actually moves when the setpoint changes, that the
-firmware watchdog trips when the panda goes silent, and that the
-clamp limits drive saturation as expected.
+side temperature actually moves when the setpoint changes and that
+the clamp limits drive saturation as expected.
 
 Controls:
   l / L    enable LNA on / off
@@ -23,7 +22,6 @@ Controls:
   i / I    LNA Ki +/- 0.005
   k / K    LOAD Ki +/- 0.005
   z / Z    reset LNA / LOAD PI integrator
-  w        push a 5 s watchdog (should trip if not refreshed)
   r        re-enable both channels at their last setpoint
   p        write a temperature-vs-time PNG of the session so far
   q        quit
@@ -93,7 +91,6 @@ KP_STEP = 0.05
 KI_STEP = 0.005  # smaller — integral accumulates over many ticks
 DEFAULT_KP = 0.2  # firmware default, matches TempCtrlEmulator
 DEFAULT_KI = 0.0  # firmware default — opt-in via this script or yaml
-WATCHDOG_PROBE_MS = 5000
 # picohost STATUS_CADENCE_MS = 200; poll at the same cadence so we
 # wake on the next publish without busy-spinning.
 PICO_PUBLISH_INTERVAL_S = 0.2
@@ -527,7 +524,7 @@ def _render(screen, snapshot, state):
     screen.addstr(16, 0, "g/G LNA Kp  h/H LOAD Kp  i/I LNA Ki  k/K LOAD Ki")
     screen.addstr(17, 0, "z/Z reset LNA/LOAD integral")
     screen.addstr(
-        18, 0, "w push 5s watchdog   r re-enable both   p plot PNG   q quit"
+        18, 0, "r re-enable both   p plot PNG   q quit"
     )
     if state.last_message:
         screen.addstr(20, 0, f"> {state.last_message}"[: curses.COLS - 1])
@@ -607,10 +604,6 @@ def _handle_key(ch, proxy, state, history=None, outdir="."):
         state.last_message = _send(proxy, "reset_integral", LNA=True)
     elif ch == ord("Z"):
         state.last_message = _send(proxy, "reset_integral", LOAD=True)
-    elif ch == ord("w"):
-        state.last_message = _send(
-            proxy, "set_watchdog_timeout", timeout_ms=WATCHDOG_PROBE_MS
-        )
     elif ch == ord("r"):
         state.lna_enabled = True
         state.load_enabled = True
@@ -646,7 +639,7 @@ def _curses_main(screen, transport, args):
 def _parse_args():
     parser = ArgumentParser(
         description="Interactive tempctrl bring-up: drive setpoints and "
-        "exercise the firmware watchdog."
+        "tune the PI loop."
     )
     parser.add_argument(
         "--dummy",

--- a/uv.lock
+++ b/uv.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "eigsep-observing"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## What

Remove the `w` watchdog-probe key (and its `WATCHDOG_PROBE_MS` constant, docstring, and footer help) from `tempctrl_manual.py`.

## Why

`w` pushed `set_watchdog_timeout(timeout_ms=5000)`, but the `PicoManager` keepalive (`PicoPeltier`, `keepalive_interval=10.0`) only refreshes the firmware watchdog every 10 s. A 5 s window therefore trips between keepalives, the trip **latches** (sticky until a `*_enable=true` ack), and the 5 s value **persists in firmware** after the tool exits — with no companion key to restore the 30 s default. The result was a one-way trap that silently gated the peltiers during ordinary idle watching (the exact confusion this originated from: "why is the watchdog tripping while I'm just reading temperature?").

A probe short enough to actually trip is inherently indistinguishable from that trap given the 10 s keepalive, so it can't be made "safe" while remaining a probe. The watchdog trip/clear behavior is already covered by the emulator and conformance tests, so the manual probe adds no coverage — remove it outright.

## Notes

- Does **not** touch any live Pico. A unit left at 5 s from an earlier `w` press stays at 5 s until rebooted/re-flashed or explicitly re-pushed to a longer timeout; clear the current trip with `l`/`o`/`r`.
- No test referenced the key. `tests/test_tempctrl_manual.py` passes (15 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
