### PR TITLE
feat: per-channel corr linear-range product for headers + live status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,25 @@ If you change the on-disk format in the future, update `read_hdf5` to
 invert the transformation so that callers never need to know about the
 storage representation.
 
+## Linear-range product: operating-point-validated, omit-on-mismatch
+
+`linear_range.py` defines the per-channel linear-range calibration
+product (min/max raw corr counts, NaN where the fit is degenerate,
+e.g. above the LPF cutoff), fit by
+`scripts/linearity_test/fit_linearity.py` from a manual attenuation
+sweep and shipped as an npz in `data/` named by `linear_range_file`
+in `corr_config.yaml` (null = feature off). Two consumers load it via
+the shared `load_linear_range`: `append_corr_header` (native
+`linear_range_min`/`linear_range_max` float datasets in corr file
+headers, injected writer-side like `freqs` because the Redis header
+is JSON) and the live-status aggregator (dashed bounds on the raw
+corr plot; NaN → JSON null → Plotly line gap). Both validate
+`OPERATING_POINT_FIELDS` (adc_gain, fft_shift, corr_scalar, ...)
+against the live corr header and **omit the bounds with an ERROR
+log on any failure** — bounds from a different operating point are
+junk, and a bad product must never block corr writes. Re-fit the
+product after any operating-point change.
+
 ## Testing philosophy: dummies over mocks
 
 When testing classes that interact with hardware, Redis, or other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ where = ["src"]
 "eigsep_observing" = [
   "config/*.yaml",
   "data/*.fpg",
+  "data/*.npz",
   "live_status/templates/*.html",
   "live_status/static/css/*.css",
   "live_status/static/js/*.js",

--- a/scripts/linearity_test/README.md
+++ b/scripts/linearity_test/README.md
@@ -1,0 +1,53 @@
+# SNAP linearity test
+
+Measures the linear range of the SNAP signal chain per frequency
+channel and turns it into the `linear_range_file` calibration product
+consumed by corr file headers and the live-status dashboard (dashed
+min/max bounds on the corr spectrum plot).
+
+Prior art: the April 2026 total-power test (memo in
+`memos/linearity/`), which eyeballed the linear range from log-log
+plots. This workflow supersedes it with per-channel line fits.
+
+## Workflow
+
+1. **Sweep** (lab, manual step attenuator on the noise source):
+
+   ```
+   python corr_linearity.py --redis-host 10.10.10.10 --outfile sweep
+   ```
+
+   At each attenuation step, type the dB value and press Enter; the
+   script records `--nsamples` integrations of the full per-channel
+   auto spectra for inputs 0 and 1, plus the corr header — the
+   operating-point provenance (adc_gain, fft_shift, corr_scalar, ...)
+   the product is validated against downstream. If your noise source
+   or LPF differ from the defaults, record them with
+   `--noise-density-dbm-hz` / `--bandwidth-hz`.
+
+2. **Fit**:
+
+   ```
+   python fit_linearity.py sweep.npz --plot
+   ```
+
+   Per input and channel this fits log10(counts) vs input power (dBm)
+   on a sigma-clipped middle region; steps within `--threshold-db`
+   (default 1 dB) of the fit are "linear", and the min/max bounds are
+   the measured counts at the lowest/highest linear step. Channels
+   with too little dynamic range (e.g. above the LPF cutoff) get NaN
+   bounds. Bounds are median-smoothed across frequency
+   (`--smooth-window`) and combined into a conservative envelope
+   across inputs. Inspect the `*_diagnostics.png` before deploying.
+
+3. **Deploy**: commit the product npz to
+   `src/eigsep_observing/data/` and set `linear_range_file` in
+   `config/corr_config.yaml`. From then on corr files carry
+   `linear_range_min`/`linear_range_max` header datasets and
+   live-status draws the dashed bounds. Both consumers validate the
+   product's operating point against the live corr header and omit
+   the bounds (with an ERROR log) on mismatch — re-fit after any
+   operating-point change.
+
+`plot_linear.py` plots total power vs input power for both the new
+per-channel sweeps and the archived April 2026 total-power npz files.

--- a/scripts/linearity_test/corr_linearity.py
+++ b/scripts/linearity_test/corr_linearity.py
@@ -1,17 +1,24 @@
 """Correlator linearity test. Grabs auto-correlation spectra from Redis
-at each attenuation step (set manually) and saves total power per input.
+at each attenuation step (set manually on the noise-source step
+attenuator) and saves the full per-channel spectra per input, plus the
+corr header as operating-point provenance for ``fit_linearity.py`` —
+the fitted linear-range product is only valid at the operating point
+(adc_gain, fft_shift, corr_scalar, ...) it was measured at.
 
 Usage:
     python corr_linearity.py --redis-host 10.10.10.10 --outfile linearity_corr
 """
 
 import argparse
+import json
+
 import numpy as np
 
 from eigsep_redis import Transport
 
 from eigsep_observing.corr import CorrConfigStore, CorrReader
 from eigsep_observing.io import reshape_data
+from eigsep_observing.utils import calc_freqs_dfreq
 
 parser = argparse.ArgumentParser(
     description="Correlator linearity test",
@@ -23,7 +30,7 @@ parser.add_argument(
     "--nsamples",
     type=int,
     default=10,
-    help="Number of integrations to average per step",
+    help="Number of integrations to record per step",
 )
 parser.add_argument(
     "--outfile",
@@ -31,22 +38,42 @@ parser.add_argument(
     default="linearity_corr",
     help="Output npz filename (without extension)",
 )
+parser.add_argument(
+    "--noise-density-dbm-hz",
+    type=float,
+    default=-75.0,
+    help="Noise-source power spectral density at 0 dB attenuation",
+)
+parser.add_argument(
+    "--bandwidth-hz",
+    type=float,
+    default=225e6,
+    help="Lowpass filter cutoff limiting the injected noise band",
+)
 args = parser.parse_args()
 
 transport = Transport(host=args.redis_host, port=args.redis_port)
 corr_reader = CorrReader(transport)
 print(f"Connected to Redis at {args.redis_host}:{args.redis_port}")
 
-# Data layout follows the firmware version the producer stamped on the
-# corr config (acc_bins 1 for v2.4 single-spectrum, 2 for legacy
+# The full producer header is the operating-point provenance the
+# fitted product gets validated against downstream; without it the
+# sweep cannot become a product, so require it up front.
+header = CorrConfigStore(transport).get_header()  # raises if unpublished
+
+# Data layout follows the firmware version the producer stamped on
+# the header (acc_bins 1 for v2.4 single-spectrum, 2 for legacy
 # even/odd). Read it once; the firmware does not change mid-run.
-_corr_cfg = CorrConfigStore(transport).get()
-acc_bins = _corr_cfg.get("acc_bins", 2)
-avg_even_odd = _corr_cfg.get("avg_even_odd", True)
+acc_bins = header.get("acc_bins", 2)
+avg_even_odd = header.get("avg_even_odd", True)
+freqs, _ = calc_freqs_dfreq(
+    float(header["sample_rate"]) * 1e6, int(header["nchan"])
+)
 
 pairs = ["0", "1"]
 attens = []
-power = {p: [] for p in pairs}
+spectra = {p: [] for p in pairs}
+acc_cnts = []
 
 print("At each attenuation step, press Enter to capture.")
 print("Type 'done' to finish and save.\n")
@@ -67,7 +94,8 @@ while True:
         corr_reader.seek(last_id[0][0])
 
     print(f"  Capturing {args.nsamples} integrations...")
-    pwr = {p: [] for p in pairs}
+    step_spectra = {p: [] for p in pairs}
+    step_cnts = []
     last_cnt = None
     collected = 0
     while collected < args.nsamples:
@@ -78,19 +106,28 @@ while True:
         data = {k: v for k, v in data.items() if k in pairs}
         data = reshape_data(data, acc_bins=acc_bins, avg_even_odd=avg_even_odd)
         for p in pairs:
-            pwr[p].append(np.sum(data[p]))
+            # reshape_data returns (ntimes=1, nchan) per auto
+            step_spectra[p].append(data[p][0])
+        step_cnts.append(acc_cnt)
         collected += 1
 
     attens.append(atten)
+    acc_cnts.append(step_cnts)
     for p in pairs:
-        mean_pwr = np.mean(pwr[p])
-        power[p].append(mean_pwr)
-        print(f"  Input {p}: total power = {mean_pwr:.2e}")
+        step_arr = np.array(step_spectra[p])
+        spectra[p].append(step_arr)
+        total = step_arr.mean(axis=0).sum()
+        print(f"  Input {p}: total power = {total:.2e}")
 
 print(f"\nSaving {len(attens)} points to {args.outfile}.npz")
 np.savez(
     args.outfile,
     attenuation_dB=np.array(attens),
-    **{f"power_{p}": np.array(power[p]) for p in pairs},
+    freqs=freqs,
+    header_json=json.dumps(header),
+    noise_density_dbm_hz=args.noise_density_dbm_hz,
+    bandwidth_hz=args.bandwidth_hz,
+    acc_cnts=np.array(acc_cnts),
+    **{f"spectra_{p}": np.array(spectra[p]) for p in pairs},
 )
 print("Done.")

--- a/scripts/linearity_test/fit_linearity.py
+++ b/scripts/linearity_test/fit_linearity.py
@@ -1,0 +1,375 @@
+"""Fit per-channel linear-range bounds from a corr_linearity sweep.
+
+Reads the per-channel sweep npz written by ``corr_linearity.py`` and,
+per input and per frequency channel, fits a line to
+``log10(counts)`` vs input power (dBm) over a robust middle region
+(sigma-clipped). The linear range is the set of attenuation steps
+whose measured counts stay within ``--threshold-db`` of the fit; the
+per-channel min/max bounds are the measured counts at the lowest and
+highest linear step. Channels with too little dynamic range or too
+few usable steps (e.g. above the anti-aliasing LPF cutoff, where the
+noise source injects no power) get NaN bounds.
+
+The per-input bounds are median-smoothed across frequency and
+combined into a conservative envelope (min bound = max over inputs,
+max bound = min over inputs), then saved as a linear-range product
+npz via :func:`eigsep_observing.linear_range.save_linear_range`. To
+deploy the product, commit it to ``src/eigsep_observing/data/`` and
+set ``linear_range_file`` in ``corr_config.yaml``.
+
+Usage:
+    python fit_linearity.py linearity_corr.npz --plot
+"""
+
+import argparse
+import json
+import time
+import warnings
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from eigsep_observing.linear_range import save_linear_range
+
+MAX_CLIP_ITERATIONS = 5
+# Steps within this margin of a channel's weakest measurement are
+# averaged into its noise-floor estimate.
+FLOOR_BAND_DB = 3.0
+
+parser = argparse.ArgumentParser(
+    description="Fit per-channel linear-range bounds from a sweep npz",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("sweep", type=str, help="Sweep npz from corr_linearity")
+parser.add_argument(
+    "--outfile",
+    type=str,
+    default=None,
+    help=(
+        "Output product npz; default "
+        "corr_linear_range_v<maj>_<min>_<date>.npz from the sweep header"
+    ),
+)
+parser.add_argument(
+    "--threshold-db",
+    type=float,
+    default=1.0,
+    help="Max |deviation| from the fit line for a step to count linear",
+)
+parser.add_argument(
+    "--floor-margin-db",
+    type=float,
+    default=6.0,
+    help="Steps must exceed the channel noise floor by this to enter the fit",
+)
+parser.add_argument(
+    "--min-steps",
+    type=int,
+    default=4,
+    help="Minimum fit steps per channel; fewer masks the channel (NaN)",
+)
+parser.add_argument(
+    "--min-dynamic-range-db",
+    type=float,
+    default=10.0,
+    help="Minimum floor-to-peak range per channel; less masks the "
+    "channel (NaN)",
+)
+parser.add_argument(
+    "--smooth-window",
+    type=int,
+    default=17,
+    help="Median-filter window (channels) for the bound curves; odd",
+)
+parser.add_argument(
+    "--noise-density-dbm-hz",
+    type=float,
+    default=None,
+    help="Override the sweep's recorded noise-source density",
+)
+parser.add_argument(
+    "--bandwidth-hz",
+    type=float,
+    default=None,
+    help="Override the sweep's recorded noise bandwidth",
+)
+parser.add_argument(
+    "--plot",
+    action="store_true",
+    help="Save and show diagnostic plots",
+)
+
+
+def fit_channel(
+    p_in_dbm, counts, threshold_db, floor_margin_db, min_steps, min_dr_db
+):
+    """Fit one channel's log10(counts) vs input power.
+
+    Parameters
+    ----------
+    p_in_dbm : np.ndarray
+        Input power per step (dBm), sorted ascending.
+    counts : np.ndarray
+        Mean measured counts per step (same order).
+    threshold_db, floor_margin_db, min_steps, min_dr_db
+        See the CLI flags of the same names.
+
+    Returns
+    -------
+    slope, intercept, min_counts, max_counts : float
+        All NaN when the channel is degenerate (insufficient dynamic
+        range or too few fit steps).
+
+    """
+    nan4 = (np.nan,) * 4
+    positive = counts > 0
+    if not positive.any():
+        return nan4
+    floor_ceiling = counts[positive].min() * 10 ** (FLOOR_BAND_DB / 10)
+    floor_mask = positive & (counts <= floor_ceiling)
+    floor = counts[floor_mask].mean()
+    peak = counts[positive].max()
+    if 10 * np.log10(peak / floor) < min_dr_db:
+        return nan4
+    candidates = positive & (counts > floor * 10 ** (floor_margin_db / 10))
+    if candidates.sum() < min_steps:
+        return nan4
+
+    with np.errstate(divide="ignore"):
+        log_counts = np.log10(np.where(positive, counts, np.nan))
+    mask = candidates
+    slope = intercept = None
+    for _ in range(MAX_CLIP_ITERATIONS):
+        slope, intercept = np.polyfit(p_in_dbm[mask], log_counts[mask], 1)
+        resid_db = 10 * (log_counts - (slope * p_in_dbm + intercept))
+        new_mask = candidates & (np.abs(resid_db) <= threshold_db)
+        if new_mask.sum() < min_steps:
+            break  # keep the previous (last valid) fit
+        if (new_mask == mask).all():
+            break
+        mask = new_mask
+
+    resid_db = 10 * (log_counts - (slope * p_in_dbm + intercept))
+    linear = positive & (np.abs(resid_db) <= threshold_db)
+    if not linear.any():
+        return nan4
+    idx = np.nonzero(linear)[0]
+    return slope, intercept, counts[idx[0]], counts[idx[-1]]
+
+
+def nan_median_smooth(arr, window):
+    """NaN-aware sliding median that preserves the input's NaN mask.
+
+    Smoothing must not invent bounds for masked (degenerate-fit)
+    channels, so the original NaN mask is re-applied after filtering.
+    """
+    if window <= 1:
+        return arr.copy()
+    pad = window // 2
+    padded = np.pad(arr, pad, constant_values=np.nan)
+    windows = np.lib.stride_tricks.sliding_window_view(padded, window)
+    out = np.full(arr.shape, np.nan)
+    has_data = (~np.isnan(windows)).any(axis=1)
+    out[has_data] = np.nanmedian(windows[has_data], axis=1)
+    out[np.isnan(arr)] = np.nan
+    return out
+
+
+def main():
+    args = parser.parse_args()
+    if args.smooth_window % 2 == 0:
+        parser.error("--smooth-window must be odd")
+
+    sweep = np.load(args.sweep, allow_pickle=False)
+    header = json.loads(str(sweep["header_json"]))
+    freqs = sweep["freqs"]
+    inputs = sorted(
+        k[len("spectra_") :] for k in sweep.files if k.startswith("spectra_")
+    )
+
+    noise_density = (
+        args.noise_density_dbm_hz
+        if args.noise_density_dbm_hz is not None
+        else float(sweep["noise_density_dbm_hz"])
+    )
+    bandwidth = (
+        args.bandwidth_hz
+        if args.bandwidth_hz is not None
+        else float(sweep["bandwidth_hz"])
+    )
+    total_power_dbm = noise_density + 10 * np.log10(bandwidth)
+    p_in_dbm = total_power_dbm - sweep["attenuation_dB"]
+
+    # Sort steps by ascending input power so "lowest/highest linear
+    # step" is well defined regardless of sweep direction.
+    order = np.argsort(p_in_dbm)
+    p_in_dbm = p_in_dbm[order]
+
+    nchan = freqs.size
+    per_input = {}
+    counts_by_input = {}
+    for p in inputs:
+        counts = sweep[f"spectra_{p}"].astype(np.float64).mean(axis=1)
+        counts = counts[order]
+        counts_by_input[p] = counts
+        fields = {
+            name: np.full(nchan, np.nan)
+            for name in ("slope", "intercept", "linear_min", "linear_max")
+        }
+        for c in range(nchan):
+            slope, intercept, lo, hi = fit_channel(
+                p_in_dbm,
+                counts[:, c],
+                args.threshold_db,
+                args.floor_margin_db,
+                args.min_steps,
+                args.min_dynamic_range_db,
+            )
+            fields["slope"][c] = slope
+            fields["intercept"][c] = intercept
+            fields["linear_min"][c] = lo
+            fields["linear_max"][c] = hi
+        raw_min, raw_max = fields["linear_min"], fields["linear_max"]
+        fields["linear_min"] = nan_median_smooth(raw_min, args.smooth_window)
+        fields["linear_max"] = nan_median_smooth(raw_max, args.smooth_window)
+        per_input[p] = fields
+        nfit = np.isfinite(fields["linear_min"]).sum()
+        print(f"Input {p}: {nfit}/{nchan} channels fit")
+
+    with warnings.catch_warnings():
+        # all-NaN channels are expected (masked band); nanmax/nanmin
+        # warn on them and correctly yield NaN.
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        linear_min = np.nanmax(
+            np.vstack([per_input[p]["linear_min"] for p in inputs]), axis=0
+        )
+        linear_max = np.nanmin(
+            np.vstack([per_input[p]["linear_max"] for p in inputs]), axis=0
+        )
+    inverted = np.isfinite(linear_min) & (linear_min >= linear_max)
+    if inverted.any():
+        print(
+            f"WARNING: {inverted.sum()} channels have inverted envelope "
+            "(inputs disagree); masking them"
+        )
+        linear_min[inverted] = np.nan
+        linear_max[inverted] = np.nan
+    nfit = np.isfinite(linear_min).sum()
+    print(f"Combined envelope: {nfit}/{nchan} channels bounded")
+
+    outfile = args.outfile
+    if outfile is None:
+        maj, minor = header.get("fpg_version", ["x", "x"])
+        date = time.strftime("%Y-%m-%d")
+        outfile = f"corr_linear_range_v{maj}_{minor}_{date}.npz"
+    save_linear_range(
+        outfile,
+        freqs=freqs,
+        linear_min=linear_min,
+        linear_max=linear_max,
+        header=header,
+        threshold_db=args.threshold_db,
+        smooth_window=args.smooth_window,
+        created_unix=time.time(),
+        source_file=Path(args.sweep).name,
+        per_input=per_input,
+    )
+    print(f"Saved product to {outfile}")
+
+    if args.plot:
+        plot_diagnostics(
+            outfile,
+            freqs,
+            p_in_dbm,
+            counts_by_input,
+            per_input,
+            linear_min,
+            linear_max,
+        )
+
+
+def plot_diagnostics(
+    outfile,
+    freqs,
+    p_in_dbm,
+    counts_by_input,
+    per_input,
+    linear_min,
+    linear_max,
+):
+    freq_mhz = freqs * 1e-6
+    inputs = sorted(counts_by_input)
+    nchan = freqs.size
+    sample_chans = [nchan // 4, nchan // 2, 3 * nchan // 4]
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5))
+
+    ax = axes[0]
+    for p in inputs:
+        counts = counts_by_input[p]
+        fields = per_input[p]
+        for c in sample_chans:
+            (line,) = ax.plot(
+                p_in_dbm,
+                counts[:, c],
+                "o",
+                ms=4,
+                label=f"in{p} ch{c} ({freq_mhz[c]:.0f} MHz)",
+            )
+            slope, intercept = fields["slope"][c], fields["intercept"][c]
+            if np.isfinite(slope):
+                ax.plot(
+                    p_in_dbm,
+                    10 ** (slope * p_in_dbm + intercept),
+                    "--",
+                    color=line.get_color(),
+                    lw=1,
+                )
+    ax.set_yscale("log")
+    ax.set_xlabel("Input power (dBm)")
+    ax.set_ylabel("Counts")
+    ax.set_title("Per-channel fits (sample channels)")
+    ax.legend(fontsize=7)
+    ax.grid(True)
+
+    ax = axes[1]
+    for p in inputs:
+        fields = per_input[p]
+        ax.plot(freq_mhz, fields["linear_min"], lw=1, label=f"in{p} min")
+        ax.plot(freq_mhz, fields["linear_max"], lw=1, label=f"in{p} max")
+    ax.plot(freq_mhz, linear_min, "k--", lw=1.5, label="envelope min")
+    ax.plot(freq_mhz, linear_max, "k--", lw=1.5, label="envelope max")
+    ax.set_yscale("log")
+    ax.set_xlabel("Frequency (MHz)")
+    ax.set_ylabel("Counts")
+    ax.set_title("Linear-range bounds")
+    ax.legend(fontsize=7)
+    ax.grid(True)
+
+    ax = axes[2]
+    p = inputs[0]
+    counts = counts_by_input[p]
+    fields = per_input[p]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        fit = 10 ** (
+            fields["slope"][None, :] * p_in_dbm[:, None]
+            + fields["intercept"][None, :]
+        )
+        resid_db = 10 * np.log10(counts / fit)
+    im = ax.pcolormesh(
+        freq_mhz, p_in_dbm, resid_db, vmin=-3, vmax=3, cmap="RdBu_r"
+    )
+    fig.colorbar(im, ax=ax, label="Residual (dB)")
+    ax.set_xlabel("Frequency (MHz)")
+    ax.set_ylabel("Input power (dBm)")
+    ax.set_title(f"Fit residuals, input {p}")
+
+    fig.tight_layout()
+    png = str(Path(outfile).with_suffix("")) + "_diagnostics.png"
+    fig.savefig(png, dpi=150)
+    print(f"Saved diagnostics to {png}")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linearity_test/plot_linear.py
+++ b/scripts/linearity_test/plot_linear.py
@@ -49,9 +49,32 @@ if args.adc:
 if args.corr:
     ax = axes[idx]
     d = np.load(args.corr)
-    input_power = TOTAL_POWER_DBM - d["attenuation_dB"]
-    ax.plot(input_power, d["power_0"], "o-", label="Input N0")
-    ax.plot(input_power, d["power_1"], "s-", label="Input E2")
+    # Old sweeps (April 2026) stored total power directly as
+    # power_{p}; per-channel sweeps store spectra_{p} with shape
+    # (nsteps, nsamples, nchan) — reduce to total power on the fly.
+    if "power_0" in d.files:
+        total_power_dbm = TOTAL_POWER_DBM
+        power = {
+            k[len("power_") :]: d[k] for k in d.files if k.startswith("power_")
+        }
+    else:
+        total_power_dbm = float(d["noise_density_dbm_hz"]) + 10 * np.log10(
+            float(d["bandwidth_hz"])
+        )
+        power = {
+            k[len("spectra_") :]: d[k].mean(axis=1).sum(axis=-1)
+            for k in d.files
+            if k.startswith("spectra_")
+        }
+    input_power = total_power_dbm - d["attenuation_dB"]
+    markers = "os^vD"
+    for i, p in enumerate(sorted(power)):
+        ax.plot(
+            input_power,
+            power[p],
+            markers[i % len(markers)] + "-",
+            label=f"Input {p}",
+        )
     ax.set_yscale("log")
     ax.set_xlabel("Input power (dBm)")
     ax.set_ylabel("Total power (correlator units)")

--- a/src/eigsep_observing/config/corr_config.yaml
+++ b/src/eigsep_observing/config/corr_config.yaml
@@ -60,5 +60,13 @@ adc_snapshot_period_s: 0
 # headroom that matters as corr_acc_len is lowered. Set to 0 to disable
 # both; absent → defaults to 1.0.
 diagnostics_period_s: 1.0
+# Per-channel linear-range calibration product (npz in the packaged
+# data/ dir, produced by scripts/linearity_test/fit_linearity.py).
+# When set, the file writer embeds linear_range_min/max in corr
+# headers and live-status draws them as dashed bounds on the corr
+# plot — both after validating the product's operating point against
+# the live corr header (mismatch => ERROR log, bounds omitted).
+# null = feature off (no product measured for this operating point).
+linear_range_file: null
 # Hardware wiring (antenna → FEM → PAM → SNAP input mapping) lives in
 # `wiring.yaml`, not here. This file is software-only.

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -12,6 +12,11 @@ import threading
 import time
 from pathlib import Path
 
+from .linear_range import (
+    LinearRangeError,
+    load_linear_range,
+    validate_operating_point,
+)
 from .utils import calc_times, calc_freqs_dfreq
 
 logger = logging.getLogger(__name__)
@@ -216,7 +221,8 @@ def corr_pair_labels(header, pairs):
 def append_corr_header(header, acc_cnts, sync_times):
     """
     Append header for correlation files with useful computed
-    quantities: times and frequencies.
+    quantities: times, frequencies, and (when configured via
+    ``linear_range_file``) the per-channel linear-range bounds.
 
     Each computed field is wrapped in a try/except so that a missing
     or malformed header field cannot prevent the corr data from being
@@ -266,6 +272,35 @@ def append_corr_header(header, acc_cnts, sync_times):
             f"({type(e).__name__}: {e}). 'freqs' and 'dfreq' will be "
             f"missing from the file. Producer must be fixed."
         )
+    # Per-channel linear-range bounds (raw corr counts), from the
+    # packaged calibration product named by ``linear_range_file`` in
+    # corr_config.yaml (which reaches this header via the set_header
+    # cfg merge). Bounds measured at a different operating point are
+    # junk, so a mismatch omits them — fix the config or re-measure.
+    lr_file = header.get("linear_range_file")
+    if lr_file:
+        try:
+            product = load_linear_range(lr_file)
+        except LinearRangeError as e:
+            logger.error(
+                f"Linear-range contract violation: {e}. "
+                f"'linear_range_min'/'linear_range_max' will be "
+                f"missing from the file. Fix 'linear_range_file' in "
+                f"corr_config or regenerate the product."
+            )
+        else:
+            mismatches = validate_operating_point(product["header"], header)
+            if mismatches:
+                logger.error(
+                    f"Linear-range operating-point mismatch for "
+                    f"{lr_file!r}: {'; '.join(mismatches)}. "
+                    f"'linear_range_min'/'linear_range_max' will be "
+                    f"missing from the file. Re-measure the product "
+                    f"at this operating point or fix corr_config."
+                )
+            else:
+                new_header["linear_range_min"] = product["linear_min"]
+                new_header["linear_range_max"] = product["linear_max"]
     return new_header
 
 

--- a/src/eigsep_observing/linear_range.py
+++ b/src/eigsep_observing/linear_range.py
@@ -1,0 +1,272 @@
+"""
+Per-channel correlator linear-range calibration product.
+
+The product is an npz file produced by
+``scripts/linearity_test/fit_linearity.py`` from a manual noise-source
+attenuation sweep. It holds per-channel minimum and maximum raw corr
+counts inside which the SNAP signal chain was measured to be linear
+(NaN where the fit is degenerate, e.g. above the anti-aliasing LPF
+cutoff), plus the full corr header of the measurement as the
+operating-point provenance.
+
+Two consumers share this module:
+
+- ``io.append_corr_header`` injects the bounds into corr file headers
+  as native float datasets at file-write time.
+- The live-status aggregator draws them as dashed reference curves on
+  the corr spectrum plot.
+
+Both consumers must validate the product's operating point against the
+live corr header (:func:`validate_operating_point`) and **omit** the
+bounds on mismatch — bounds measured at a different operating point
+(gain, FFT shift, accumulation length, ...) are junk data. Failures
+raise :class:`LinearRangeError` here; consumers log at ERROR and move
+on, so a bad product can never block corr data.
+"""
+
+import functools
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from .utils import get_data_path
+
+logger = logging.getLogger(__name__)
+
+# Corr-header fields that pin the operating point the product was
+# measured at. If any of these differ between the product and the live
+# header, the counts-space bounds do not transfer.
+OPERATING_POINT_FIELDS = (
+    "nchan",
+    "sample_rate",
+    "adc_gain",
+    "fft_shift",
+    "corr_scalar",
+    "corr_acc_len",
+    "acc_bins",
+    "avg_even_odd",
+    "fpg_version",
+)
+
+# npz keys every product file must carry. Per-input provenance keys
+# (``linear_min_{p}``, ``slope_{p}``, ...) are optional and discovered
+# by prefix scan.
+_REQUIRED_KEYS = (
+    "freqs",
+    "linear_min",
+    "linear_max",
+    "header_json",
+    "threshold_db",
+    "smooth_window",
+    "created_unix",
+    "source_file",
+)
+
+
+class LinearRangeError(ValueError):
+    """A linear-range product file is missing, unreadable, or malformed."""
+
+
+def save_linear_range(
+    path,
+    *,
+    freqs,
+    linear_min,
+    linear_max,
+    header,
+    threshold_db,
+    smooth_window,
+    created_unix,
+    source_file,
+    per_input=None,
+):
+    """
+    Write a linear-range product npz.
+
+    The single writer of the product schema — used by
+    ``fit_linearity.py`` and by test fixtures, so fixtures match the
+    production format by construction.
+
+    Parameters
+    ----------
+    path : str or Path
+        Output file path.
+    freqs : array_like
+        Frequency axis in Hz, shape (nchan,).
+    linear_min, linear_max : array_like
+        Per-channel bounds in raw corr counts, shape (nchan,),
+        NaN where the fit was degenerate.
+    header : dict
+        Corr header of the measurement (JSON-native), the
+        operating-point provenance.
+    threshold_db : float
+        Deviation-from-fit tolerance used to define the linear region.
+    smooth_window : int
+        Median-filter window (channels) applied across frequency.
+    created_unix : float
+        Product creation time (unix seconds).
+    source_file : str
+        Name of the sweep npz the product was fit from.
+    per_input : dict, optional
+        Per-input provenance, ``{input: {field: (nchan,) array}}`` with
+        fields ``linear_min``, ``linear_max``, ``slope``, ``intercept``.
+
+    """
+    freqs = np.asarray(freqs, dtype=np.float64)
+    linear_min = np.asarray(linear_min, dtype=np.float64)
+    linear_max = np.asarray(linear_max, dtype=np.float64)
+    if not (freqs.shape == linear_min.shape == linear_max.shape):
+        raise LinearRangeError(
+            f"shape mismatch: freqs {freqs.shape}, "
+            f"linear_min {linear_min.shape}, linear_max {linear_max.shape}"
+        )
+    flat = {}
+    for p, fields in (per_input or {}).items():
+        for field, arr in fields.items():
+            flat[f"{field}_{p}"] = np.asarray(arr, dtype=np.float64)
+    np.savez(
+        path,
+        freqs=freqs,
+        linear_min=linear_min,
+        linear_max=linear_max,
+        header_json=json.dumps(header),
+        threshold_db=float(threshold_db),
+        smooth_window=int(smooth_window),
+        created_unix=float(created_unix),
+        source_file=str(source_file),
+        **flat,
+    )
+
+
+def load_linear_range(fname):
+    """
+    Load a linear-range product npz.
+
+    Non-absolute names resolve against the packaged
+    ``eigsep_observing/data/`` directory, mirroring the ``fpg_file``
+    convention. Results are cached per resolved path (product files
+    are immutable, versioned artifacts); the returned arrays are
+    marked read-only so one consumer cannot corrupt another's view.
+
+    Returns
+    -------
+    dict
+        Keys ``freqs``, ``linear_min``, ``linear_max`` (read-only
+        float64 arrays), ``header`` (dict — the measurement's corr
+        header), ``threshold_db``, ``smooth_window``, ``created_unix``,
+        ``source_file``, and ``per_input``
+        (``{input: {field: array}}``).
+
+    Raises
+    ------
+    LinearRangeError
+        If the file is missing, unreadable, or violates the product
+        schema.
+
+    """
+    path = Path(fname)
+    if not path.is_absolute():
+        path = Path(get_data_path(fname))
+    return _load_cached(str(path))
+
+
+@functools.lru_cache(maxsize=8)
+def _load_cached(path):
+    try:
+        with np.load(path, allow_pickle=False) as npz:
+            return _parse_product(npz, path)
+    except LinearRangeError:
+        raise
+    except Exception as e:
+        # np.load failure modes span OSError, ValueError, and
+        # zipfile.BadZipFile; collapse them into the module's typed
+        # contract error so consumers catch exactly one thing.
+        raise LinearRangeError(
+            f"cannot load linear-range product {path!r} "
+            f"({type(e).__name__}: {e})"
+        ) from e
+
+
+def _parse_product(npz, path):
+    missing = [k for k in _REQUIRED_KEYS if k not in npz.files]
+    if missing:
+        raise LinearRangeError(
+            f"linear-range product {path!r} is missing required "
+            f"keys: {missing}"
+        )
+    product = {
+        "freqs": npz["freqs"].astype(np.float64),
+        "linear_min": npz["linear_min"].astype(np.float64),
+        "linear_max": npz["linear_max"].astype(np.float64),
+        "header": json.loads(str(npz["header_json"])),
+        "threshold_db": float(npz["threshold_db"]),
+        "smooth_window": int(npz["smooth_window"]),
+        "created_unix": float(npz["created_unix"]),
+        "source_file": str(npz["source_file"]),
+    }
+    nchan = product["freqs"].shape
+    for key in ("linear_min", "linear_max"):
+        if product[key].shape != nchan:
+            raise LinearRangeError(
+                f"linear-range product {path!r}: {key} shape "
+                f"{product[key].shape} != freqs shape {nchan}"
+            )
+    per_input = {}
+    prefixes = ("linear_min_", "linear_max_", "slope_", "intercept_")
+    for key in npz.files:
+        for prefix in prefixes:
+            if key.startswith(prefix):
+                p = key[len(prefix) :]
+                field = prefix[:-1]
+                per_input.setdefault(p, {})[field] = npz[key].astype(
+                    np.float64
+                )
+                break
+    product["per_input"] = per_input
+    for arr in (
+        product["freqs"],
+        product["linear_min"],
+        product["linear_max"],
+    ):
+        arr.setflags(write=False)
+    for fields in per_input.values():
+        for arr in fields.values():
+            arr.setflags(write=False)
+    return product
+
+
+def validate_operating_point(product_header, live_header):
+    """
+    Compare the product's operating point against a live corr header.
+
+    Parameters
+    ----------
+    product_header : dict
+        The ``header`` entry of a loaded product.
+    live_header : dict
+        The current corr header (from ``CorrConfigStore.get_header``
+        or the merged file header).
+
+    Returns
+    -------
+    list of str
+        One human-readable entry per mismatched
+        ``OPERATING_POINT_FIELDS`` field; empty means the product is
+        valid for this header. A field missing on either side counts
+        as a mismatch — silence is not agreement.
+
+    """
+    mismatches = []
+    for name in OPERATING_POINT_FIELDS:
+        prod = product_header.get(name)
+        live = live_header.get(name)
+        # JSON round-trips tuples to lists; normalize before comparing.
+        if isinstance(prod, tuple):
+            prod = list(prod)
+        if isinstance(live, tuple):
+            live = list(live)
+        if prod != live:
+            mismatches.append(f"{name}: product={prod!r} live={live!r}")
+    return mismatches

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -62,6 +62,11 @@ from ..corr_health import read as read_corr_health
 from ..file_heartbeat import read as read_file_heartbeat
 from ..host_health import read as read_host_health
 from ..io import RFSWITCH_TRANSITION_WINDOW_S, reshape_data
+from ..linear_range import (
+    LinearRangeError,
+    load_linear_range,
+    validate_operating_point,
+)
 from ..run_tag import read as read_run_tag
 from ..snap_reinit import read as read_snap_reinit
 from ..utils import calc_freqs_dfreq
@@ -116,6 +121,17 @@ class StateSnapshot:
     corr_freqs: Optional[np.ndarray] = None
     corr_header: Optional[dict] = None
     corr_config: Optional[dict] = None
+
+    # Per-channel linear-range bounds (raw corr counts, NaN-masked)
+    # from the packaged calibration product named by
+    # ``corr_config["linear_range_file"]``, populated only after the
+    # product's operating point validates against the live corr
+    # header. ``linear_range_key`` memoizes the (file, header-upload)
+    # pair so a bad product logs one ERROR per header publish, not one
+    # per ~1 s tick.
+    corr_linear_min: Optional[np.ndarray] = None
+    corr_linear_max: Optional[np.ndarray] = None
+    linear_range_key: Optional[tuple] = None
 
     # ADC stats stream (SNAP side, one entry per diagnostics-period
     # tick).
@@ -602,6 +618,8 @@ class LiveStatusAggregator:
                         float(sample_rate) * 1e6, int(nchan)
                     )
                     s.corr_freqs = freqs
+            if header is not None or cfg is not None:
+                self._maybe_load_linear_range(s)
 
             if corr_result is not None:
                 acc_cnt, pairs_data = corr_result
@@ -845,6 +863,57 @@ class LiveStatusAggregator:
             return
         self.thresholds = self.thresholds.with_header(header)
         self._thresholds_int_time = new_int_time
+
+    def _maybe_load_linear_range(self, s: StateSnapshot) -> None:
+        """Populate the per-channel linear-range bounds on ``s``.
+
+        Called under ``self._lock`` from ``_snap_tick`` whenever the
+        corr config or header was (re)read. Loads the packaged product
+        named by ``corr_config["linear_range_file"]`` and validates its
+        operating point against the live corr header; a failed load or
+        mismatch clears the bounds. Memoized on the (file,
+        ``header_upload_unix``) pair so a chronic failure logs one
+        ERROR per header publish instead of one per tick (the tick
+        re-reads config/header every ~1 s).
+        """
+        cfg = s.corr_config or {}
+        lr_file = cfg.get("linear_range_file")
+        header = s.corr_header
+        if not lr_file or header is None:
+            s.corr_linear_min = None
+            s.corr_linear_max = None
+            s.linear_range_key = None
+            return
+        key = (lr_file, header.get("header_upload_unix"))
+        if key == s.linear_range_key:
+            return
+        s.linear_range_key = key
+        s.corr_linear_min = None
+        s.corr_linear_max = None
+        try:
+            product = load_linear_range(lr_file)
+        except LinearRangeError as e:
+            logger.error(
+                "Linear-range contract violation: %s. Dashed bounds "
+                "will be missing from the corr plot. Fix "
+                "'linear_range_file' in corr_config or regenerate "
+                "the product.",
+                e,
+            )
+            return
+        mismatches = validate_operating_point(product["header"], header)
+        if mismatches:
+            logger.error(
+                "Linear-range operating-point mismatch for %r: %s. "
+                "Dashed bounds will be missing from the corr plot. "
+                "Re-measure the product at this operating point or "
+                "fix corr_config.",
+                lr_file,
+                "; ".join(mismatches),
+            )
+            return
+        s.corr_linear_min = product["linear_min"]
+        s.corr_linear_max = product["linear_max"]
 
     # -- panda drain loop ------------------------------------------
 

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -318,9 +318,23 @@ def _corr_payload(
         "freq_mhz": ((freqs * 1e-6).tolist() if freqs is not None else None),
         "pairs": pairs_out,
     }
+    if state.corr_linear_min is not None and state.corr_linear_max is not None:
+        # NaN (degenerate-fit channels, e.g. above the LPF cutoff)
+        # must become JSON null: stdlib json emits bare ``NaN`` tokens
+        # that JS ``JSON.parse`` rejects, and Plotly renders null as a
+        # line gap — exactly the wanted look for masked channels. The
+        # bounds are raw counts, so the front end draws them on the
+        # raw (uncalibrated) view only.
+        payload["linear_min"] = _nan_to_none(state.corr_linear_min)
+        payload["linear_max"] = _nan_to_none(state.corr_linear_max)
     if cal_meta is not None:
         payload["calibration_meta"] = cal_meta
     return payload
+
+
+def _nan_to_none(arr: np.ndarray) -> list:
+    """Return ``arr`` as a JSON-safe list with NaN mapped to None."""
+    return [None if math.isnan(v) else v for v in arr.tolist()]
 
 
 def _metadata_payload(state: StateSnapshot, thresholds: Thresholds) -> dict:

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -401,6 +401,28 @@ function updateCorr(corr) {
   // toggle to decide which axis to render.
   const isCalibrated =
     getUseCalibrated() && corr.calibration_meta && !corr.calibration_meta.stale;
+  // Measured linear-range bounds (raw counts) as dashed reference
+  // curves — raw view only; they are meaningless on the Kelvin axis.
+  // null entries (degenerate-fit channels, e.g. above the LPF cutoff)
+  // render as line gaps.
+  if (!isCalibrated && corr.linear_min && corr.linear_max) {
+    for (const [bounds, name] of [
+      [corr.linear_min, "linear range min"],
+      [corr.linear_max, "linear range max"],
+    ]) {
+      magTraces.push({
+        x: freqs,
+        y: bounds,
+        type: "scatter",
+        mode: "lines",
+        name,
+        line: { dash: "dash", width: 1, color: activeTheme.font },
+        opacity: 0.5,
+        hoverinfo: "skip",
+        showlegend: false,
+      });
+    }
+  }
   const layout = isCalibrated ? magLayoutCal : magLayoutRaw;
   if (!magPlotInitialized) {
     Plotly.newPlot("plot-mag", magTraces, layout, { displayModeBar: false });

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -27,6 +27,7 @@ from conftest import (
     tempctrl_post_handler_reading,
 )
 from eigsep_observing import io
+from eigsep_observing.linear_range import save_linear_range
 from eigsep_observing.testing.utils import (
     compare_dicts,
     generate_data,
@@ -3720,3 +3721,109 @@ def test_imu_az_derived_fields_round_trip():
     assert avg["el_deg"] == 0.0
     assert avg["az_blend_weight"] == 1.0
     assert "az_from_accel_deg" in avg and "az_from_yaw_deg" in avg
+
+
+# -- linear-range header injection ------------------------------------
+#
+# ``append_corr_header`` embeds the per-channel linear-range bounds
+# when the (cfg-merged) header names a product file. Product fixtures
+# are written with ``save_linear_range`` — the production writer — so
+# they match the real file schema by construction.
+
+
+def _write_linear_range_product(path, header=HEADER):
+    nchan = HEADER["nchan"]
+    linear_min = np.full(nchan, 1e5)
+    linear_max = np.full(nchan, 5e8)
+    # NaN-masked top band, as the real fit produces above the LPF cutoff
+    linear_min[-nchan // 10 :] = np.nan
+    linear_max[-nchan // 10 :] = np.nan
+    save_linear_range(
+        path,
+        freqs=np.arange(nchan, dtype=np.float64),
+        linear_min=linear_min,
+        linear_max=linear_max,
+        header=header,
+        threshold_db=1.0,
+        smooth_window=17,
+        created_unix=1751000000.0,
+        source_file="linearity_corr.npz",
+    )
+    return linear_min, linear_max
+
+
+def _append_header_args():
+    acc_cnts = np.arange(1, 4)
+    sync_times = np.full(3, HEADER["sync_time"])
+    return acc_cnts, sync_times
+
+
+def test_append_corr_header_injects_linear_range(tmp_path):
+    product_path = tmp_path / "product.npz"
+    linear_min, linear_max = _write_linear_range_product(product_path)
+    header = dict(HEADER, linear_range_file=str(product_path))
+    new_header = io.append_corr_header(header, *_append_header_args())
+    np.testing.assert_array_equal(new_header["linear_range_min"], linear_min)
+    np.testing.assert_array_equal(new_header["linear_range_max"], linear_max)
+
+
+def test_append_corr_header_linear_range_off_by_default(caplog):
+    """Absent or null ``linear_range_file`` disables the feature with
+    no ERROR noise — that's the shipped default until a product is
+    measured."""
+    with caplog.at_level(logging.ERROR):
+        new_header = io.append_corr_header(
+            dict(HEADER), *_append_header_args()
+        )
+        null_header = io.append_corr_header(
+            dict(HEADER, linear_range_file=None), *_append_header_args()
+        )
+    assert "linear_range_min" not in new_header
+    assert "linear_range_min" not in null_header
+    assert not [r for r in caplog.records if "inear-range" in r.message]
+
+
+def test_append_corr_header_missing_product_logs_error(tmp_path, caplog):
+    header = dict(HEADER, linear_range_file=str(tmp_path / "nope.npz"))
+    with caplog.at_level(logging.ERROR):
+        new_header = io.append_corr_header(header, *_append_header_args())
+    assert "linear_range_min" not in new_header
+    assert "linear_range_max" not in new_header
+    errors = [r for r in caplog.records if "Linear-range" in r.message]
+    assert len(errors) == 1
+    # corr-sacred: the rest of the header is intact
+    assert "freqs" in new_header
+    assert "times" in new_header
+
+
+def test_append_corr_header_operating_point_mismatch_omits(tmp_path, caplog):
+    product_path = tmp_path / "product.npz"
+    measured_header = dict(HEADER, adc_gain=HEADER["adc_gain"] + 1)
+    _write_linear_range_product(product_path, header=measured_header)
+    header = dict(HEADER, linear_range_file=str(product_path))
+    with caplog.at_level(logging.ERROR):
+        new_header = io.append_corr_header(header, *_append_header_args())
+    assert "linear_range_min" not in new_header
+    assert "linear_range_max" not in new_header
+    errors = [r for r in caplog.records if "mismatch" in r.message]
+    assert len(errors) == 1
+    assert "adc_gain" in errors[0].message
+
+
+def test_linear_range_bounds_hdf5_round_trip(tmp_path):
+    """The injected bounds land as native float datasets and round-trip
+    through write_hdf5 → read_hdf5 with the NaN mask intact."""
+    product_path = tmp_path / "product.npz"
+    linear_min, linear_max = _write_linear_range_product(product_path)
+    header = dict(HEADER, linear_range_file=str(product_path))
+    full_header = io.append_corr_header(header, *_append_header_args())
+    data = generate_data(reshape=True)
+    fname = tmp_path / "corr_linear_range.h5"
+    io.write_hdf5(fname, data, full_header)
+    _, read_header, _ = io.read_hdf5(fname)
+    read_min = read_header["linear_range_min"]
+    read_max = read_header["linear_range_max"]
+    assert isinstance(read_min, np.ndarray)
+    assert read_min.dtype == np.float64
+    np.testing.assert_array_equal(read_min, linear_min)
+    np.testing.assert_array_equal(read_max, linear_max)

--- a/tests/test_linear_range.py
+++ b/tests/test_linear_range.py
@@ -1,0 +1,152 @@
+"""Tests for the linear-range calibration product (linear_range.py).
+
+Product fixtures are written with ``save_linear_range`` — the same
+writer ``fit_linearity.py`` uses — so they match the production file
+schema by construction.
+"""
+
+import numpy as np
+import pytest
+
+from conftest import HEADER
+from eigsep_observing import linear_range
+
+NCHAN = HEADER["nchan"]
+
+
+def _product_arrays():
+    """(freqs, linear_min, linear_max) shaped like a real fit output.
+
+    The top ~10% of channels are NaN-masked, mirroring the band above
+    the 225 MHz LPF cutoff where the noise source injects no power and
+    the per-channel fit is degenerate.
+    """
+    freqs = np.arange(NCHAN) * (500e6 / 2 / NCHAN)
+    linear_min = np.full(NCHAN, 1e5)
+    linear_max = np.full(NCHAN, 5e8)
+    linear_min[-NCHAN // 10 :] = np.nan
+    linear_max[-NCHAN // 10 :] = np.nan
+    return freqs, linear_min, linear_max
+
+
+def _write_product(path, header=HEADER, **overrides):
+    freqs, linear_min, linear_max = _product_arrays()
+    kwargs = dict(
+        freqs=freqs,
+        linear_min=linear_min,
+        linear_max=linear_max,
+        header=header,
+        threshold_db=1.0,
+        smooth_window=17,
+        created_unix=1751000000.0,
+        source_file="linearity_corr.npz",
+        per_input={
+            "0": {
+                "linear_min": linear_min,
+                "linear_max": linear_max,
+                "slope": np.full(NCHAN, 0.1),
+                "intercept": np.full(NCHAN, 7.0),
+            },
+        },
+    )
+    kwargs.update(overrides)
+    linear_range.save_linear_range(path, **kwargs)
+    return path
+
+
+def test_save_load_round_trip(tmp_path):
+    path = _write_product(tmp_path / "product.npz")
+    product = linear_range.load_linear_range(str(path))
+    freqs, linear_min, linear_max = _product_arrays()
+    np.testing.assert_array_equal(product["freqs"], freqs)
+    np.testing.assert_array_equal(product["linear_min"], linear_min)
+    np.testing.assert_array_equal(product["linear_max"], linear_max)
+    assert product["header"] == HEADER
+    assert product["threshold_db"] == 1.0
+    assert product["smooth_window"] == 17
+    assert product["created_unix"] == 1751000000.0
+    assert product["source_file"] == "linearity_corr.npz"
+    assert set(product["per_input"]) == {"0"}
+    per = product["per_input"]["0"]
+    assert set(per) == {"linear_min", "linear_max", "slope", "intercept"}
+    np.testing.assert_array_equal(per["slope"], np.full(NCHAN, 0.1))
+
+
+def test_loaded_arrays_are_read_only(tmp_path):
+    path = _write_product(tmp_path / "product.npz")
+    product = linear_range.load_linear_range(str(path))
+    with pytest.raises(ValueError):
+        product["linear_min"][0] = 0.0
+
+
+def test_load_is_cached_per_path(tmp_path):
+    path = _write_product(tmp_path / "product.npz")
+    first = linear_range.load_linear_range(str(path))
+    second = linear_range.load_linear_range(str(path))
+    assert first is second
+
+
+def test_missing_file_raises_typed_error(tmp_path):
+    with pytest.raises(linear_range.LinearRangeError, match="cannot load"):
+        linear_range.load_linear_range(str(tmp_path / "nope.npz"))
+
+
+def test_missing_keys_raise_typed_error(tmp_path):
+    path = tmp_path / "malformed.npz"
+    freqs, linear_min, _ = _product_arrays()
+    np.savez(path, freqs=freqs, linear_min=linear_min)
+    with pytest.raises(
+        linear_range.LinearRangeError, match="missing required"
+    ):
+        linear_range.load_linear_range(str(path))
+
+
+def test_bound_shape_mismatch_rejected_at_save(tmp_path):
+    with pytest.raises(linear_range.LinearRangeError, match="shape"):
+        _write_product(
+            tmp_path / "bad.npz", linear_min=np.full(NCHAN // 2, 1e5)
+        )
+
+
+def test_relative_name_resolves_against_data_dir(tmp_path, monkeypatch):
+    _write_product(tmp_path / "relative.npz")
+    monkeypatch.setattr(
+        linear_range, "get_data_path", lambda fname: tmp_path / fname
+    )
+    product = linear_range.load_linear_range("relative.npz")
+    assert product["header"] == HEADER
+
+
+def test_validate_operating_point_identical_headers():
+    assert linear_range.validate_operating_point(HEADER, HEADER) == []
+
+
+@pytest.mark.parametrize("field", linear_range.OPERATING_POINT_FIELDS)
+def test_validate_operating_point_flags_each_field(field):
+    live = dict(HEADER)
+    live[field] = "DIFFERENT"
+    mismatches = linear_range.validate_operating_point(HEADER, live)
+    assert len(mismatches) == 1
+    assert mismatches[0].startswith(f"{field}:")
+
+
+def test_validate_operating_point_missing_field_is_mismatch():
+    live = dict(HEADER)
+    del live["adc_gain"]
+    mismatches = linear_range.validate_operating_point(HEADER, live)
+    assert len(mismatches) == 1
+    assert "adc_gain" in mismatches[0]
+
+
+def test_validate_operating_point_tuple_list_equivalent():
+    """JSON round-trips tuples to lists; the comparison must not flag
+    fpg_version=[2, 4] vs fpg_version=(2, 4) as a mismatch."""
+    live = dict(HEADER, fpg_version=tuple(HEADER["fpg_version"]))
+    assert linear_range.validate_operating_point(HEADER, live) == []
+
+
+def test_extra_live_header_fields_ignored():
+    """Non-operating-point fields (sync_time, run_tag, ...) may differ
+    freely between measurement and deployment."""
+    live = dict(HEADER, sync_time=0.0, run_tag="manual-session")
+    assert linear_range.validate_operating_point(HEADER, live) == []

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -9,6 +9,7 @@ means we can assert state deterministically without sleeps.
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 
@@ -21,10 +22,12 @@ from eigsep_redis import (
 )
 from eigsep_redis.testing import DummyTransport
 
+from conftest import HEADER as GOLDEN_HEADER
 from eigsep_observing.adc import AdcSnapshotWriter
 from eigsep_observing.corr import CorrConfigStore, CorrWriter
 from eigsep_observing.corr_health import publish as publish_corr_health
 from eigsep_observing.host_health import publish as publish_host_health
+from eigsep_observing.linear_range import save_linear_range
 from eigsep_observing.live_status import (
     LiveStatusAggregator,
     Thresholds,
@@ -1103,3 +1106,83 @@ def test_snapshot_exposes_snap_fpga_fields(agg):
     snap = agg.snapshot()
     assert hasattr(snap, "snap_fpga_reachable")
     assert hasattr(snap, "snap_fpga_last_probe_unix")
+
+
+# ---------------------------------------------------------------------
+# Linear-range product loading
+# ---------------------------------------------------------------------
+
+
+def _seed_linear_range(transports, tmp_path, measured_header):
+    """Seed corr config (pointing at a product npz fit at
+    ``measured_header``) plus the golden production header, and return
+    a ready aggregator. The golden header carries the full operating
+    point the aggregator validates the product against."""
+    nchan = GOLDEN_HEADER["nchan"]
+    product_path = tmp_path / "product.npz"
+    save_linear_range(
+        product_path,
+        freqs=np.arange(nchan, dtype=np.float64),
+        linear_min=np.full(nchan, 1e5),
+        linear_max=np.full(nchan, 5e8),
+        header=measured_header,
+        threshold_db=1.0,
+        smooth_window=17,
+        created_unix=1751000000.0,
+        source_file="linearity_corr.npz",
+    )
+    snap, panda = transports
+    store = CorrConfigStore(snap)
+    store.upload(dict(CORR_CONFIG, linear_range_file=str(product_path)))
+    store.upload_header(GOLDEN_HEADER)
+    return LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+    )
+
+
+def test_linear_range_loads_on_operating_point_match(transports, tmp_path):
+    agg = _seed_linear_range(transports, tmp_path, GOLDEN_HEADER)
+    try:
+        agg._snap_tick()
+        state = agg.snapshot()
+    finally:
+        agg.stop(timeout=1.0)
+    np.testing.assert_array_equal(
+        state.corr_linear_min, np.full(GOLDEN_HEADER["nchan"], 1e5)
+    )
+    np.testing.assert_array_equal(
+        state.corr_linear_max, np.full(GOLDEN_HEADER["nchan"], 5e8)
+    )
+
+
+def test_linear_range_mismatch_clears_bounds_and_logs_once(
+    transports, tmp_path, caplog
+):
+    """A product fit at a different operating point never reaches the
+    dashboard, and the ERROR is memoized per header publish rather
+    than repeating on every ~1 s tick."""
+    measured = dict(GOLDEN_HEADER, adc_gain=GOLDEN_HEADER["adc_gain"] + 1)
+    agg = _seed_linear_range(transports, tmp_path, measured)
+    try:
+        with caplog.at_level(logging.ERROR):
+            agg._snap_tick()
+            agg._snap_tick()
+        state = agg.snapshot()
+    finally:
+        agg.stop(timeout=1.0)
+    assert state.corr_linear_min is None
+    assert state.corr_linear_max is None
+    errors = [r for r in caplog.records if "mismatch" in r.message]
+    assert len(errors) == 1
+    assert "adc_gain" in errors[0].message
+
+
+def test_linear_range_none_without_config(agg):
+    """The seeded fixture config has no linear_range_file — bounds
+    stay None and no linear-range ERROR fires."""
+    agg._snap_tick()
+    state = agg.snapshot()
+    assert state.corr_linear_min is None
+    assert state.corr_linear_max is None

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -21,8 +21,10 @@ from eigsep_redis import (
 )
 from eigsep_redis.testing import DummyTransport
 
+from conftest import HEADER as GOLDEN_HEADER
 from eigsep_observing.adc import AdcSnapshotWriter
 from eigsep_observing.corr import CorrConfigStore, CorrWriter
+from eigsep_observing.linear_range import save_linear_range
 from eigsep_observing.live_status import (
     LiveStatusAggregator,
     create_app,
@@ -1698,3 +1700,65 @@ def test_app_pair_label_is_io_pair_label():
     from eigsep_observing import io
 
     assert app.pair_label is io.pair_label
+
+
+# -- linear-range overlay ---------------------------------------------
+
+
+def test_corr_route_includes_linear_range_bounds(tmp_path):
+    """With a product configured and an operating-point-matching
+    header published, /api/corr carries JSON-safe per-channel bounds
+    (NaN-masked channels as null)."""
+    nchan = GOLDEN_HEADER["nchan"]
+    linear_min = np.full(nchan, 1e5)
+    linear_max = np.full(nchan, 5e8)
+    # NaN-masked top band, as the real fit produces above the LPF cutoff
+    linear_min[-nchan // 10 :] = np.nan
+    linear_max[-nchan // 10 :] = np.nan
+    product_path = tmp_path / "product.npz"
+    save_linear_range(
+        product_path,
+        freqs=np.arange(nchan, dtype=np.float64),
+        linear_min=linear_min,
+        linear_max=linear_max,
+        header=GOLDEN_HEADER,
+        threshold_db=1.0,
+        smooth_window=17,
+        created_unix=1751000000.0,
+        source_file="linearity_corr.npz",
+    )
+
+    snap = DummyTransport()
+    panda = DummyTransport()
+    store = CorrConfigStore(snap)
+    store.upload(dict(CORR_CONFIG, linear_range_file=str(product_path)))
+    # The golden production header carries the full operating point,
+    # which the aggregator validates the product against.
+    store.upload_header(GOLDEN_HEADER)
+
+    agg = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+    )
+    try:
+        agg._snap_tick()
+        data = client_for(agg).get("/api/corr").get_json()["data"]
+    finally:
+        agg.stop(timeout=1.0)
+
+    assert len(data["linear_min"]) == nchan
+    assert len(data["linear_max"]) == nchan
+    assert data["linear_min"][0] == pytest.approx(1e5)
+    assert data["linear_max"][0] == pytest.approx(5e8)
+    # NaN channels serialize as JSON null (Plotly line gap), never NaN.
+    assert data["linear_min"][-1] is None
+    assert data["linear_max"][-1] is None
+
+
+def test_corr_route_omits_linear_range_when_not_configured(client):
+    """No linear_range_file in corr_config (the shipped default) →
+    the payload simply has no bounds keys and the route still works."""
+    data = client.get("/api/corr").get_json()["data"]
+    assert "linear_min" not in data
+    assert "linear_max" not in data


### PR DESCRIPTION
## Summary

Redo of the April 2026 SNAP linearity test, per-frequency this time. Builds the full pipeline from sweep to dashboard; ships **dormant** (`linear_range_file: null`) until the lab measurement lands in a follow-up.

### Measurement (`scripts/linearity_test/`)
- `corr_linearity.py` keeps the manual step-attenuator loop but now records the full `(nsteps, nsamples, nchan)` auto spectra per input, the corr header (operating-point provenance), and the noise-source constants (`--noise-density-dbm-hz`, `--bandwidth-hz`) instead of collapsing each spectrum to total power.
- `plot_linear.py` handles both the new per-channel format and the archived April total-power npz.

### Fit (`fit_linearity.py`, new)
Replaces eyeballing: per input and channel, fit `log10(counts)` vs input power (dBm) on a sigma-clipped middle region; steps within `--threshold-db` (default 1 dB) of the fit are "linear", and the bounds are the measured counts at the lowest/highest linear step. Degenerate channels (above the 225 MHz LPF cutoff) are NaN-masked; bounds are median-smoothed across frequency and combined into a conservative envelope across inputs. `--plot` writes fit/bounds/residual diagnostics.

### Product contract (`linear_range.py`, new)
Single writer/loader for the product npz (packaged `data/` resolution like `fpg_file`, lru-cached, read-only arrays) plus operating-point validation (`nchan, sample_rate, adc_gain, fft_shift, corr_scalar, corr_acc_len, acc_bins, avg_even_odd, fpg_version`). Any failure is a typed `LinearRangeError`; consumers log ERROR and **omit** the bounds — a bad product never blocks corr data.

### Consumers
- **Corr files**: `append_corr_header` injects `linear_range_min`/`linear_range_max` as native float64 header datasets (writer-side, like `freqs`, since the Redis header is JSON) when `corr_config.yaml` names a product.
- **Live status**: the aggregator loads + validates the product (memoized per header publish, so a chronic mismatch logs once, not once per ~1 s tick); `/api/corr` carries the bounds with NaN → JSON null; the dashboard draws dashed reference curves on the **raw** view only (bounds are raw counts, meaningless on the Kelvin axis), with null gaps over masked channels.

## Verification

- 237 tests pass across `test_linear_range.py` (new), `test_io.py`, `test_live_status_app.py`, `test_live_status_aggregator.py`; `ruff check` + `ruff format --check` clean.
- End-to-end dry run on a synthetic sweep (bandpass source + 1e5-count floor + soft compression at 5e8): the fit recovers the injected floor crossover and 1 dB compression point within one 4 dB attenuation step, masks exactly the LPF-dead channels (921/1024 fit), and the bounds round-trip through `write_hdf5`/`read_hdf5` with the NaN mask intact.

## Follow-up (blocked on lab access)

Run the real sweep, commit `data/corr_linear_range_v2_4_<date>.npz`, set `linear_range_file` in `corr_config.yaml`; optionally re-tune the `adc.rms` bands in `live_status_thresholds.yaml` and update the memo in `memos/linearity/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)