### PR TITLE
feat: wiring manifest for the next deployment (C000122, Rx modules)

### DIFF
--- a/src/eigsep_observing/config/wiring.yaml
+++ b/src/eigsep_observing/config/wiring.yaml
@@ -1,10 +1,10 @@
-# EIGSEP hardware wiring manifest (SNAP C000069, 5-input layout).
+# EIGSEP hardware wiring manifest (SNAP C000122, 4-input layout).
 #
 # This file is declarative: it describes the intended RF wiring between
-# antennas, front-end modules (FEMs), optional PAMs, and SNAP digital
-# inputs. Physically wire the hardware to match the values here. Any
-# mismatch means the file header on corr HDF5 files is wrong, which is
-# the thing you actually care about at analysis time.
+# antennas, receiver-chain modules, and SNAP digital inputs. Physically
+# wire the hardware to match the values here. Any mismatch means the
+# file header on corr HDF5 files is wrong, which is the thing you
+# actually care about at analysis time.
 #
 # ---------------------------------------------------------------------
 # Editing in the field
@@ -20,6 +20,16 @@
 #        are unaffected.
 #
 # ---------------------------------------------------------------------
+# Receiver-chain modules
+# ---------------------------------------------------------------------
+# Eight interchangeable receiver modules labeled "Rx 1".."Rx 8". Each
+# signal chain pairs one Rx with either a transmitter module (tx:, the
+# box antennas) or a FEM (fem:, the Vivaldi). Module ids are null until
+# assigned at install — fill them in on the rig, then run
+# scripts/republish_header.py so subsequent files record the real ids.
+# Rx units not listed below are spares.
+#
+# ---------------------------------------------------------------------
 # PAM block is optional
 # ---------------------------------------------------------------------
 # PAMs have been removed from the current deployment. The `pam:` block
@@ -32,21 +42,29 @@
 # onto each antenna that has one (num is the SNAP PAM position 0/1/2;
 # pol is the PAM channel E or N; atten is dB in [0, 15]).
 
-snap_id: C000069
-# snap_id: C000122  # spare SNAP
+snap_id: C000122
+# snap_id: C000069  # spare SNAP
 ants:
-  box:
-    fem: {id: "eigsep1"}
+  box-air:  # suspended box
+    tx: {id: null}  # fill at install
+    rx: {id: null}  # one of Rx 1-8; fill at install
     snap: {input: 0, label: N0}
-  viv1-N:
-    fem: {id: 32, pol: N}
+  box-gnd:  # ground box
+    tx: {id: null}
+    rx: {id: null}
     snap: {input: 2, label: N4}
-  viv1-E:
-    fem: {id: 32, pol: E}
-    snap: {input: 3, label: E6}
-  viv2-N:
-    fem: {id: 348, pol: N}
+  viv-N:
+    fem: {id: null, pol: N}
+    rx: {id: null}
     snap: {input: 4, label: N8}
-  viv2-E:
-    fem: {id: 348, pol: E}
+  viv-E:
+    fem: {id: null, pol: E}
+    rx: {id: null}
     snap: {input: 5, label: E10}
+  # input 1 (label E2): unwired.
+  # input 3 (label E6): reserved for a possible additional chain. If
+  # added, copy an entry like:
+  #   <name>:
+  #     fem: {id: null}
+  #     rx: {id: null}
+  #     snap: {input: 3, label: E6}

--- a/src/eigsep_observing/config/wiring.yaml
+++ b/src/eigsep_observing/config/wiring.yaml
@@ -46,20 +46,22 @@ snap_id: C000122
 # snap_id: C000069  # spare SNAP
 ants:
   box-air:  # suspended box
-    tx: {id: null}  # fill at install
-    rx: {id: null}  # one of Rx 1-8; fill at install
+    tx: {id: 2}
+    rx: {id: 2}  # Rx 2
     snap: {input: 0, label: N0}
   box-gnd:  # ground box
-    tx: {id: null}
-    rx: {id: null}
+    tx: {id: 1}
+    rx: {id: 3}  # Rx 3
     snap: {input: 2, label: N4}
   viv-N:
+    # One dual-pol FEM serves both viv-N and viv-E; id unknown — fill
+    # both entries with the same id, then run republish_header.py.
     fem: {id: null, pol: N}
-    rx: {id: null}
+    rx: {id: 5}  # Rx 5
     snap: {input: 4, label: N8}
   viv-E:
-    fem: {id: null, pol: E}
-    rx: {id: null}
+    fem: {id: null, pol: E}  # same FEM module as viv-N
+    rx: {id: 7}  # Rx 7
     snap: {input: 5, label: E10}
   # input 1 (label E2): unwired.
   # input 3 (label E6): reserved for a possible additional chain. If

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -178,8 +178,9 @@ class EigsepFpga:
             accumulation length, dtype, redis). See
             `config/corr_config.yaml`.
         wiring : dict
-            Hardware wiring manifest (snap_id + per-antenna FEM / SNAP
-            input / optional PAM mapping). See `config/wiring.yaml`.
+            Hardware wiring manifest (snap_id + per-antenna modules
+            (tx or FEM, plus Rx) / SNAP input / optional PAM mapping).
+            See `config/wiring.yaml`.
             Kept separate from ``cfg`` so it can be edited in the field
             without tripping ``assert_config_matches_redis`` — the
             standalone ``scripts/republish_header.py`` updates the

--- a/src/eigsep_observing/scripts/fpga_init.py
+++ b/src/eigsep_observing/scripts/fpga_init.py
@@ -78,7 +78,8 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="wiring_file",
         default=str(get_config_path("wiring.yaml")),
         help=(
-            "Hardware wiring manifest (antenna → FEM → SNAP input). Edit "
+            "Hardware wiring manifest (antenna → tx/FEM + Rx → SNAP "
+            "input). Edit "
             "and re-run scripts/republish_header.py to correct a file "
             "header without --reinit."
         ),


### PR DESCRIPTION
## Summary

Updates the authoritative hardware wiring manifest (`config/wiring.yaml`) for the next field deployment:

- **SNAP**: spare **C000122** goes in; C000069 becomes the commented-out spare.
- **Receiver chains**: FEM-only chains are replaced by module *pairs*. Eight new interchangeable receiver modules ("Rx 1".."Rx 8"); each chain pairs one Rx with either a **tx** module (box antennas) or a **FEM** (Vivaldi).
- **New 4-chain roster** (authoritative install ids filled in):

  | antenna | description | SNAP input | label | modules |
  |---|---|---|---|---|
  | `box-air` | suspended box | 0 | N0 | tx 2 + Rx 2 |
  | `box-gnd` | ground box | 2 | N4 | tx 1 + Rx 3 |
  | `viv-N` | Vivaldi N-pol | 4 | N8 | FEM (shared) + Rx 5 |
  | `viv-E` | Vivaldi E-pol | 5 | E10 | FEM (shared) + Rx 7 |

  Rx 1/4/6/8 are spares. Input 1 (E2) is unwired; input 3 (E6) is reserved for a possible later chain (commented template included).
- **No PAMs** (unchanged; `pam:` blocks stay absent).

The two Vivaldi pols share one dual-pol FEM whose id is not yet known: both `fem.id` entries stay `null` with a note to fill in the same id on both and run the documented `republish_header.py` field-edit workflow. Docstrings in `fpga.py` / `fpga_init.py` updated to describe the module-pair schema.

## Why no code changes

- The per-antenna module blocks (`fem:`/`tx:`/`rx:`) are read by no source code — only `snap.input` (header `input_to_ant` derivation) and the optional `pam:` block are consumed. The new blocks are descriptive header payload.
- `null` ids serialize cleanly: nested header dicts are JSON-encoded by `io._write_dataset` (precedent: `SP2: null` in `obs_config.yaml` already rides into headers).
- The default `tests/test_fpga.py` fixture loads the shipped manifest, but its only assumption is "no `pam:` blocks", which still holds.

## Verification

- End-to-end sanity script against this branch's source: manifest loads with expected shape; `DummyEigsepFpga` header derives `input_to_ant == {"0": "box-air", "2": "box-gnd", "4": "viv-N", "5": "viv-E"}`; `write_hdf5`/`read_hdf5` round-trip preserves the `null` module ids.
- Targeted tests: `pytest tests/test_fpga.py tests/test_republish_header.py tests/test_adc.py` — 99 passed.
- After rebase onto main + id fill: manifest re-parses with the roster above; `pytest tests/test_fpga.py tests/test_republish_header.py` — 79 passed.
- `ruff check` and `ruff format --check` clean on the two touched `.py` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)