### PR TITLE
feat(vna): on-demand cmtvna.service — lazy VNA + session lifecycle

### DIFF
--- a/scripts/vna_manual.py
+++ b/scripts/vna_manual.py
@@ -188,6 +188,8 @@ def main():
     transport = build_transport_bare(
         args.dummy, host=args.redis_host, real_port=args.redis_port
     )
+    # build_vna_subsystem starts cmtvna.service (real mode) and its
+    # cleanup() stops it, so the whole REPL runs in one service window.
     subsystem = build_vna_subsystem(
         transport, cfg, source="vna_manual", dummy=args.dummy
     )

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -715,28 +715,38 @@ class PandaClient:
             If the resolved ``switch_schedule`` is neither ``None`` nor
             a dict.
         """
-        if self.vna is None:
+        if not self._vna_enabled:
             self._warn_with_status(
-                "VNA not initialized; skipping VNA portion of calibration."
+                "VNA disabled (use_vna=false); skipping VNA portion of "
+                "calibration."
             )
         else:
-            with self.coord.switch_section():
-                try:
-                    for mode in vna_modes:
-                        if self.stop_client.is_set():
-                            return False
-                        self.logger.info(
-                            f"Calibration: measuring S11 of {mode} with VNA"
-                        )
-                        self.measure_s11(mode)
-                except Exception as exc:
-                    # Match vna_loop's recovery posture: log loudly
-                    # and continue to the dwell phase rather than
-                    # aborting calibration outright.
-                    self._error_with_status(
-                        f"Calibration VNA cycle aborted "
-                        f"({type(exc).__name__}: {exc})."
-                    )
+            try:
+                with self.vna_session():
+                    with self.coord.switch_section():
+                        try:
+                            for mode in vna_modes:
+                                if self.stop_client.is_set():
+                                    return False
+                                self.logger.info(
+                                    f"Calibration: measuring S11 of "
+                                    f"{mode} with VNA"
+                                )
+                                self.measure_s11(mode)
+                        except Exception as exc:
+                            # Match vna_loop's recovery posture: log
+                            # loudly and continue to the dwell phase
+                            # rather than aborting calibration
+                            # outright.
+                            self._error_with_status(
+                                f"Calibration VNA cycle aborted "
+                                f"({type(exc).__name__}: {exc})."
+                            )
+            except Exception as exc:
+                self._error_with_status(
+                    f"Calibration VNA session failed "
+                    f"({type(exc).__name__}: {exc})."
+                )
 
         if self.stop_client.is_set():
             return False

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -779,49 +779,60 @@ class PandaClient:
         """
         Observe with VNA and write data to files.
         """
-        if self.vna is None:
+        if not self._vna_enabled:
             self._warn_with_status(
-                "VNA not initialized. Cannot execute VNA commands."
+                "VNA disabled in config (use_vna=false); vna_loop exiting."
             )
             return
         while not self.stop_client.is_set():
-            with self.coord.switch_section():
-                prev_mode = self._read_switch_mode_from_redis()
-                if prev_mode is None:
-                    self._warn_with_status(
-                        "rfswitch state unavailable in Redis; defaulting "
-                        "post-VNA switch-back to RFANT."
-                    )
-                    prev_mode = "RFANT"
-                target_mode = prev_mode
-                try:
-                    for mode in ["ant", "rec"]:
-                        self.logger.info(f"Measuring S11 of {mode} with VNA")
-                        self.measure_s11(mode)
-                except Exception as exc:
-                    # Any exception from measure_s11 (``_switch`` raising
-                    # mid-OSL under the eigsep-vna 1.3 contract, VNA
-                    # instrument TimeoutError, Redis write failure, ...)
-                    # leaves the switch at whatever state cmt_vna last
-                    # drove it to. Default the recovery target to RFANT
-                    # rather than prev_mode — we've lost the
-                    # "known-good state" invariant and RFANT is the
-                    # physically safe fallback. The next switch_loop
-                    # iteration will re-assert the configured mode.
-                    self._error_with_status(
-                        f"VNA cycle aborted "
-                        f"({type(exc).__name__}: {exc}); "
-                        "recovering rfswitch to RFANT."
-                    )
-                    target_mode = "RFANT"
-                self.logger.info(
-                    f"Switching rfswitch to {target_mode} "
-                    f"(previous mode: {prev_mode})"
+            try:
+                with self.vna_session():
+                    with self.coord.switch_section():
+                        prev_mode = self._read_switch_mode_from_redis()
+                        if prev_mode is None:
+                            self._warn_with_status(
+                                "rfswitch state unavailable in Redis; "
+                                "defaulting post-VNA switch-back to RFANT."
+                            )
+                            prev_mode = "RFANT"
+                        target_mode = prev_mode
+                        try:
+                            for mode in ["ant", "rec"]:
+                                self.logger.info(
+                                    f"Measuring S11 of {mode} with VNA"
+                                )
+                                self.measure_s11(mode)
+                        except Exception as exc:
+                            # Any exception from measure_s11 (``_switch``
+                            # raising mid-OSL under the eigsep-vna 1.3
+                            # contract, VNA instrument TimeoutError, Redis
+                            # write failure, ...) leaves the switch at
+                            # whatever state cmt_vna last drove it to.
+                            # Default the recovery target to RFANT rather
+                            # than prev_mode — we've lost the
+                            # "known-good state" invariant and RFANT is
+                            # the physically safe fallback. The next
+                            # switch_loop iteration will re-assert the
+                            # configured mode.
+                            self._error_with_status(
+                                f"VNA cycle aborted "
+                                f"({type(exc).__name__}: {exc}); "
+                                "recovering rfswitch to RFANT."
+                            )
+                            target_mode = "RFANT"
+                        self.logger.info(
+                            f"Switching rfswitch to {target_mode} "
+                            f"(previous mode: {prev_mode})"
+                        )
+                        if not self._safe_switch(target_mode):
+                            self._warn_with_status(
+                                f"Failed to switch back to {target_mode}"
+                            )
+            except Exception as exc:
+                self._error_with_status(
+                    f"VNA session failed "
+                    f"({type(exc).__name__}: {exc}); skipping this cycle."
                 )
-                if not self._safe_switch(target_mode):
-                    self._warn_with_status(
-                        f"Failed to switch back to {target_mode}"
-                    )
             self.stop_client.wait(self.cfg["vna_interval"])
 
     def motor_loop(self):

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -13,6 +13,7 @@ from eigsep_redis import (
 from picohost.base import PicoRFSwitch
 from picohost.proxy import PicoProxy
 
+from . import vna_service
 from .motion_switch import MotionSwitchCoordinator
 from .motor_client import MotorClient
 from .tempctrl_client import TempCtrlClient
@@ -114,11 +115,16 @@ class PandaClient:
                 "is unknown."
             )
 
-        if self.cfg.get("use_vna", False):
-            self.init_VNA()
-        else:
-            self.vna = None
-            self.logger.info("VNA not initialized")
+        # VNA is lazy: cmtvna.service busy-loops the CPU, so it runs
+        # on-demand. vna_open()/vna_session() start the service, wait for
+        # readiness, and build a fresh VNA; the service is stopped on
+        # close. self.vna is None between sessions. See
+        # eigsep_observing.vna_service.
+        self.vna = None
+        self._vna_enabled = self.cfg.get("use_vna", False)
+        self._vna_depth = 0
+        if not self._vna_enabled:
+            self.logger.info("VNA disabled (use_vna=false)")
 
         if self.cfg.get("use_motor", False):
             self.init_motor_client()
@@ -374,6 +380,82 @@ class PandaClient:
         self.logger.info(f"vna kwargs: {kwargs}")
         self.vna.setup(**kwargs)
         self.logger.info("VNA initialized")
+
+    _manage_vna_service = True
+
+    @property
+    def vna_enabled(self):
+        """True if the config enabled the VNA (``use_vna``)."""
+        return self._vna_enabled
+
+    def vna_open(self):
+        """Start cmtvna.service, wait for readiness, and build the VNA.
+
+        Refcounted: the service starts and the VNA is built on the
+        outermost open; inner opens only bump the depth. On the outermost
+        open, a readiness/build failure stops the service again before
+        re-raising, so a failed open never leaves the CPU pegged. Raises
+        RuntimeError if the config disabled the VNA.
+        """
+        if not self._vna_enabled:
+            raise RuntimeError(
+                "Cannot open a VNA session: VNA disabled in config "
+                "(use_vna=false)."
+            )
+        if self._vna_depth == 0:
+            if self._manage_vna_service:
+                vna_service.start()
+            try:
+                if self._manage_vna_service:
+                    vna_service.wait_ready(
+                        self.cfg["vna_ip"], self.cfg["vna_port"]
+                    )
+                self.init_VNA()
+            except Exception:
+                if self._manage_vna_service:
+                    try:
+                        vna_service.stop()
+                    except Exception:
+                        self.logger.warning(
+                            "cmtvna stop after failed open also failed",
+                            exc_info=True,
+                        )
+                raise
+        self._vna_depth += 1
+
+    def vna_close(self):
+        """Tear down the VNA and stop cmtvna.service on the outermost close."""
+        if self._vna_depth == 0:
+            return
+        self._vna_depth -= 1
+        if self._vna_depth > 0:
+            return
+        vna = self.vna
+        self.vna = None
+        sock = getattr(vna, "s", None)
+        if sock is not None and hasattr(sock, "close"):
+            try:
+                sock.close()
+            except Exception:
+                self.logger.warning("VNA socket close failed", exc_info=True)
+        if self._manage_vna_service:
+            try:
+                vna_service.stop()
+            except Exception:
+                self.logger.warning("cmtvna stop failed", exc_info=True)
+
+    @contextmanager
+    def vna_session(self):
+        """Context-managed VNA window: open on enter, close on exit.
+
+        Wrap it OUTSIDE ``coord.switch_section()`` so the ~5.5s warm-up
+        does not hold the RF-switch lock.
+        """
+        self.vna_open()
+        try:
+            yield
+        finally:
+            self.vna_close()
 
     def init_motor_client(self):
         """

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -412,6 +412,7 @@ class PandaClient:
                     )
                 self.init_VNA()
             except Exception:
+                self._teardown_vna()
                 if self._manage_vna_service:
                     try:
                         vna_service.stop()
@@ -423,13 +424,8 @@ class PandaClient:
                 raise
         self._vna_depth += 1
 
-    def vna_close(self):
-        """Tear down the VNA and stop cmtvna.service on the outermost close."""
-        if self._vna_depth == 0:
-            return
-        self._vna_depth -= 1
-        if self._vna_depth > 0:
-            return
+    def _teardown_vna(self):
+        """Close the VNA socket (if any) and clear the handle."""
         vna = self.vna
         self.vna = None
         sock = getattr(vna, "s", None)
@@ -438,6 +434,15 @@ class PandaClient:
                 sock.close()
             except Exception:
                 self.logger.warning("VNA socket close failed", exc_info=True)
+
+    def vna_close(self):
+        """Tear down the VNA and stop cmtvna.service on the outermost close."""
+        if self._vna_depth == 0:
+            return
+        self._vna_depth -= 1
+        if self._vna_depth > 0:
+            return
+        self._teardown_vna()
         if self._manage_vna_service:
             try:
                 vna_service.stop()

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -351,7 +351,8 @@ def test_measure_s11_publishes_conforming_payload(mode, tmp_path):
     transport = DummyTransport()
     client = DummyPandaClient(transport, cfg=cfg)
     try:
-        client.measure_s11(mode)
+        with client.vna_session():
+            client.measure_s11(mode)
         # The reader skips producer-backlog by design (see
         # test_vna_reader_skips_producer_backlog); rewind to stream
         # origin so this single-threaded test picks up the entry the

--- a/src/eigsep_observing/scripts/no_switch_observation.py
+++ b/src/eigsep_observing/scripts/no_switch_observation.py
@@ -97,9 +97,9 @@ def main(transport, args):
                     "Motor client not initialized; check motor pico "
                     "registration."
                 )
-            if client.vna is None:
+            if not client.vna_enabled:
                 raise RuntimeError(
-                    "VNA not initialized; check vna config block."
+                    "VNA disabled (use_vna=false); check vna config block."
                 )
 
             status.send("no_switch_observation started")

--- a/src/eigsep_observing/scripts/vna_position_sweep.py
+++ b/src/eigsep_observing/scripts/vna_position_sweep.py
@@ -111,9 +111,9 @@ def main(transport, args):
                     "Motor client not initialized; check motor pico "
                     "registration."
                 )
-            if client.vna is None:
+            if not client.vna_enabled:
                 raise RuntimeError(
-                    "VNA not initialized; check vna config block."
+                    "VNA disabled (use_vna=false); check vna config block."
                 )
 
             status.send(
@@ -128,22 +128,26 @@ def main(transport, args):
             client.motor_client.set_delay()
             client.motor_client.halt()
             client.motor_client.home()
-            for idx, (az, el) in enumerate(grid):
-                if client.stop_client.is_set():
-                    logger.info("stop_client set; aborting sweep")
-                    break
-                logger.info(
-                    f"[{idx + 1}/{len(grid)}] move_to az={az}, el={el}"
-                )
-                client.motor_client.move_to(az_deg=az, el_deg=el)
-                if settle_s > 0 and client.stop_client.wait(settle_s):
-                    break
-                with client.coord.switch_section():
-                    for mode in ("ant", "rec"):
-                        logger.info(
-                            f"[{idx + 1}/{len(grid)}] measure_s11({mode!r})"
-                        )
-                        client.measure_s11(mode)
+            # One service window for the whole burst: start cmtvna once,
+            # keep it warm across every grid point, stop it after.
+            with client.vna_session():
+                for idx, (az, el) in enumerate(grid):
+                    if client.stop_client.is_set():
+                        logger.info("stop_client set; aborting sweep")
+                        break
+                    logger.info(
+                        f"[{idx + 1}/{len(grid)}] move_to az={az}, el={el}"
+                    )
+                    client.motor_client.move_to(az_deg=az, el_deg=el)
+                    if settle_s > 0 and client.stop_client.wait(settle_s):
+                        break
+                    with client.coord.switch_section():
+                        for mode in ("ant", "rec"):
+                            logger.info(
+                                f"[{idx + 1}/{len(grid)}] "
+                                f"measure_s11({mode!r})"
+                            )
+                            client.measure_s11(mode)
             client.motor_client.home()
     except KeyboardInterrupt:
         logger.info("Sweep interrupted by user")

--- a/src/eigsep_observing/testing/client.py
+++ b/src/eigsep_observing/testing/client.py
@@ -94,6 +94,10 @@ class DummyPandaClient(PandaClient):
     their devices already registered.
     """
 
+    # The dummy client uses DummyVNA and has no cmtvna.service; never
+    # shell out to systemctl.
+    _manage_vna_service = False
+
     def __init__(self, transport=None, *, cfg=None):
         if transport is None:
             transport = DummyTransport()

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -327,7 +327,11 @@ def measure_s11(
     if mode not in ("ant", "rec"):
         raise ValueError(f"Unknown VNA mode: {mode}. Must be 'ant' or 'rec'.")
     if vna is None:
-        raise RuntimeError("VNA not initialized. Cannot execute VNA commands.")
+        raise RuntimeError(
+            "VNA not initialized. Open a VNA session first "
+            "(PandaClient.vna_open()/vna_session(), or "
+            "build_vna_subsystem)."
+        )
 
     vna.power_dBm = cfg["vna_settings"]["power_dBm"][mode]
     osl_s11 = vna.measure_OSL()

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -224,23 +224,11 @@ def build_vna_subsystem(transport, cfg, *, source, dummy=False):
         vna_cls = DummyVNA
         manager = start_dummy_pico_manager(transport)
     else:
-        # Real hardware: bring cmtvna.service up and wait for the R60
-        # before opening the socket. cleanup() stops it again.
+        # Real hardware: bring cmtvna.service up before opening the
+        # socket. cleanup() (below) stops it again — including on any
+        # failure during the build, so a half-built subsystem never
+        # leaves the CPU-pegging service running.
         vna_service.start()
-        vna_service.wait_ready(cfg["vna_ip"], cfg["vna_port"])
-
-    vna = vna_cls(
-        ip=cfg["vna_ip"],
-        port=cfg["vna_port"],
-        timeout=cfg["vna_timeout"],
-        switch_fn=switch_fn,
-    )
-
-    require_pico(sw_proxy)
-
-    setup_kwargs = cfg["vna_settings"].copy()
-    setup_kwargs["power_dBm"] = setup_kwargs["power_dBm"]["ant"]
-    vna.setup(**setup_kwargs)
 
     def cleanup():
         if manager is not None:
@@ -250,6 +238,23 @@ def build_vna_subsystem(transport, cfg, *, source, dummy=False):
                 vna_service.stop()
             except Exception:
                 logger.warning("cmtvna stop failed", exc_info=True)
+
+    try:
+        if not dummy:
+            vna_service.wait_ready(cfg["vna_ip"], cfg["vna_port"])
+        vna = vna_cls(
+            ip=cfg["vna_ip"],
+            port=cfg["vna_port"],
+            timeout=cfg["vna_timeout"],
+            switch_fn=switch_fn,
+        )
+        require_pico(sw_proxy)
+        setup_kwargs = cfg["vna_settings"].copy()
+        setup_kwargs["power_dBm"] = setup_kwargs["power_dBm"]["ant"]
+        vna.setup(**setup_kwargs)
+    except Exception:
+        cleanup()
+        raise
 
     return VnaSubsystem(
         vna=vna,

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -17,7 +17,7 @@ from eigsep_redis import (
 )
 from picohost.proxy import PicoProxy
 
-from . import imu_calibration, obs_config_owner, run_tag
+from . import imu_calibration, obs_config_owner, run_tag, vna_service
 from ._scripts_util import require_pico
 from .io import _validate_vna_s11_data, _validate_vna_s11_header
 from .keys import VNA_STREAM
@@ -187,14 +187,18 @@ def build_vna_subsystem(transport, cfg, *, source, dummy=False):
     dummy : bool, optional
         If True, use ``DummyVNA`` and start an in-process dummy
         ``PicoManager`` (so the ``rfswitch`` proxy resolves). The
-        manager is shut down by the returned ``cleanup`` callback.
+        manager is shut down by the returned ``cleanup`` callback. If
+        False (default), start ``cmtvna.service`` and wait for the R60
+        to answer before opening the socket; the returned ``cleanup``
+        stops the service again.
 
     Returns
     -------
     VnaSubsystem
         Dataclass with ``vna``, ``vna_writer``, ``metadata_snapshot``
         and a ``cleanup`` callable the caller must invoke on teardown
-        (idempotent; no-op when ``dummy=False``).
+        (stops the dummy ``PicoManager`` when ``dummy=True``, stops
+        ``cmtvna.service`` when ``dummy=False``).
 
     Raises
     ------
@@ -219,6 +223,11 @@ def build_vna_subsystem(transport, cfg, *, source, dummy=False):
 
         vna_cls = DummyVNA
         manager = start_dummy_pico_manager(transport)
+    else:
+        # Real hardware: bring cmtvna.service up and wait for the R60
+        # before opening the socket. cleanup() stops it again.
+        vna_service.start()
+        vna_service.wait_ready(cfg["vna_ip"], cfg["vna_port"])
 
     vna = vna_cls(
         ip=cfg["vna_ip"],
@@ -236,6 +245,11 @@ def build_vna_subsystem(transport, cfg, *, source, dummy=False):
     def cleanup():
         if manager is not None:
             manager.stop()
+        if not dummy:
+            try:
+                vna_service.stop()
+            except Exception:
+                logger.warning("cmtvna stop failed", exc_info=True)
 
     return VnaSubsystem(
         vna=vna,

--- a/src/eigsep_observing/vna_service.py
+++ b/src/eigsep_observing/vna_service.py
@@ -76,17 +76,23 @@ def wait_ready(ip, port, *, timeout=30.0, poll_interval=0.5):
     deadline = time.monotonic() + timeout
     last_exc = None
     while time.monotonic() < deadline:
+        res = None
         try:
             res = rm.open_resource(addr)
             res.read_termination = "\n"
             res.timeout = 2000
             idn = res.query("*IDN?\n")
-            res.close()
             logger.info("%s ready: %s", UNIT, idn.strip())
             return idn.strip()
         except Exception as exc:  # pyvisa raises many error types
             last_exc = exc
             time.sleep(poll_interval)
+        finally:
+            if res is not None:
+                try:
+                    res.close()
+                except Exception:
+                    pass
     raise TimeoutError(
         f"cmtvna not ready on {ip}:{port} after {timeout}s "
         f"(last error: {last_exc})"

--- a/src/eigsep_observing/vna_service.py
+++ b/src/eigsep_observing/vna_service.py
@@ -1,0 +1,93 @@
+"""On-demand control of ``cmtvna.service`` (panda-side).
+
+The CMT R60 driver binary runs as a systemd service in socket-server
+mode and busy-loops at ~300% CPU whenever it is up, so the field stack
+keeps it stopped and starts it only around an S11 measurement window.
+This module is the thin start/stop/readiness layer; the session
+lifecycle lives in :meth:`eigsep_observing.client.PandaClient.vna_session`
+and :func:`eigsep_observing.vna.build_vna_subsystem`.
+
+Panda-only: the caller runs on the same host as the service (``vna_ip``
+is ``127.0.0.1``). ``start``/``stop`` shell out to ``systemctl`` and fall
+back to ``sudo -n`` — the field image ships a sudoers drop-in granting
+the ``eigsep`` user passwordless start/stop of exactly this unit (mirrors
+the flash-picos ``systemctl``-then-``sudo -n`` fallback).
+"""
+
+import logging
+import subprocess
+import time
+
+import pyvisa
+
+UNIT = "cmtvna.service"
+
+logger = logging.getLogger(__name__)
+
+
+def _systemctl(action):
+    """Run ``systemctl <action> --no-ask-password cmtvna.service``.
+
+    Try plain ``systemctl`` first (works as root / when already
+    permitted), then ``sudo -n`` (passwordless via the image sudoers
+    drop-in). Raise ``RuntimeError`` with both captured outputs if both
+    fail.
+    """
+    base = ["systemctl", action, "--no-ask-password", UNIT]
+    first = subprocess.run(base, capture_output=True, text=True)
+    if first.returncode == 0:
+        return
+    second = subprocess.run(
+        ["sudo", "-n", *base], capture_output=True, text=True
+    )
+    if second.returncode == 0:
+        return
+    raise RuntimeError(
+        f"{action} {UNIT} failed: "
+        f"{(first.stderr or first.stdout).strip()!r} then "
+        f"{(second.stderr or second.stdout).strip()!r}"
+    )
+
+
+def start():
+    """Start ``cmtvna.service``. Idempotent (systemctl no-ops if active)."""
+    logger.info("Starting %s", UNIT)
+    _systemctl("start")
+
+
+def stop():
+    """Stop ``cmtvna.service`` to release the CPU."""
+    logger.info("Stopping %s", UNIT)
+    _systemctl("stop")
+
+
+def wait_ready(ip, port, *, timeout=30.0, poll_interval=0.5):
+    """Block until the cmtvna socket answers ``*IDN?``; raise on timeout.
+
+    The socket server accepts TCP before the instrument is ready, so we
+    probe at the SCPI level. Cold start is a consistent ~5.5s on the
+    panda; the 30s default is ~5x headroom.
+
+    Returns the trimmed ``*IDN?`` response. Raises ``TimeoutError`` if
+    the instrument never answers within ``timeout`` seconds.
+    """
+    rm = pyvisa.ResourceManager("@py")
+    addr = f"TCPIP::{ip}::{port}::SOCKET"
+    deadline = time.monotonic() + timeout
+    last_exc = None
+    while time.monotonic() < deadline:
+        try:
+            res = rm.open_resource(addr)
+            res.read_termination = "\n"
+            res.timeout = 2000
+            idn = res.query("*IDN?\n")
+            res.close()
+            logger.info("%s ready: %s", UNIT, idn.strip())
+            return idn.strip()
+        except Exception as exc:  # pyvisa raises many error types
+            last_exc = exc
+            time.sleep(poll_interval)
+    raise TimeoutError(
+        f"cmtvna not ready on {ip}:{port} after {timeout}s "
+        f"(last error: {last_exc})"
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -138,10 +138,11 @@ def test_pico_manager_devices_visible(client):
 
 
 def test_vna_loop_returns_when_vna_is_none(caplog, client):
-    """vna_loop must return promptly when self.vna is None — no
-    polling. Regression for a bare `threading.Event().wait(5)` that
-    ignored stop_client. Also asserts the warning rides both channels
-    (local + status stream) so the ground observer sees the failure."""
+    """vna_loop must return promptly when the VNA is disabled
+    (``use_vna=false``) — no polling. Regression for a bare
+    `threading.Event().wait(5)` that ignored stop_client. Also asserts
+    the warning rides both channels (local + status stream) so the
+    ground observer sees it."""
     caplog.set_level("WARNING")
     assert client.vna is None
     _arm_status_reader(client)
@@ -149,11 +150,13 @@ def test_vna_loop_returns_when_vna_is_none(caplog, client):
     client.vna_loop()
     elapsed = time.monotonic() - t0
     assert elapsed < 1.0, f"vna_loop did not return promptly ({elapsed}s)"
-    assert any("VNA not initialized" in r.getMessage() for r in caplog.records)
+    assert any(
+        "VNA disabled in config" in r.getMessage() for r in caplog.records
+    )
 
     level, status = _status_reader(client).read(timeout=1)
     assert level == logging.WARNING
-    assert "VNA not initialized" in status
+    assert "VNA disabled in config" in status
 
 
 def test_switch_loop_does_not_mutate_cfg_schedule(client):
@@ -2684,5 +2687,33 @@ def test_vna_open_resets_vna_on_build_failure(
         assert closed["n"] == 1  # socket closed
         assert events == ["start", "stop"]  # service started then stopped
         assert client._vna_depth == 0
+    finally:
+        client.stop()
+
+
+def test_vna_loop_measures_then_stops(transport, dummy_cfg):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    cfg["vna_interval"] = 0.05
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        from eigsep_observing.keys import VNA_STREAM
+
+        # Stop after the first iteration's measurements land.
+        import threading
+
+        def stopper():
+            while client.transport.r.xlen(VNA_STREAM) < 2:
+                pass
+            client.stop_client.set()
+
+        t = threading.Thread(target=stopper, daemon=True)
+        t.start()
+        client.vna_loop()  # returns once stop_client is set
+        t.join(timeout=5)
+        # ant + rec bundles were published in at least one session.
+        assert client.transport.r.xlen(VNA_STREAM) >= 2
+        # Session torn down on loop exit.
+        assert client.vna is None
     finally:
         client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2553,3 +2553,89 @@ def test_run_calibration_sequence_skips_invalid_modes(
         )
     finally:
         client.stop()
+
+
+def test_vna_lazy_none_until_session(transport, dummy_cfg):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        assert client.vna is None  # lazy: not built at construction
+        assert client.vna_enabled is True
+        with client.vna_session():
+            assert isinstance(client.vna, DummyVNA)
+        assert client.vna is None  # torn down on exit
+    finally:
+        client.stop()
+
+
+def test_vna_session_nests_without_early_teardown(transport, dummy_cfg):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        with client.vna_session():
+            outer = client.vna
+            with client.vna_session():
+                assert client.vna is outer  # inner reuses the object
+            assert client.vna is outer  # still alive after inner exit
+        assert client.vna is None
+    finally:
+        client.stop()
+
+
+def test_vna_open_rejected_when_disabled(client):
+    # default fixture cfg has use_vna=False
+    assert client.vna_enabled is False
+    with pytest.raises(RuntimeError, match="use_vna=false"):
+        client.vna_open()
+
+
+def test_vna_session_starts_and_stops_service(
+    transport, dummy_cfg, monkeypatch
+):
+    # Force the real (service-managed) path even on the dummy client.
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(transport, cfg=cfg)
+    monkeypatch.setattr(client, "_manage_vna_service", True)
+    events = []
+    from eigsep_observing import vna_service
+
+    monkeypatch.setattr(vna_service, "start", lambda: events.append("start"))
+    monkeypatch.setattr(vna_service, "stop", lambda: events.append("stop"))
+    monkeypatch.setattr(
+        vna_service, "wait_ready", lambda ip, port, **k: events.append("ready")
+    )
+    try:
+        with client.vna_session():
+            assert events == ["start", "ready"]
+        assert events == ["start", "ready", "stop"]
+    finally:
+        client.stop()
+
+
+def test_vna_session_stops_service_on_ready_failure(
+    transport, dummy_cfg, monkeypatch
+):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(transport, cfg=cfg)
+    monkeypatch.setattr(client, "_manage_vna_service", True)
+    events = []
+    from eigsep_observing import vna_service
+
+    monkeypatch.setattr(vna_service, "start", lambda: events.append("start"))
+    monkeypatch.setattr(vna_service, "stop", lambda: events.append("stop"))
+
+    def boom(ip, port, **k):
+        raise TimeoutError("not ready")
+
+    monkeypatch.setattr(vna_service, "wait_ready", boom)
+    try:
+        with pytest.raises(TimeoutError):
+            client.vna_open()
+        assert events == ["start", "stop"]  # service stopped on failure
+        assert client._vna_depth == 0
+    finally:
+        client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -779,7 +779,8 @@ def test_measure_s11_contract_violation_emits_on_both_channels(
             return_value=violations,
         ):
             caplog.set_level(logging.WARNING, logger="eigsep_observing.client")
-            client.measure_s11("ant")
+            with client.vna_session():
+                client.measure_s11("ant")
 
         # Panda-local log channel.
         warning_msgs = [
@@ -813,7 +814,8 @@ def test_measure_s11_clean_payload_does_not_send_status(transport, dummy_cfg):
     client = DummyPandaClient(transport, cfg=cfg)
     try:
         _arm_status_reader(client)
-        client.measure_s11("ant")
+        with client.vna_session():
+            client.measure_s11("ant")
         level, status = _status_reader(client).read(timeout=0.2)
     finally:
         client.stop()
@@ -831,7 +833,8 @@ def test_measure_s11_returns_published_payload(transport, dummy_cfg):
     cfg["use_vna"] = True
     client = DummyPandaClient(transport, cfg=cfg)
     try:
-        result = client.measure_s11("ant")
+        with client.vna_session():
+            result = client.measure_s11("ant")
         assert isinstance(result, tuple) and len(result) == 3
         s11, header, metadata = result
         assert set(("ant", "noise", "load")).issubset(s11.keys())
@@ -1109,12 +1112,13 @@ def test_measure_s11_uses_mode_specific_power_dbm(transport, dummy_cfg):
     cfg["use_vna"] = True
     client = DummyPandaClient(transport, cfg=cfg)
     try:
-        client.measure_s11("rec")
-        expected_rec = cfg["vna_settings"]["power_dBm"]["rec"]
-        assert client.vna.power_dBm == expected_rec
-        client.measure_s11("ant")
-        expected_ant = cfg["vna_settings"]["power_dBm"]["ant"]
-        assert client.vna.power_dBm == expected_ant
+        with client.vna_session():
+            client.measure_s11("rec")
+            expected_rec = cfg["vna_settings"]["power_dBm"]["rec"]
+            assert client.vna.power_dBm == expected_rec
+            client.measure_s11("ant")
+            expected_ant = cfg["vna_settings"]["power_dBm"]["ant"]
+            assert client.vna.power_dBm == expected_ant
     finally:
         client.stop()
 
@@ -1127,7 +1131,8 @@ def test_measure_s11_injects_overlay_sentinels(transport, dummy_cfg):
     client = DummyPandaClient(transport, cfg=cfg)
     try:
         with patch.object(client.vna_writer, "add") as mock_add:
-            client.measure_s11("ant")
+            with client.vna_session():
+                client.measure_s11("ant")
         assert mock_add.called
         header = mock_add.call_args.kwargs["header"]
         assert header["run_tag"] == "UNKNOWN"
@@ -1151,7 +1156,8 @@ def test_measure_s11_injects_published_run_tag(transport, dummy_cfg):
     try:
         run_tag.publish(transport, "vna_position_sweep", started_unix=12345.0)
         with patch.object(client.vna_writer, "add") as mock_add:
-            client.measure_s11("rec")
+            with client.vna_session():
+                client.measure_s11("rec")
         header = mock_add.call_args.kwargs["header"]
         assert header["run_tag"] == "vna_position_sweep"
         assert header["run_started_at_unix"] == 12345.0
@@ -1171,7 +1177,8 @@ def test_measure_s11_injects_published_owner(transport, dummy_cfg):
             transport, "panda_observe", uploaded_at_unix=7.5
         )
         with patch.object(client.vna_writer, "add") as mock_add:
-            client.measure_s11("ant")
+            with client.vna_session():
+                client.measure_s11("ant")
         header = mock_add.call_args.kwargs["header"]
         assert header["obs_config_owner"] == "panda_observe"
         assert header["obs_config_owner_uploaded_unix"] == 7.5

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2700,11 +2700,12 @@ def test_vna_loop_measures_then_stops(transport, dummy_cfg):
         from eigsep_observing.keys import VNA_STREAM
 
         # Stop after the first iteration's measurements land.
-        import threading
-
         def stopper():
-            while client.transport.r.xlen(VNA_STREAM) < 2:
-                pass
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if client.transport.r.xlen(VNA_STREAM) >= 2:
+                    break
+                time.sleep(0.01)
             client.stop_client.set()
 
         t = threading.Thread(target=stopper, daemon=True)
@@ -2714,6 +2715,52 @@ def test_vna_loop_measures_then_stops(transport, dummy_cfg):
         # ant + rec bundles were published in at least one session.
         assert client.transport.r.xlen(VNA_STREAM) >= 2
         # Session torn down on loop exit.
+        assert client.vna is None
+    finally:
+        client.stop()
+
+
+def test_vna_loop_survives_session_open_failure(
+    transport, dummy_cfg, monkeypatch, caplog
+):
+    """A failed vna_open (service won't start) must not kill vna_loop:
+    it logs and continues to the next iteration."""
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    cfg["vna_interval"] = 0.01
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        from eigsep_observing.keys import VNA_STREAM
+
+        calls = {"n": 0}
+        orig_open = client.vna_open
+
+        def flaky_open():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("service start failed")
+            return orig_open()
+
+        monkeypatch.setattr(client, "vna_open", flaky_open)
+
+        def stopper():
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if client.transport.r.xlen(VNA_STREAM) >= 2:
+                    break
+                time.sleep(0.01)
+            client.stop_client.set()
+
+        caplog.set_level(logging.ERROR, logger="eigsep_observing.client")
+        t = threading.Thread(target=stopper, daemon=True)
+        t.start()
+        client.vna_loop()
+        t.join(timeout=5)
+
+        assert calls["n"] >= 2  # first open failed, a later one succeeded
+        assert any(
+            "VNA session failed" in r.getMessage() for r in caplog.records
+        )
         assert client.vna is None
     finally:
         client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2639,3 +2639,43 @@ def test_vna_session_stops_service_on_ready_failure(
         assert client._vna_depth == 0
     finally:
         client.stop()
+
+
+def test_vna_open_resets_vna_on_build_failure(
+    transport, dummy_cfg, monkeypatch
+):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    client = DummyPandaClient(transport, cfg=cfg)
+    monkeypatch.setattr(client, "_manage_vna_service", True)
+    from eigsep_observing import vna_service
+
+    events = []
+    monkeypatch.setattr(vna_service, "start", lambda: events.append("start"))
+    monkeypatch.setattr(vna_service, "stop", lambda: events.append("stop"))
+    monkeypatch.setattr(vna_service, "wait_ready", lambda ip, port, **k: None)
+
+    closed = {"n": 0}
+
+    class FakeSock:
+        def close(self):
+            closed["n"] += 1
+
+    class HalfVNA:
+        s = FakeSock()
+
+    def failing_init():
+        # mimic init_VNA assigning self.vna then setup() raising
+        client.vna = HalfVNA()
+        raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(client, "init_VNA", failing_init)
+    try:
+        with pytest.raises(RuntimeError, match="setup failed"):
+            client.vna_open()
+        assert client.vna is None  # not leaked
+        assert closed["n"] == 1  # socket closed
+        assert events == ["start", "stop"]  # service started then stopped
+        assert client._vna_depth == 0
+    finally:
+        client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2419,14 +2419,19 @@ def test_coord_lock_is_rlock(client):
     client.coord.lock.release()
 
 
-def test_run_calibration_sequence_skips_vna_when_uninitialized(client, caplog):
-    """No VNA → calibration logs a warning and proceeds to dwells."""
+def test_run_calibration_sequence_skips_vna_when_disabled(client, caplog):
+    """use_vna=false → calibration logs a warning and proceeds to
+    dwells without opening a VNA session.
+    """
     assert client.vna is None  # dummy_cfg has use_vna: false
     caplog.set_level("WARNING")
     schedule = {"RFANT": 60, "RFNOFF": 0.05}
     completed = client.run_calibration_sequence(schedule=schedule)
     assert completed is True
-    assert any("VNA not initialized" in r.getMessage() for r in caplog.records)
+    assert any(
+        "VNA disabled (use_vna=false)" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_run_calibration_sequence_filters_rfant(transport, dummy_cfg):
@@ -2762,5 +2767,20 @@ def test_vna_loop_survives_session_open_failure(
             "VNA session failed" in r.getMessage() for r in caplog.records
         )
         assert client.vna is None
+    finally:
+        client.stop()
+
+
+def test_run_calibration_sequence_uses_session(transport, dummy_cfg):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    cfg["switch_schedule"] = {}  # skip dwell phase; test the VNA block
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        from eigsep_observing.keys import VNA_STREAM
+
+        assert client.run_calibration_sequence() is True
+        assert client.transport.r.xlen(VNA_STREAM) >= 2  # ant + rec
+        assert client.vna is None  # session closed after the block
     finally:
         client.stop()

--- a/tests/test_vna_helper.py
+++ b/tests/test_vna_helper.py
@@ -330,3 +330,70 @@ def dummy_cfg_vna(dummy_cfg):
     cfg = dict(dummy_cfg)
     cfg["use_vna"] = True
     return cfg
+
+
+def test_build_vna_subsystem_real_stops_service_on_wait_ready_failure(
+    monkeypatch, dummy_cfg
+):
+    from eigsep_redis.testing import DummyTransport
+    from eigsep_observing import vna, vna_service
+    from cmt_vna.testing import DummyVNA
+    from eigsep_observing.testing import start_dummy_pico_manager
+
+    events = []
+    monkeypatch.setattr(vna_service, "start", lambda: events.append("start"))
+    monkeypatch.setattr(vna_service, "stop", lambda: events.append("stop"))
+
+    def boom(ip, port, **k):
+        raise TimeoutError("not ready")
+
+    monkeypatch.setattr(vna_service, "wait_ready", boom)
+    monkeypatch.setattr(vna, "VNA", DummyVNA)
+
+    transport = DummyTransport()
+    mgr = start_dummy_pico_manager(transport)
+    try:
+        with pytest.raises(TimeoutError):
+            vna.build_vna_subsystem(
+                transport,
+                dummy_cfg_vna(dummy_cfg),
+                source="test",
+                dummy=False,
+            )
+        assert events == ["start", "stop"]
+    finally:
+        mgr.stop()
+
+
+def test_build_vna_subsystem_real_stops_service_on_build_failure(
+    monkeypatch, dummy_cfg
+):
+    from eigsep_redis.testing import DummyTransport
+    from eigsep_observing import vna, vna_service
+    from cmt_vna.testing import DummyVNA
+    from eigsep_observing.testing import start_dummy_pico_manager
+
+    events = []
+    monkeypatch.setattr(vna_service, "start", lambda: events.append("start"))
+    monkeypatch.setattr(vna_service, "stop", lambda: events.append("stop"))
+    monkeypatch.setattr(vna_service, "wait_ready", lambda ip, port, **k: None)
+
+    class BoomVNA(DummyVNA):
+        def setup(self, **kwargs):
+            raise RuntimeError("setup boom")
+
+    monkeypatch.setattr(vna, "VNA", BoomVNA)
+
+    transport = DummyTransport()
+    mgr = start_dummy_pico_manager(transport)
+    try:
+        with pytest.raises(RuntimeError, match="setup boom"):
+            vna.build_vna_subsystem(
+                transport,
+                dummy_cfg_vna(dummy_cfg),
+                source="test",
+                dummy=False,
+            )
+        assert events == ["start", "stop"]
+    finally:
+        mgr.stop()

--- a/tests/test_vna_helper.py
+++ b/tests/test_vna_helper.py
@@ -294,3 +294,39 @@ def test_measure_s11_helper_freqs_match_setup(transport, dummy_cfg):
     assert freqs[0] == pytest.approx(dummy_cfg["vna_settings"]["fstart"])
     assert freqs[-1] == pytest.approx(dummy_cfg["vna_settings"]["fstop"])
     assert freqs.size == dummy_cfg["vna_settings"]["npoints"]
+
+
+def test_build_vna_subsystem_real_manages_service(monkeypatch, dummy_cfg):
+    from eigsep_redis.testing import DummyTransport
+    from eigsep_observing import vna, vna_service
+    from cmt_vna.testing import DummyVNA
+
+    events = []
+    monkeypatch.setattr(vna_service, "start", lambda: events.append("start"))
+    monkeypatch.setattr(vna_service, "stop", lambda: events.append("stop"))
+    monkeypatch.setattr(
+        vna_service, "wait_ready", lambda ip, port, **k: events.append("ready")
+    )
+    # Build the real (non-dummy) subsystem but with the VNA class faked
+    # so no real socket is opened.
+    monkeypatch.setattr(vna, "VNA", DummyVNA)
+
+    transport = DummyTransport()
+    from eigsep_observing.testing import start_dummy_pico_manager
+
+    mgr = start_dummy_pico_manager(transport)
+    try:
+        sub = vna.build_vna_subsystem(
+            transport, dummy_cfg_vna(dummy_cfg), source="test", dummy=False
+        )
+        assert events == ["start", "ready"]
+        sub.cleanup()
+        assert events == ["start", "ready", "stop"]
+    finally:
+        mgr.stop()
+
+
+def dummy_cfg_vna(dummy_cfg):
+    cfg = dict(dummy_cfg)
+    cfg["use_vna"] = True
+    return cfg

--- a/tests/test_vna_service.py
+++ b/tests/test_vna_service.py
@@ -91,3 +91,35 @@ def test_wait_ready_times_out(monkeypatch):
     monkeypatch.setattr(vna_service.time, "monotonic", fake_monotonic)
     with pytest.raises(TimeoutError, match="cmtvna not ready"):
         vna_service.wait_ready("127.0.0.1", 5025, timeout=2.0)
+
+
+def test_wait_ready_closes_resource_on_query_failure(monkeypatch):
+    closed = {"n": 0}
+    attempts = {"n": 0}
+
+    class FakeResource:
+        read_termination = None
+        timeout = None
+
+        def query(self, _msg):
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                raise OSError("instrument not ready")
+            return "CMT,R60,1,1.7.1\n"
+
+        def close(self):
+            closed["n"] += 1
+
+    class FakeRM:
+        def open_resource(self, _addr):
+            return FakeResource()
+
+    monkeypatch.setattr(
+        vna_service.pyvisa, "ResourceManager", lambda _b: FakeRM()
+    )
+    monkeypatch.setattr(vna_service.time, "sleep", lambda _s: None)
+
+    idn = vna_service.wait_ready("127.0.0.1", 5025, timeout=30.0)
+    assert idn == "CMT,R60,1,1.7.1"
+    # closed on the failed attempt AND the successful one
+    assert closed["n"] == 2

--- a/tests/test_vna_service.py
+++ b/tests/test_vna_service.py
@@ -1,0 +1,93 @@
+import subprocess
+
+import pytest
+
+from eigsep_observing import vna_service
+
+
+def test_start_runs_systemctl_start(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    vna_service.start()
+    assert calls == [
+        ["systemctl", "start", "--no-ask-password", "cmtvna.service"]
+    ]
+
+
+def test_start_falls_back_to_sudo(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        rc = 0 if cmd[0] == "sudo" else 1
+        return subprocess.CompletedProcess(cmd, rc, "", "boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    vna_service.start()
+    assert calls[0][0] == "systemctl"
+    assert calls[1][:2] == ["sudo", "-n"]
+
+
+def test_start_raises_when_both_fail(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, "", "nope")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="start cmtvna.service failed"):
+        vna_service.start()
+
+
+def test_wait_ready_returns_idn_after_retries(monkeypatch):
+    attempts = {"n": 0}
+
+    class FakeResource:
+        read_termination = None
+        timeout = None
+
+        def query(self, _msg):
+            return "CMT,R60,123,1.7.1\n"
+
+        def close(self):
+            pass
+
+    class FakeRM:
+        def open_resource(self, _addr):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise OSError("connection refused")
+            return FakeResource()
+
+    monkeypatch.setattr(
+        vna_service.pyvisa, "ResourceManager", lambda _b: FakeRM()
+    )
+    monkeypatch.setattr(vna_service.time, "sleep", lambda _s: None)
+
+    idn = vna_service.wait_ready("127.0.0.1", 5025, timeout=30.0)
+    assert idn == "CMT,R60,123,1.7.1"
+    assert attempts["n"] == 3
+
+
+def test_wait_ready_times_out(monkeypatch):
+    clock = {"t": 0.0}
+
+    class FakeRM:
+        def open_resource(self, _addr):
+            raise OSError("refused")
+
+    monkeypatch.setattr(
+        vna_service.pyvisa, "ResourceManager", lambda _b: FakeRM()
+    )
+    monkeypatch.setattr(vna_service.time, "sleep", lambda _s: None)
+
+    def fake_monotonic():
+        clock["t"] += 1.0
+        return clock["t"]
+
+    monkeypatch.setattr(vna_service.time, "monotonic", fake_monotonic)
+    with pytest.raises(TimeoutError, match="cmtvna not ready"):
+        vna_service.wait_ready("127.0.0.1", 5025, timeout=2.0)


### PR DESCRIPTION
## Summary

Makes the CMT VNA connection **lazy and lifecycle-managed** so `cmtvna.service` — the CMT R60 driver binary, which busy-loops at ~300% CPU whenever it runs — stays **stopped except around an S11 measurement window**. Today it runs 24/7 and heats the Pi even though S11 is measured only ~once/hour (occasionally in bursts).

This is the **eigsep_observing half of a two-repo change.** It must land **in lockstep** with the paired `eigsep-field` PR (which flips `cmtvna.service` to an `on-demand` activation and adds the sudoers rule that lets this code start/stop it). On its own this branch is correct and fully tested; the deployed CPU win only materializes once the image PR flips too.

## What changed

- **New `eigsep_observing.vna_service`** — `start()` / `stop()` (shell out to `systemctl … --no-ask-password cmtvna.service`, with a `sudo -n` fallback mirroring flash-picos) and `wait_ready()` (SCPI `*IDN?` probe with a 30s cap; cold start measured a consistent ~5.5s on the panda).
- **`PandaClient` VNA is now lazy** — `init_VNA()` no longer runs in `__init__`; `self.vna` is `None` between sessions. New refcounted `vna_open()` / `vna_close()` / `vna_session()` trio starts the service → waits ready → builds a **fresh** `VNA` (fresh socket + full `setup()` re-push, so a restarted instrument is always reconfigured) → measures → closes the socket → stops the service. A failed open never leaves the service running or `self.vna` non-None.
- **`DummyPandaClient._manage_vna_service = False`** — the dummy/CI path uses `DummyVNA` and never touches `systemctl`.
- **Call sites wrapped**, sized so the ~5.5s cold start is paid once per window:
  - `vna_loop` — one session per iteration (service down during the `vna_interval` wait).
  - `run_calibration_sequence` — one session around its ant+rec block.
  - `scripts/vna_position_sweep.py` — **one** session around the whole grid (burst stays warm).
  - `scripts/vna_manual.py` — whole REPL runs in one window via `build_vna_subsystem`.
- **`build_vna_subsystem`** starts/stops the service on the real path (dummy path unchanged); stops it even if the build fails after start.
- Script pre-flight checks changed from `client.vna is None` to `not client.vna_enabled` (the VNA is lazily `None` now).
- `measure_s11` outside a session raises a clear "open a VNA session first" error.

## Session ⊃ switch_section

Sessions wrap **outside** `coord.switch_section()` so the warm-up never holds the RF-switch lock; the inter-iteration `vna_interval` wait is outside the session so the service is stopped during it.

## Testing

Full suite: **866 passed, 1 skipped** (the skip is `test_casperfpga_api` via `importorskip`, environmental). New tests cover: readiness retry/timeout/close-on-every-attempt; refcount nesting; failed-open teardown (service stopped, `vna` reset); `vna_loop` measure-then-stop and session-open-failure recovery; `run_calibration_sequence` session; `build_vna_subsystem` real-path start/stop incl. two failure paths.

## Review

Built via a spec → plan → subagent-per-task flow with a task review after each task and an adversarial whole-branch review at the end. The reviews caught and fixed **four real bugs** in the original plan code (readiness-probe fd leak, failed-open VNA leak, `vna_loop` recovery-path test gap, `build_vna_subsystem` service leak on build failure). Final whole-branch verdict: **ready to merge**, no Critical/Important findings.

### Suggested (non-blocking) follow-ups
- Add a direct `pyvisa` pin to `pyproject.toml` (now imported directly in `vna_service`; currently transitive via `eigsep-vna`).
- Add a `run_calibration_sequence` session-open-failure test to match the `vna_loop` one (identical pattern, already tested there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
