### PR TITLE
feat: descope tempctrl channels via per-channel installed flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,11 @@ normal operation.
 generic `_avg_sensor_values` path — picohost publishes them as
 separate per-channel streams, so the consumer no longer needs a custom
 splitter. (The standalone `temp_mon` Pico app was retired in picohost
-1.0.0.)
+1.0.0.) A channel descoped via
+`tempctrl_settings.{LNA,LOAD}.installed: false` (firmware `installed`
+flag, picohost 4.2) publishes no stream at all — consumers see clean
+absence, never a sentinel or error stream; see OPERATIONS.md
+"Tempctrl channel descope and hot-swap".
 
 **IMU mode (picohost 1.0.0+).** The two IMU picos (`imu_el` panda elevation,
 app_id 3; `imu_az` antenna azimuth, app_id 6) emit BNO085 UART RVC payloads:

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -305,3 +305,53 @@ RPi + SNAP:       10.10.10.10 (Redis port 6379)
 LattePanda:       10.10.10.11 (Redis port 6379)
 VNA:              127.0.0.1:5025 (local to panda)
 ```
+
+## Tempctrl channel descope and hot-swap
+
+The tempctrl Pico's two Peltier channels are independent config knobs:
+`tempctrl_settings.{LNA,LOAD}.installed` in `obs_config.yaml`. A channel
+marked `installed: false` is descoped: firmware never samples its
+thermistor (no ADC-mux switch to the dead divider, so it cannot
+crosstalk into the live channel) or drives its Peltier, and it publishes
+**no Redis stream** — its corr-file columns, dashboard tiles, threshold
+bands, and health checks all disappear cleanly rather than streaming
+`status="error"` forever. `installed: false` must be paired with
+`enable: false` (rejected at init otherwise). Flip back to `true` when
+the module returns.
+
+**Hot-swap (LOAD connector fails in the field → move the LOAD module to
+the LNA connector):**
+
+1. Stop `panda_observe`. Peltier control replay stays owned by
+   `pico-manager.service`, so the LOAD side stays controlled until you
+   push new state.
+2. In `tempctrl_manual`: disable LOAD (`O`), mark it uninstalled (`U`).
+   Physically move the Peltier+thermistor module to the LNA connector.
+   Mark LNA installed (`t`) and confirm the `tempctrl_lna` row comes
+   alive with a sane `T_now` within a tick.
+3. Edit `obs_config.yaml`:
+   - `LOAD: {installed: false, enable: false}`
+   - `LNA: {installed: true, enable: true}` plus a copy of the LOAD
+     block's `target_C` / `hysteresis_C` / `clamp` / `cooling_enabled` /
+     `Kp` / `Ki` — the physical module is the same, only the channel
+     (pins + stream name) changed.
+   - `calibration.t_load_stream: tempctrl_lna` — the Y-factor
+     calibration's load-temperature reference now rides the
+     LNA-connector stream.
+4. One-time Redis cleanup so the retired `tempctrl_load` stream doesn't
+   emit throttled staleness warnings on the ground side: delete its
+   stream key (`stream:tempctrl_load`), its `metadata` hash fields
+   (`tempctrl_load`, `tempctrl_load_ts`), and its `metadata_streams`
+   set entry.
+5. Restart `panda_observe`, and restart the live-status dashboard after
+   updating **its** copy of `obs_config.yaml` too — signal gating reads
+   the dashboard host's local file, not the panda's upload.
+6. Verify with `pico_preflight` (the retired row reads "no stream
+   (channel uninstalled or producer fault)") and the dashboard cal
+   panel.
+
+Note: after any tempctrl Pico reboot, firmware defaults to
+`installed: true` for a few 200 ms ticks until `pico-manager` replays
+the cached flags — a brief `status="error"` burst on the retired stream
+is expected and harmless (schema-valid rows, at most one spurious
+health-check warning).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=4.1",
+  # >=4.2: tempctrl per-channel installed flag (set_installed command +
+  # fan-out stream suppression for descoped channels).
+  "picohost>=4.2",
   "eigsep-vna>=1.3",
   "eigsep_redis>=2.3",
 ]

--- a/scripts/pico_preflight.py
+++ b/scripts/pico_preflight.py
@@ -127,6 +127,22 @@ def _fmt_summary(name, reading):
     return " ".join(parts)
 
 
+def _absent_stream_note(*, alive, ts, reading):
+    """Annotation for an alive device whose stream never published.
+
+    A live heartbeat with no stream data is either a deliberately
+    descoped channel (tempctrl ``installed=false`` publishes nothing —
+    see OPERATIONS.md "Tempctrl channel descope and hot-swap") or a
+    producer fault. Say so instead of leaving the reading column
+    blank, without false-failing a descoped field rig. Empty when the
+    device is dead (the alive column already tells that story) or the
+    stream is publishing.
+    """
+    if alive and ts is None and not reading:
+        return "no stream (channel uninstalled or producer fault)"
+    return ""
+
+
 def _flashed_lookup(devices):
     """Return ``{name: port}`` for flashed devices, ``{}`` if no config."""
     if not devices:
@@ -159,11 +175,15 @@ def render(transport):
     for device in APP_NAMES.values():
         port = flashed.get(device, "--")
         hb = HeartbeatReader(transport, name=pico_heartbeat_name(device))
-        alive = "yes" if hb.check() else "no"
+        is_alive = hb.check()
+        alive = "yes" if is_alive else "no"
         for stream in _streams_for(device):
             ts = meta.get(f"{stream}_ts")
             age = _fmt_age(ts, now)
-            summary = _fmt_summary(stream, meta.get(stream))
+            reading = meta.get(stream)
+            summary = _fmt_summary(stream, reading) or _absent_stream_note(
+                alive=is_alive, ts=ts, reading=reading
+            )
             print(f"{stream:14} {port:14} {alive:5} {age:>5}  {summary}")
 
     if devices is None:

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -676,7 +676,7 @@ def _handle_key(ch, proxy, state, history=None, outdir="."):
     elif ch == ord("U"):
         state.load_installed = False
         _push_installed(proxy, state)
-        elif ch == ord("r"):
+    elif ch == ord("r"):
         state.lna_enabled = True
         state.load_enabled = True
         _push_enables(proxy, state)

--- a/scripts/tempctrl_manual.py
+++ b/scripts/tempctrl_manual.py
@@ -23,6 +23,8 @@ Controls:
   i / I    LNA Ki +/- 0.005
   k / K    LOAD Ki +/- 0.005
   z / Z    reset LNA / LOAD PI integrator
+  t / T    LNA installed yes / no (hardware descope, see below)
+  u / U    LOAD installed yes / no
   w        push a 5 s watchdog (should trip if not refreshed)
   r        re-enable both channels at their last setpoint
   p        write a temperature-vs-time PNG of the session so far
@@ -59,6 +61,16 @@ data validity only: a channel can read ``armed=False`` with
 is gating drive — check the ``trips`` column for which one. ``T_now``
 reads ``--`` (null) exactly when the current sample is untrustworthy;
 ``voltage`` stays live then (≈3.3 V says open thermistor, ≈0 V short).
+
+Hardware descope / hot-swap (per-channel ``installed`` flag): a
+channel marked not installed is never sampled or driven and publishes
+no Redis stream — its readout row shows all ``--``. On startup, a
+stream that stays silent through the seed window is taken as a
+descoped channel and the UI comes up on the live one (both silent is
+still a hard error). ``t``/``u`` re-install a channel — the hot-swap
+ack after physically moving the LOAD module onto the LNA connector
+(procedure in OPERATIONS.md); expect its stream to start publishing
+within a tick. ``T``/``U`` descope it again.
 """
 
 from argparse import ArgumentParser
@@ -93,6 +105,7 @@ KP_STEP = 0.05
 KI_STEP = 0.005  # smaller — integral accumulates over many ticks
 DEFAULT_KP = 0.2  # firmware default, matches TempCtrlEmulator
 DEFAULT_KI = 0.0  # firmware default — opt-in via this script or yaml
+DEFAULT_T_TARGET_C = 30.0  # firmware default T_target (init_single_tempctrl)
 WATCHDOG_PROBE_MS = 5000
 # picohost STATUS_CADENCE_MS = 200; poll at the same cadence so we
 # wake on the next publish without busy-spinning.
@@ -131,6 +144,8 @@ class _State:
         load_Ki,
         lna_cooling_enabled,
         load_cooling_enabled,
+        lna_installed=True,
+        load_installed=True,
     ):
         self.lna_setpoint = lna_setpoint
         self.load_setpoint = load_setpoint
@@ -146,6 +161,12 @@ class _State:
         # never disagrees with what the firmware is enforcing.
         self.lna_cooling_enabled = lna_cooling_enabled
         self.load_cooling_enabled = load_cooling_enabled
+        # Hardware-descope flag per channel (see module docstring): an
+        # uninstalled channel publishes no stream, so it's seeded from
+        # stream presence at startup and toggled by t/T (LNA), u/U
+        # (LOAD) during a hot swap.
+        self.lna_installed = lna_installed
+        self.load_installed = load_installed
         self.clamp_idx = CLAMPS.index(0.2)  # firmware default clamp
         self.last_message = ""
 
@@ -251,48 +272,51 @@ def _seed_state(
     poll_interval_s=PICO_PUBLISH_INTERVAL_S,
 ):
     """Block until firmware has published ``T_target`` on both
-    ``tempctrl_lna`` and ``tempctrl_load``, then build a starting
-    :class:`_State` from those values.
+    ``tempctrl_lna`` and ``tempctrl_load`` (or the seed window closes
+    with at least one live), then build a starting :class:`_State`.
 
-    No hardcoded setpoint fallback — the pico's own ``T_target``
-    (firmware default 30 deg C until reconfigured) is the single
-    source of truth, so the UI can never disagree with what the
+    No hardcoded setpoint fallback for a live channel — the pico's own
+    ``T_target`` (firmware default 30 deg C until reconfigured) is the
+    single source of truth, so the UI can never disagree with what the
     firmware is actually driving. ``enabled`` likewise comes from the
     pico; missing ``Kp`` / ``Ki`` fall back to the firmware-side
     defaults (``DEFAULT_KP`` / ``DEFAULT_KI``).
 
+    A stream still silent when the window closes is taken as a
+    descoped channel (firmware ``installed=false`` publishes nothing)
+    and marked not-installed, seeded from firmware defaults so a later
+    re-install (``t``/``u`` during a hot swap) starts from sane
+    values. A fully-fitted rig therefore pays no wait, a descoped one
+    pays one ``timeout_s`` at startup.
+
     Raises
     ------
     SystemExit
-        ``T_target`` did not appear on one or both streams within
-        ``timeout_s``. ``require_pico`` passed first, so the proxy
-        heartbeat is live — that means the pico is registered but the
-        firmware tempctrl publisher hasn't pushed a status frame yet.
-        Usually a misflashed pico or a stuck producer thread.
+        Neither stream published ``T_target`` within ``timeout_s``.
+        ``require_pico`` passed first, so the proxy heartbeat is live —
+        that means the pico is registered but the firmware tempctrl
+        publisher hasn't pushed a status frame yet. Usually a
+        misflashed pico or a stuck producer thread. (Both channels
+        descoped at once is not a supported shape — that's "unplug the
+        pico".)
     """
     deadline = time.monotonic() + timeout_s
     while True:
         lna = _snap(snapshot, "tempctrl_lna") or {}
         load = _snap(snapshot, "tempctrl_load") or {}
-        if (
-            lna.get("T_target") is not None
-            and load.get("T_target") is not None
-        ):
+        lna_live = lna.get("T_target") is not None
+        load_live = load.get("T_target") is not None
+        if lna_live and load_live:
             break
         if time.monotonic() >= deadline:
-            missing = [
-                name
-                for name, d in (
-                    ("tempctrl_lna", lna),
-                    ("tempctrl_load", load),
+            if not lna_live and not load_live:
+                raise SystemExit(
+                    f"ERROR: tempctrl pico is registered but did not "
+                    f"publish T_target on ['tempctrl_lna', "
+                    f"'tempctrl_load'] within {timeout_s:.1f}s. "
+                    f"Check pico-manager logs."
                 )
-                if d.get("T_target") is None
-            ]
-            raise SystemExit(
-                f"ERROR: tempctrl pico is registered but did not publish "
-                f"T_target on {missing} within {timeout_s:.1f}s. "
-                f"Check pico-manager logs."
-            )
+            break
         time.sleep(poll_interval_s)
 
     def _f(d, k, default):
@@ -308,8 +332,12 @@ def _seed_state(
         return v if isinstance(v, bool) else default
 
     return _State(
-        lna_setpoint=float(lna["T_target"]),
-        load_setpoint=float(load["T_target"]),
+        lna_setpoint=(
+            float(lna["T_target"]) if lna_live else DEFAULT_T_TARGET_C
+        ),
+        load_setpoint=(
+            float(load["T_target"]) if load_live else DEFAULT_T_TARGET_C
+        ),
         lna_enabled=bool(lna.get("enabled") or False),
         load_enabled=bool(load.get("enabled") or False),
         lna_Kp=_f(lna, "Kp", DEFAULT_KP),
@@ -320,6 +348,8 @@ def _seed_state(
         # means the firmware predates the setting, so default True too.
         lna_cooling_enabled=_b(lna, "cooling_enabled", True),
         load_cooling_enabled=_b(load, "cooling_enabled", True),
+        lna_installed=lna_live,
+        load_installed=load_live,
     )
 
 
@@ -377,6 +407,25 @@ def _push_cooling(proxy, state):
         "set_cooling_enabled",
         LNA=state.lna_cooling_enabled,
         LOAD=state.load_cooling_enabled,
+    )
+
+
+def _push_installed(proxy, state):
+    """Push the per-channel installed (hardware-descope) flags.
+
+    Both channels ride each push to match the enable/cooling/gain
+    idiom — one round-trip per keypress, and the firmware always sees
+    the UI's full installed state. Re-installing (``t``/``u``) is the
+    hot-swap ack: firmware resumes sampling the channel and its stream
+    starts publishing within a tick. Descoping (``T``/``U``) stops
+    sampling, forces drive off, and the stream disappears; sticky trip
+    latches survive (clear them with the enable ack as usual).
+    """
+    state.last_message = _send(
+        proxy,
+        "set_installed",
+        LNA=state.lna_installed,
+        LOAD=state.load_installed,
     )
 
 
@@ -519,13 +568,26 @@ def _render(screen, snapshot, state):
         f"client gains: LNA(Kp={state.lna_Kp:.3f}, Ki={state.lna_Ki:.3f})  "
         f"LOAD(Kp={state.load_Kp:.3f}, Ki={state.load_Ki:.3f})",
     )
+    # An uninstalled channel publishes no stream, so its readout rows
+    # above show all `--`; this line says whether that's a descope
+    # (installed=False) or a fault.
+    screen.addstr(
+        12,
+        0,
+        f"client installed: LNA={state.lna_installed} "
+        f"LOAD={state.load_installed}",
+    )
     screen.addstr(13, 0, "l/L enable LNA on/off       o/O enable LOAD on/off")
     screen.addstr(14, 0, "n/N LNA cooling on/off      m/M LOAD cooling on/off")
     screen.addstr(
         15, 0, "+/- LNA setpoint  ][ LOAD setpoint  c/C clamp up/down"
     )
     screen.addstr(16, 0, "g/G LNA Kp  h/H LOAD Kp  i/I LNA Ki  k/K LOAD Ki")
-    screen.addstr(17, 0, "z/Z reset LNA/LOAD integral")
+    screen.addstr(
+        17,
+        0,
+        "z/Z reset LNA/LOAD integral  t/T LNA installed  u/U LOAD installed",
+    )
     screen.addstr(
         18, 0, "w push 5s watchdog   r re-enable both   p plot PNG   q quit"
     )
@@ -607,6 +669,18 @@ def _handle_key(ch, proxy, state, history=None, outdir="."):
         state.last_message = _send(proxy, "reset_integral", LNA=True)
     elif ch == ord("Z"):
         state.last_message = _send(proxy, "reset_integral", LOAD=True)
+    elif ch == ord("t"):
+        state.lna_installed = True
+        _push_installed(proxy, state)
+    elif ch == ord("T"):
+        state.lna_installed = False
+        _push_installed(proxy, state)
+    elif ch == ord("u"):
+        state.load_installed = True
+        _push_installed(proxy, state)
+    elif ch == ord("U"):
+        state.load_installed = False
+        _push_installed(proxy, state)
     elif ch == ord("w"):
         state.last_message = _send(
             proxy, "set_watchdog_timeout", timeout_ms=WATCHDOG_PROBE_MS

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -218,7 +218,7 @@ def _lidar_avg_entry(distance_m):
     }
 
 
-def tempctrl_post_handler_reading(stream_name):
+def tempctrl_post_handler_reading(stream_name, *, sensor_error=None):
     """One per-channel tempctrl reading after ``_peltier_redis_handler``.
 
     The firmware/emulator emits one combined ``sensor_name="tempctrl"``
@@ -228,6 +228,16 @@ def tempctrl_post_handler_reading(stream_name):
     the emulator with the handler here means every test fixture downstream
     is anchored to the real producer output rather than drifting on
     hand-typed steady-state values.
+
+    Parameters
+    ----------
+    sensor_error : str, optional
+        Channel name (``"LNA"`` or ``"LOAD"``) to put into the
+        railed-divider error state before the op tick, yielding that
+        stream's real error-row shape (``status: "error"``, null
+        T_now/resistance, voltage at the rail) — the row an unplugged
+        thermistor produces, e.g. during the reboot burst before
+        pico-manager replays the installed flags.
     """
     pel = PicoPeltier.__new__(PicoPeltier)
     captured = []
@@ -237,6 +247,8 @@ def tempctrl_post_handler_reading(stream_name):
     # null T_now/resistance), which is not the steady state this fixture
     # is meant to pin.
     emu = TempCtrlEmulator()
+    if sensor_error is not None:
+        emu.inject_sensor_error(sensor_error)
     emu.op()
     pel._peltier_redis_handler(emu.get_status())
     for entry in captured:

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -445,12 +445,20 @@ class PandaClient:
         self.logger.info(
             f"Tempctrl initialized (settings={self.tempctrl.settings})"
         )
-        # Cooling-mode guard: a deliberate non-default safety setting
-        # (see picohost asymmetric clamp). Surfaced once at init rather
-        # than every tempctrl_loop iteration — it's a deployment choice,
-        # not a runtime fault.
+        # Deliberate non-default deployment choices, surfaced once at
+        # init rather than every tempctrl_loop iteration — they are
+        # config decisions, not runtime faults.
         for ch in ("LNA", "LOAD"):
             section = self.tempctrl.settings.get(ch, {})
+            if section.get("installed") is False:
+                # Hardware descope: the module is physically absent —
+                # never sampled, never driven, no Redis stream, no
+                # dashboard tiles. See OPERATIONS.md "Tempctrl channel
+                # descope and hot-swap".
+                self.logger.warning(
+                    f"Tempctrl {ch} not installed — channel descoped: "
+                    "no sampling, no drive, no metadata stream."
+                )
             if section.get("cooling_enabled") is False:
                 self.logger.warning(
                     f"Tempctrl {ch} cooling disabled — drive clamped to "
@@ -967,6 +975,12 @@ class PandaClient:
            thermal capability. Uses a ±0.02 slack on the clamp check
            because ``drive_level`` is a floating-point duty cycle and
            we don't want to false-fire on the last bit of rounding.
+
+        A descoped channel (``installed: false``) never warns: every
+        check here is ``.get()``-guarded and
+        :meth:`TempCtrlClient.get_status` omits an uninstalled
+        channel's keys from the merged snapshot by construction, so no
+        code change is needed per channel.
         """
         if status.get("watchdog_tripped"):
             self._warn_with_status(

--- a/src/eigsep_observing/config/dummy_config.yaml
+++ b/src/eigsep_observing/config/dummy_config.yaml
@@ -46,6 +46,7 @@ tempctrl_interval: 1  # seconds; short for tests
 tempctrl_settings:
   watchdog_timeout_ms: 30000
   LNA:
+    installed: true  # hardware-descope flag; see obs_config.yaml
     enable: true
     target_C: 25.0
     hysteresis_C: 0.5
@@ -56,6 +57,7 @@ tempctrl_settings:
     # Kp: 0.2
     # Ki: 0.0
   LOAD:
+    installed: true
     enable: true
     target_C: 25.0
     hysteresis_C: 0.5

--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -61,6 +61,11 @@ vna_position_sweep:
 # from the IEEE-standard ENR convention: T_ns = 290 K · 10^(ENR_dB / 10).
 calibration:
   noise_diode_enr_db: 11.0   # post-attenuator ENR (dB), referenced to 290 K
+  # Which metadata stream carries the calibration load's temperature
+  # (T_LOAD above). Change only for the hot-swap contingency where the
+  # LOAD module rides the LNA connector and publishes as tempctrl_lna —
+  # see OPERATIONS.md "Tempctrl channel descope and hot-swap".
+  t_load_stream: tempctrl_load
 
 # tempctrl
 use_tempctrl: false
@@ -68,6 +73,14 @@ tempctrl_interval: 60  # seconds between setpoint re-apply + health check
 tempctrl_settings:
   watchdog_timeout_ms: 30000
   LNA:
+    # Hardware descope flag: false means the channel's Peltier +
+    # thermistor module is physically absent — firmware never samples
+    # or drives it and its tempctrl_lna stream stops publishing
+    # entirely (no corr-file column, no dashboard tiles, no health
+    # checks). Must be paired with enable: false. Flip back to true
+    # when the module is (re)connected. See OPERATIONS.md "Tempctrl
+    # channel descope and hot-swap".
+    installed: true
     enable: true
     target_C: 25.0
     hysteresis_C: 0.5
@@ -81,6 +94,7 @@ tempctrl_settings:
     # tempctrl.c (lower_clamp) for the firmware behavior.
     cooling_enabled: false
   LOAD:
+    installed: true  # see the LNA block's descope note
     enable: true
     target_C: 25.0
     hysteresis_C: 0.5

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -33,7 +33,7 @@ import numpy as np
 import pytest
 import yaml
 from picohost import PicoPotentiometer
-from picohost.base import PicoIMU, PicoLidar, PicoRFSwitch
+from picohost.base import PicoIMU, PicoLidar, PicoPeltier, PicoRFSwitch
 from picohost.motor import PicoMotor
 from picohost.testing import (
     ImuEmulator,
@@ -41,6 +41,7 @@ from picohost.testing import (
     MotorEmulator,
     PotMonEmulator,
     RFSwitchEmulator,
+    TempCtrlEmulator,
 )
 
 from eigsep_redis.keys import STATUS_STREAM  # noqa: F401
@@ -265,6 +266,29 @@ SENSOR_EMULATORS = {
     "adc_stats": _adc_stats_post_publish_reading,
     "system_current": lambda: _lidar_post_handler_readings()[1],
 }
+
+
+def test_uninstalled_tempctrl_channel_publishes_nothing():
+    """Descope contract: a channel whose firmware ``installed`` flag is
+    false is fanned out as *nothing* — clean stream absence downstream
+    (no corr-file column, no snapshot staleness warnings) rather than a
+    permanent error stream off the dead thermistor divider. The
+    surviving channel still conforms to its schema, and the installed
+    flag itself never enters the published per-channel shape, so
+    ``_PELTIER_SCHEMA`` is untouched by the descope feature."""
+    pel = PicoPeltier.__new__(PicoPeltier)
+    captured = []
+    pel._base_redis_handler = lambda d: captured.append(dict(d))
+    emu = TempCtrlEmulator()
+    emu.server({"LNA_installed": 0})
+    emu.op()
+    pel._peltier_redis_handler(emu.get_status())
+    assert [e["sensor_name"] for e in captured] == ["tempctrl_load"]
+    entry = captured[0]
+    assert "installed" not in entry
+    assert (
+        io._validate_metadata(entry, io.SENSOR_SCHEMAS["tempctrl_load"]) == []
+    )
 
 
 def test_test_header_conforms_to_corr_schema():

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -816,6 +816,13 @@ _IMU_AZ_SCHEMA = {
 # `watchdog_tripped` / `watchdog_timeout_ms` fields into both streams.
 # With per-stream `status`, both streams flow through the generic
 # `_avg_sensor_values` reduction like every other sensor.
+#
+# A channel descoped via the firmware `installed` flag
+# (tempctrl_settings.{LNA,LOAD}.installed: false) publishes NO stream
+# at all — clean absence (no corr-file column, no staleness warnings),
+# never a sentinel or a permanent error stream. Both schemas stay
+# registered here regardless: the module may return, and the fan-out
+# never puts an `installed` field into the published per-channel shape.
 _PELTIER_SCHEMA = {
     "sensor_name": str,
     "status": str,

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -140,10 +140,18 @@ def _solve_calibration(
 
     t_enr_k = T_REF_K * 10.0 ** (enr_db / 10.0) if enr_db is not None else None
 
+    # Which metadata stream carries the calibration load's temperature.
+    # Default is the LOAD channel's stream; the knob exists for the
+    # hot-swap contingency where the LOAD module rides the LNA connector
+    # and publishes as tempctrl_lna (see OPERATIONS.md "Tempctrl channel
+    # descope and hot-swap").
+    t_load_stream = cal_cfg.get("t_load_stream") or "tempctrl_load"
+
     meta: dict = {
         "stale": True,
         "reason": None,
         "t_load_k": None,
+        "t_load_stream": t_load_stream,
         "noise_diode_enr_db": enr_db,
         "t_enr_k": t_enr_k,
         "last_rfnoff_age_s": None,
@@ -166,22 +174,23 @@ def _solve_calibration(
     if state.last_rfnon_unix is not None:
         meta["last_rfnon_age_s"] = max(0.0, now - state.last_rfnon_unix)
 
-    tempctrl_load = state.metadata_snapshot.get("tempctrl_load")
+    load_entry = state.metadata_snapshot.get(t_load_stream)
     load_t_now = (
-        tempctrl_load.get("T_now") if isinstance(tempctrl_load, dict) else None
+        load_entry.get("T_now") if isinstance(load_entry, dict) else None
     )
     try:
         load_t_now_f = float(load_t_now) if load_t_now is not None else None
     except (TypeError, ValueError):
         logger.error(
-            "Live-status cal: tempctrl_load.T_now=%r is not coercible to "
+            "Live-status cal: %s.T_now=%r is not coercible to "
             "float; producer/schema contract violation (T_now must be "
             "float per SENSOR_SCHEMAS).",
+            t_load_stream,
             load_t_now,
         )
         load_t_now_f = None
     if load_t_now_f is None:
-        meta["reason"] = "tempctrl_load.T_now missing or non-numeric"
+        meta["reason"] = f"{t_load_stream}.T_now missing or non-numeric"
         return None, meta
     t_load_k = load_t_now_f + CELSIUS_TO_KELVIN
     meta["t_load_k"] = t_load_k

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -240,12 +240,28 @@ def enabled_signals(
     ``use_tempctrl: true``. A missing key is treated as disabled so the
     dashboard doesn't render tiles for subsystems the observer isn't
     running.
+
+    A tempctrl channel descoped via
+    ``tempctrl_settings.{LNA,LOAD}.installed: false`` is dropped even
+    with ``use_tempctrl: true``: the producer publishes no stream for
+    it (see ``TempCtrlClient.set_installed``), so its tiles would sit
+    permanently empty on the dashboard — the field deployment's only
+    alerting surface.
     """
     reg = registry if registry is not None else SIGNAL_REGISTRY
     out: dict[str, Signal] = {}
     for name, sig in reg.items():
         if sig.enabled_by is None or obs_cfg.get(sig.enabled_by):
             out[name] = sig
+    settings = obs_cfg.get("tempctrl_settings", {}) or {}
+    for channel, stream in (
+        ("LNA", "tempctrl_lna"),
+        ("LOAD", "tempctrl_load"),
+    ):
+        if (settings.get(channel) or {}).get("installed") is False:
+            out = {
+                k: v for k, v in out.items() if not k.startswith(f"{stream}.")
+            }
     return out
 
 
@@ -309,6 +325,11 @@ def default_thresholds(
             ("LOAD", "tempctrl_load"),
         ):
             ch_cfg = settings.get(channel, {}) or {}
+            if ch_cfg.get("installed") is False:
+                # Descoped channel: no stream exists, so staged
+                # setpoints (kept for hot-swap re-install) must not
+                # produce bands with nothing to classify.
+                continue
             target = ch_cfg.get("target_C")
             hyst = ch_cfg.get("hysteresis_C")
             clamp = ch_cfg.get("clamp")

--- a/src/eigsep_observing/tempctrl_client.py
+++ b/src/eigsep_observing/tempctrl_client.py
@@ -30,6 +30,7 @@ class TempCtrlClient:
             {
                 "watchdog_timeout_ms": int,
                 "LNA": {
+                    "installed": bool,  # optional; firmware default True
                     "enable": bool,
                     "cooling_enabled": bool,  # optional; firmware default True
                     "target_C": float,
@@ -55,6 +56,11 @@ class TempCtrlClient:
         ``[-clamp, +clamp]``); omit to leave the firmware default
         (True) in place. Deployments that cannot dissipate Peltier
         heat should set this False on the affected channel.
+        ``installed: false`` descopes a channel whose hardware module
+        is physically absent: firmware never samples or drives it, its
+        Redis stream stops publishing entirely, and :meth:`get_status`
+        stops reading it. Must be paired with ``enable: false`` (an
+        absent module cannot be armed — rejected at construction).
     source : str
         Identifier stamped on proxy command stream entries.
     """
@@ -125,7 +131,7 @@ class TempCtrlClient:
                             f"tempctrl[{ch}].{fname}: {val!r} not "
                             f"float-coercible ({exc})"
                         ) from exc
-            for bname in ("enable", "cooling_enabled"):
+            for bname in ("installed", "enable", "cooling_enabled"):
                 if bname in section:
                     val = section[bname]
                     if not isinstance(val, bool):
@@ -134,6 +140,15 @@ class TempCtrlClient:
                             f"bool, got {type(val).__name__}"
                         )
                     coerced[bname] = val
+            if (
+                coerced.get("installed") is False
+                and coerced.get("enable") is True
+            ):
+                raise ValueError(
+                    f"tempctrl[{ch}]: installed: false with enable: true "
+                    "— an absent module cannot be armed; set enable: "
+                    "false or mark the channel installed"
+                )
             out[ch] = coerced
         return out
 
@@ -150,15 +165,29 @@ class TempCtrlClient:
         merges them back into the flat ``LNA_*`` / ``LOAD_*`` shape
         used internally by ``_tempctrl_health_check`` so callers don't
         have to know about the split.
+
+        A channel whose settings say ``installed: false`` is never
+        read: its stream stopped publishing at the producer, but a
+        leftover hash entry (lab bring-up, pre-descope deployment, the
+        reboot burst before pico-manager replays the flags) would
+        otherwise feed stale data into the merged status and trigger
+        the snapshot reader's staleness warning on every poll. With
+        one channel skipped, the device-wide ``watchdog_*`` fields
+        ride the remaining channel's entry — same firmware tick, no
+        information loss.
         """
-        try:
-            lna = self._reader.get("tempctrl_lna")
-        except KeyError:
-            lna = None
-        try:
-            load = self._reader.get("tempctrl_load")
-        except KeyError:
-            load = None
+        lna = None
+        if self.settings.get("LNA", {}).get("installed") is not False:
+            try:
+                lna = self._reader.get("tempctrl_lna")
+            except KeyError:
+                lna = None
+        load = None
+        if self.settings.get("LOAD", {}).get("installed") is not False:
+            try:
+                load = self._reader.get("tempctrl_load")
+            except KeyError:
+                load = None
         if not lna and not load:
             return None
         merged = {}
@@ -180,6 +209,27 @@ class TempCtrlClient:
         self._proxy.send_command(
             "set_watchdog_timeout", timeout_ms=int(timeout_ms)
         )
+
+    def set_installed(self, *, LNA=None, LOAD=None):
+        """Mark a channel's hardware module present/absent.
+
+        Mirrors :meth:`picohost.base.PicoPeltier.set_installed`.
+        ``False`` descopes the channel: firmware never samples its
+        thermistor (no ADC mux switch to a dead divider) or drives it,
+        and the redis fan-out suppresses its stream entirely — clean
+        absence downstream. Distinct from :meth:`set_enable` (drive
+        intent for present hardware); not a trip ack. Only the kwargs
+        that are not ``None`` are forwarded, so partial application
+        does not flip the untouched channel. Firmware caches the
+        setting for replay on reconnect.
+        """
+        kwargs = {}
+        if LNA is not None:
+            kwargs["LNA"] = bool(LNA)
+        if LOAD is not None:
+            kwargs["LOAD"] = bool(LOAD)
+        if kwargs:
+            self._proxy.send_command("set_installed", **kwargs)
 
     def set_clamp(self, *, LNA=None, LOAD=None):
         kwargs = {}
@@ -296,22 +346,25 @@ class TempCtrlClient:
         """Push the full config to the pico in safe order.
 
         Order matches ``PicoPeltier``'s reconnect replay
-        (watchdog → clamp → cooling_enabled → gains → temperature →
-        enable):
+        (watchdog → installed → clamp → cooling_enabled → gains →
+        temperature → enable):
 
         1. ``set_watchdog_timeout`` first so any subsequent
            delay-between-commands cannot trip a zero-timeout default.
-        2. ``set_clamp`` — establish the duty-cycle ceiling before
+        2. ``set_installed`` — gate a descoped channel (no sampling,
+           no drive, no stream) before any drive-producing config
+           arrives; firmware reboots to installed=true defaults.
+        3. ``set_clamp`` — establish the duty-cycle ceiling before
            anything is armed.
-        3. ``set_cooling_enabled`` — apply the asymmetric-clamp safety
+        4. ``set_cooling_enabled`` — apply the asymmetric-clamp safety
            setting before the PI controller can produce drive on the
            new config.
-        4. ``set_gains`` — tune the PI controller before the setpoint
+        5. ``set_gains`` — tune the PI controller before the setpoint
            is published, so the very first PI tick on the new target
            uses the configured Kp/Ki rather than firmware defaults.
-        5. ``set_temperature`` — publish the target (and hysteresis)
+        6. ``set_temperature`` — publish the target (and hysteresis)
            while still disarmed (or at prior arm state).
-        6. ``set_enable`` — arm last, so by the time the channel turns
+        7. ``set_enable`` — arm last, so by the time the channel turns
            on the clamp, gains, and setpoint are already in place.
 
         Idempotent: calling repeatedly with unchanged settings is a
@@ -319,8 +372,13 @@ class TempCtrlClient:
         with identical ones). Missing sections are skipped — e.g.
         omitting ``watchdog_timeout_ms`` leaves whatever the firmware
         currently has. Missing ``Kp``/``Ki`` likewise leaves the
-        firmware defaults in place. Missing ``cooling_enabled`` leaves
-        the firmware default (True) in place.
+        firmware defaults in place. Missing ``cooling_enabled`` and
+        ``installed`` leave the firmware defaults (True) in place.
+        An uninstalled channel's setpoints/gains still push — harmless
+        while descoped (no sampling, no drive) and pre-staged for the
+        moment the module is re-installed; arming it is what's
+        forbidden (``_coerce_settings`` rejects ``installed: false``
+        with ``enable: true``).
 
         Raises
         ------
@@ -336,6 +394,10 @@ class TempCtrlClient:
             self.set_watchdog_timeout(watchdog)
         lna = s.get("LNA", {})
         load = s.get("LOAD", {})
+        self.set_installed(
+            LNA=lna.get("installed"),
+            LOAD=load.get("installed"),
+        )
         self.set_clamp(
             LNA=lna.get("clamp"),
             LOAD=load.get("clamp"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,13 +8,19 @@ from unittest.mock import patch
 import pytest
 
 from cmt_vna.testing import DummyVNA
-from eigsep_redis import ConfigStore, HeartbeatReader, StatusReader
+from eigsep_redis import (
+    ConfigStore,
+    HeartbeatReader,
+    MetadataWriter,
+    StatusReader,
+)
 from eigsep_redis.keys import STATUS_STREAM
 from eigsep_redis.testing import DummyTransport
 from picohost.proxy import PicoProxy
 
 import eigsep_observing
 from eigsep_observing import MotorClient, PandaClient, TempCtrlClient, run_tag
+from eigsep_observing._test_fixtures import tempctrl_post_handler_reading
 from eigsep_observing.testing import DummyPandaClient
 from eigsep_observing.testing.utils import compare_dicts
 
@@ -2021,6 +2027,97 @@ def test_init_tempctrl_no_warning_when_cooling_default(
         ]
         assert not any("cooling disabled" in m for m in warnings), (
             f"unexpected cooling warning with default config: {warnings}"
+        )
+    finally:
+        client.stop()
+
+
+def test_init_tempctrl_warns_when_channel_uninstalled(
+    transport, dummy_cfg, caplog
+):
+    """``installed: False`` is a deliberate hardware descope — surface
+    it once at init so operators know the channel is dark on purpose,
+    not from a fault. Fires per affected channel."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_settings"] = {
+        "LNA": {"installed": False, "enable": False},
+        "LOAD": {"installed": True, "enable": True, "target_C": 25.0},
+    }
+    caplog.set_level("WARNING")
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any("LNA not installed" in m for m in warnings), (
+            f"expected LNA not-installed warning in: {warnings}"
+        )
+        assert not any("LOAD not installed" in m for m in warnings), (
+            f"unexpected LOAD warning in: {warnings}"
+        )
+    finally:
+        client.stop()
+
+
+def test_init_tempctrl_no_warning_when_installed_default(
+    transport, dummy_cfg, caplog
+):
+    """Default config (no ``installed`` key) means both modules present
+    — no not-installed warning should fire."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    # dummy_cfg's tempctrl_settings carries no installed keys.
+    caplog.set_level("WARNING")
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert not any("not installed" in m for m in warnings), (
+            f"unexpected not-installed warning with default config: {warnings}"
+        )
+    finally:
+        client.stop()
+
+
+def test_tempctrl_health_check_skips_uninstalled_channel(
+    transport, dummy_cfg, caplog
+):
+    """End-to-end descope guard: with ``LNA.installed: false``, the
+    merged status from the real ``TempCtrlClient.get_status`` carries
+    no LNA keys — even with a leftover ``tempctrl_lna`` hash entry in
+    its real error-row shape (the reboot burst) — so the health check
+    emits no LNA warnings. If the stream were read, the error row
+    would trip "LNA thermistor in error state"; its absence proves the
+    skip, not a lucky healthy row."""
+    cfg = dict(dummy_cfg)
+    cfg["use_tempctrl"] = True
+    cfg["tempctrl_settings"] = {
+        "LNA": {"installed": False, "enable": False},
+        "LOAD": {"installed": True, "enable": True, "target_C": 25.0},
+    }
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        writer = MetadataWriter(client.transport)
+        writer.add(
+            "tempctrl_lna",
+            tempctrl_post_handler_reading("tempctrl_lna", sensor_error="LNA"),
+        )
+        writer.add(
+            "tempctrl_load", tempctrl_post_handler_reading("tempctrl_load")
+        )
+        caplog.set_level("WARNING")
+        status = client.tempctrl.get_status()
+        assert status is not None
+        assert not any(k.startswith("LNA_") for k in status)
+        # Drop the init-time "LNA not installed" descope warning (by
+        # design, tested separately) so the assertion scopes to the
+        # health check alone.
+        caplog.clear()
+        client._tempctrl_health_check(status)
+        assert not any("LNA" in r.getMessage() for r in caplog.records), (
+            f"unexpected LNA warning: {[r.getMessage() for r in caplog.records]}"
         )
     finally:
         client.stop()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,9 @@ import pytest
 import yaml
 
 from eigsep_redis import MetadataSnapshotReader
+from eigsep_redis.keys import METADATA_HASH
 from eigsep_redis.testing import DummyTransport
+from picohost.proxy import PicoProxy
 
 import eigsep_observing
 from eigsep_observing.testing import DummyPandaClient
@@ -102,6 +104,35 @@ def test_sensor_metadata_in_redis(client, transport):
             f"Expected sensor '{sensor}' in metadata, "
             f"got keys: {list(metadata.keys())}"
         )
+
+
+def test_uninstalled_channel_stream_stops(client, transport):
+    """Descope end-to-end through the embedded PicoManager:
+    ``set_installed(LNA=False)`` stops ``tempctrl_lna`` publishing
+    entirely (its snapshot timestamp freezes) while ``tempctrl_load``
+    keeps advancing — the clean-absence contract the consumer relies
+    on (no corr-file column, no staleness warnings)."""
+    _wait_for_sensors(transport, sensors=("tempctrl_lna", "tempctrl_load"))
+    proxy = PicoProxy("tempctrl", transport, source="test_integration")
+    assert proxy.send_command("set_installed", LNA=False) is not None
+
+    def _ts(stream):
+        return transport.r.hget(METADATA_HASH, f"{stream}_ts")
+
+    # The command dispatches through the manager's async cmd loop; poll
+    # until one publish gap shows LNA frozen while LOAD advanced.
+    deadline = time.monotonic() + 5.0
+    while True:
+        lna0, load0 = _ts("tempctrl_lna"), _ts("tempctrl_load")
+        time.sleep(0.5)
+        lna1, load1 = _ts("tempctrl_lna"), _ts("tempctrl_load")
+        if load1 != load0 and lna1 == lna0:
+            break
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"tempctrl_lna did not stop publishing: "
+                f"lna {lna0!r}->{lna1!r}, load {load0!r}->{load1!r}"
+            )
 
 
 def test_metadata_has_expected_fields(client, transport):

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1198,6 +1198,52 @@ def test_solve_calibration_meta_exposes_both_db_and_kelvin(agg_primed):
     assert meta["t_enr_k"] == pytest.approx(expected_k, rel=1e-9)
 
 
+def test_solve_calibration_honors_t_load_stream_knob(agg_primed):
+    """``calibration.t_load_stream`` re-points the load-temperature
+    reference at another stream — the hot-swap path where the LOAD
+    module rides the LNA connector and publishes as ``tempctrl_lna``.
+    The default ``tempctrl_load`` entry is removed to prove the knob
+    (not a fallback) satisfied the lookup."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        snap = agg_primed.state.metadata_snapshot
+        snap["tempctrl_lna"] = dict(snap["tempctrl_load"])
+        snap.pop("tempctrl_load", None)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "t_load_stream": "tempctrl_lna",
+        }
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is not None
+    assert meta["t_load_k"] is not None
+
+
+def test_solve_calibration_reason_names_configured_stream(agg_primed):
+    """When the configured temp-reference stream is missing, the bail
+    reason names *that* stream so a mis-typed knob is self-describing."""
+    _seed_onoff_cache(agg_primed)
+    # Remove the configured stream (agg_primed seeds both channels);
+    # tempctrl_load remains, proving the lookup follows the knob and
+    # does not fall back.
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot.pop("tempctrl_lna", None)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "t_load_stream": "tempctrl_lna",
+        }
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is None
+    assert "tempctrl_lna" in meta["reason"]
+
+
 def test_solve_calibration_logs_error_on_non_numeric_enr_db(
     agg_primed, caplog
 ):

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -122,6 +122,53 @@ def test_enabled_signals_includes_tempctrl_when_on():
     assert "tempctrl_lna.drive_level" in enabled
 
 
+# LNA descoped (installed: false) but with setpoints still staged for a
+# potential re-install/hot-swap — the realistic field shape. The channel
+# publishes no stream, so its tiles/bands must disappear while LOAD's
+# stay.
+OBS_CFG_LNA_UNINSTALLED = {
+    "use_tempctrl": True,
+    "corr_ntimes": 240,
+    "tempctrl_settings": {
+        "LNA": {
+            "installed": False,
+            "enable": False,
+            "target_C": 25.0,
+            "hysteresis_C": 0.5,
+            "clamp": 0.6,
+        },
+        "LOAD": {"target_C": 25.0, "hysteresis_C": 0.5, "clamp": 0.6},
+    },
+}
+
+
+def test_enabled_signals_drops_uninstalled_channel():
+    """A descoped channel publishes no stream — its tiles would sit
+    permanently empty on the dashboard (the field's only alerting
+    surface), so they're dropped per channel while LOAD's stay."""
+    enabled = enabled_signals(OBS_CFG_LNA_UNINSTALLED)
+    for key in (
+        "tempctrl_lna.T_now",
+        "tempctrl_lna.drive_level",
+        "tempctrl_lna.Kp",
+        "tempctrl_lna.Ki",
+        "tempctrl_lna.integral",
+    ):
+        assert key not in enabled, key
+    assert "tempctrl_load.T_now" in enabled
+    assert "tempctrl_load.drive_level" in enabled
+
+
+def test_default_thresholds_skips_uninstalled_channel():
+    """Staged setpoints on a descoped channel must not produce bands —
+    there is no stream for them to classify."""
+    out = default_thresholds(OBS_CFG_LNA_UNINSTALLED, corr_header=CORR_HEADER)
+    assert "tempctrl_lna.T_now" not in out
+    assert "tempctrl_lna.drive_level" not in out
+    assert "tempctrl_load.T_now" in out
+    assert "tempctrl_load.drive_level" in out
+
+
 # ---------------------------------------------------------------------
 # Thresholds merge + classify
 # ---------------------------------------------------------------------

--- a/tests/test_pico_preflight.py
+++ b/tests/test_pico_preflight.py
@@ -1,0 +1,39 @@
+"""Tests for the alive-but-absent annotation in ``scripts/pico_preflight.py``.
+
+A live device heartbeat with no published stream is either a
+deliberately descoped tempctrl channel (firmware ``installed=false``
+publishes nothing) or a producer fault. The preflight table must say
+so instead of leaving the reading column blank — without false-failing
+a descoped field rig.
+"""
+
+import importlib.util
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(name):
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_absent_stream_note_fires_when_alive_and_silent():
+    mod = _load("pico_preflight")
+    note = mod._absent_stream_note(alive=True, ts=None, reading=None)
+    assert "no stream" in note
+    assert "uninstalled" in note
+
+
+def test_absent_stream_note_silent_otherwise():
+    mod = _load("pico_preflight")
+    # Device dead: the alive column already tells the story.
+    assert mod._absent_stream_note(alive=False, ts=None, reading=None) == ""
+    # Stream publishing: nothing to annotate.
+    assert (
+        mod._absent_stream_note(alive=True, ts=123.0, reading={"T_now": 25.0})
+        == ""
+    )

--- a/tests/test_tempctrl_client.py
+++ b/tests/test_tempctrl_client.py
@@ -308,6 +308,18 @@ def test_is_available_reflects_registration(client):
         # non-bool truthy value would silently leave the cooling guard
         # *armed* (i.e. the safety setting wouldn't apply).
         ({"LNA": {"cooling_enabled": "false"}}, "cooling_enabled"),
+        # `installed: "false"` would silently keep the descoped channel
+        # publishing its dead-divider error stream.
+        ({"LNA": {"installed": "false"}}, "installed"),
+        # Config contradiction: an absent module cannot be armed.
+        (
+            {"LNA": {"installed": False, "enable": True}},
+            "cannot be armed",
+        ),
+        (
+            {"LOAD": {"installed": False, "enable": True}},
+            "cannot be armed",
+        ),
     ],
 )
 def test_coerce_settings_raises_on_bad_config(bad_settings, needle):
@@ -351,6 +363,132 @@ def test_coerce_settings_normalizes_types():
     assert out["LNA"]["Kp"] == 0.0
     assert isinstance(out["LNA"]["Ki"], float)
     assert out["LNA"]["Ki"] == 0.0
+
+
+def test_coerce_settings_accepts_installed_bool():
+    """``installed`` rides the same strict-bool path as ``enable``;
+    ``installed: false`` with ``enable: false`` is the valid descope
+    shape."""
+    out = TempCtrlClient._coerce_settings(
+        {
+            "LNA": {"installed": False, "enable": False},
+            "LOAD": {"installed": True, "enable": True},
+        }
+    )
+    assert out["LNA"]["installed"] is False
+    assert out["LOAD"]["installed"] is True
+
+
+def test_set_installed_pushes_to_emulator(client):
+    """``set_installed`` flips the firmware-side installed flag on the
+    addressed channel(s); the fan-out then stops publishing that
+    channel's stream."""
+    tc = TempCtrlClient(client.transport)
+    em = _emulator(client)
+    assert em.lna.installed is True
+    assert em.load.installed is True
+
+    tc.set_installed(LNA=False)
+
+    assert _wait_until(lambda: em.lna.installed is False)
+    # LOAD was never sent; firmware default (True) untouched.
+    assert em.load.installed is True
+
+
+def test_set_installed_no_kwargs_is_no_op(client):
+    """``set_installed()`` with both args None must not send a command
+    — partial-application callers don't flip the untouched channel."""
+    tc = TempCtrlClient(client.transport)
+    with patch.object(tc._proxy, "send_command") as mock_send:
+        tc.set_installed()
+        mock_send.assert_not_called()
+
+
+def test_apply_settings_order_installed_after_watchdog():
+    """``apply_settings`` pushes installed right after the watchdog —
+    before anything drive-producing — mirroring PicoPeltier's
+    reconnect replay order."""
+    from eigsep_redis.testing import DummyTransport
+
+    transport = DummyTransport()
+    tc = TempCtrlClient(
+        transport,
+        settings={
+            "watchdog_timeout_ms": 25000,
+            "LNA": {
+                "installed": False,
+                "enable": False,
+                "target_C": 25.0,
+                "clamp": 0.5,
+            },
+            "LOAD": {
+                "installed": True,
+                "enable": True,
+                "cooling_enabled": False,
+                "target_C": 25.0,
+                "clamp": 0.5,
+                "Kp": 0.3,
+                "Ki": 0.01,
+            },
+        },
+    )
+    sent = []
+    with patch.object(
+        tc._proxy,
+        "send_command",
+        side_effect=lambda cmd, **kw: sent.append(cmd),
+    ):
+        tc.apply_settings()
+    assert sent == [
+        "set_watchdog_timeout",
+        "set_installed",
+        "set_clamp",
+        "set_cooling_enabled",
+        "set_gains",
+        "set_temperature",
+        "set_enable",
+    ]
+
+
+@pytest.mark.parametrize(
+    "off_ch, on_ch",
+    [("LNA", "LOAD"), ("LOAD", "LNA")],
+)
+def test_get_status_skips_uninstalled_channel_stream(off_ch, on_ch):
+    """A channel whose settings say ``installed: false`` is never read:
+    a leftover hash entry (lab bring-up, pre-descope deployment, reboot
+    burst) must not resurrect stale data into the merged status or
+    trigger the snapshot reader's staleness warning on every poll."""
+    from eigsep_redis import MetadataWriter
+    from eigsep_redis.testing import DummyTransport
+
+    from eigsep_observing._test_fixtures import tempctrl_post_handler_reading
+
+    transport = DummyTransport()
+    writer = MetadataWriter(transport)
+    for stream in ("tempctrl_lna", "tempctrl_load"):
+        writer.add(stream, tempctrl_post_handler_reading(stream))
+
+    tc = TempCtrlClient(
+        transport,
+        settings={off_ch: {"installed": False, "enable": False}},
+    )
+    reads = []
+    original_get = tc._reader.get
+
+    def spying_get(key, *args, **kwargs):
+        reads.append(key)
+        return original_get(key, *args, **kwargs)
+
+    with patch.object(tc._reader, "get", side_effect=spying_get):
+        status = tc.get_status()
+
+    assert f"tempctrl_{off_ch.lower()}" not in reads
+    assert status is not None
+    assert not any(k.startswith(f"{off_ch}_") for k in status)
+    assert any(k.startswith(f"{on_ch}_") for k in status)
+    # Device-wide watchdog fields still ride the installed channel.
+    assert "watchdog_timeout_ms" in status
 
 
 def test_set_cooling_enabled_pushes_to_emulator(client):

--- a/tests/test_tempctrl_manual.py
+++ b/tests/test_tempctrl_manual.py
@@ -155,9 +155,9 @@ def test_seed_state_falls_back_to_default_gains_only(transport):
 
 def test_seed_state_times_out_when_streams_silent(transport):
     """If the pico is registered (``require_pico`` already passed) but
-    never publishes a ``T_target``, the seed exits with a SystemExit
-    message naming the silent streams — rather than papering over the
-    silence with a hardcoded default."""
+    never publishes a ``T_target`` on either stream, the seed exits
+    with a SystemExit message naming the silent streams — rather than
+    papering over the silence with a hardcoded default."""
     mod = _load("tempctrl_manual")
     snapshot = MetadataSnapshotReader(transport)
     with pytest.raises(SystemExit) as exc:
@@ -168,9 +168,39 @@ def test_seed_state_times_out_when_streams_silent(transport):
     assert "T_target" in msg
 
 
-def test_seed_state_times_out_when_one_stream_silent(transport):
-    """One stream silent is still a timeout — both must publish before
-    the UI is allowed to come up with consistent state."""
+def test_seed_state_one_stream_silent_marks_not_installed(transport):
+    """One silent stream is the descoped-channel shape (its firmware
+    channel is marked not installed, so it publishes nothing — see the
+    per-channel installed flag): the UI comes up on the live channel
+    and marks the silent one not-installed, seeding it from firmware
+    defaults so a later re-install (`u` during a hot swap) starts from
+    sane values."""
+    mod = _load("tempctrl_manual")
+    _publish(
+        transport,
+        lna={
+            "sensor_name": "tempctrl_lna",
+            "status": "update",
+            "T_target": 28.0,
+            "enabled": True,
+        },
+    )
+    snapshot = MetadataSnapshotReader(transport)
+    state = mod._seed_state(snapshot, timeout_s=0.05, poll_interval_s=0.01)
+    assert state.lna_installed is True
+    assert state.load_installed is False
+    assert state.lna_setpoint == 28.0
+    assert state.lna_enabled is True
+    # Silent channel seeds firmware defaults.
+    assert state.load_setpoint == mod.DEFAULT_T_TARGET_C
+    assert state.load_enabled is False
+    assert state.load_Kp == mod.DEFAULT_KP
+    assert state.load_Ki == mod.DEFAULT_KI
+    assert state.load_cooling_enabled is True
+
+
+def test_seed_state_both_streams_marks_installed(transport):
+    """Both streams publishing → both channels marked installed."""
     mod = _load("tempctrl_manual")
     _publish(
         transport,
@@ -179,13 +209,16 @@ def test_seed_state_times_out_when_one_stream_silent(transport):
             "status": "update",
             "T_target": 30.0,
         },
+        load={
+            "sensor_name": "tempctrl_load",
+            "status": "update",
+            "T_target": 30.0,
+        },
     )
     snapshot = MetadataSnapshotReader(transport)
-    with pytest.raises(SystemExit) as exc:
-        mod._seed_state(snapshot, timeout_s=0.05, poll_interval_s=0.01)
-    msg = str(exc.value)
-    assert "tempctrl_load" in msg
-    assert "tempctrl_lna" not in msg
+    state = mod._seed_state(snapshot, timeout_s=1.0, poll_interval_s=0.01)
+    assert state.lna_installed is True
+    assert state.load_installed is True
 
 
 def _record_n(mod, snapshot, n):
@@ -389,6 +422,46 @@ def test_clamp_steps_up_and_saturates_at_max(transport):
     for _ in range(10):
         mod._handle_key(ord("c"), proxy, state)
     assert mod.CLAMPS[state.clamp_idx] == 1.0
+
+
+def test_installed_hotkeys_push_set_installed(transport):
+    """`t`/`T` toggle LNA installed, `u`/`U` toggle LOAD installed —
+    the hot-swap keys. Both channels ride each push (matching the
+    enable/cooling/gain push idiom) so the firmware always sees the
+    UI's full installed state."""
+    mod = _load("tempctrl_manual")
+    proxy = _FakeProxy()
+    state = _make_state(mod)
+    assert state.lna_installed is True
+    assert state.load_installed is True
+
+    assert mod._handle_key(ord("T"), proxy, state) is True
+    assert state.lna_installed is False
+    assert proxy.sent[-1] == (
+        "set_installed",
+        {"LNA": False, "LOAD": True},
+    )
+
+    mod._handle_key(ord("u"), proxy, state)
+    assert state.load_installed is True
+    assert proxy.sent[-1] == (
+        "set_installed",
+        {"LNA": False, "LOAD": True},
+    )
+
+    mod._handle_key(ord("U"), proxy, state)
+    assert state.load_installed is False
+    assert proxy.sent[-1] == (
+        "set_installed",
+        {"LNA": False, "LOAD": False},
+    )
+
+    mod._handle_key(ord("t"), proxy, state)
+    assert state.lna_installed is True
+    assert proxy.sent[-1] == (
+        "set_installed",
+        {"LNA": True, "LOAD": False},
+    )
 
 
 def test_handle_p_key_no_data(transport, tmp_path):


### PR DESCRIPTION
## Why

The field trip runs without the LNA temperature-control module. Without a descope path, its open thermistor streams `status="error"` every 200 ms forever: an error/None `tempctrl_lna` column in every corr file, permanently red LNA tiles on the field dashboard (the only alerting surface offline), a health-check warning every 60 s with `use_tempctrl: true` (the field config), and a dead ADC input sharing the mux with the live LOAD channel — the same multiplexed-ADC crosstalk mechanism that forced potmon down to one channel.

This is the **consumer half** of the per-channel `installed` flag (producer half: EIGSEP/pico-firmware#146 — firmware skips sampling/drive; the picohost fan-out publishes **no stream** for a descoped channel). Clean stream absence means schemas, `avg_metadata`, and golden fixtures need no changes at all; everything here is config plumbing, operator surfaces, and contract pins.

## What

- **TempCtrlClient**: per-channel `installed` in `tempctrl_settings` (strict bool; `installed: false` + `enable: true` rejected at construction — an absent module cannot be armed). New `set_installed`; `apply_settings` pushes it right after the watchdog, mirroring `PicoPeltier`'s reconnect replay order. `get_status` never reads an uninstalled channel's stream, so a leftover hash entry (lab bring-up, reboot burst) can't resurrect stale data or per-poll staleness warnings. Setpoints/gains still push while descoped — harmless (no sampling, no drive) and pre-staged for re-install.
- **PandaClient**: `init_tempctrl` warns once per descoped channel ("dark on purpose, not a fault"). `_tempctrl_health_check` needs no code change — uninstalled keys are absent from the merged snapshot by construction; proven by an end-to-end test that seeds a *real error-shaped* leftover `tempctrl_lna` row (would trip "LNA thermistor in error state" if read) and asserts silence.
- **live-status**: `enabled_signals` / `default_thresholds` gate per channel on `installed`; the Y-factor calibration's temperature reference is now `calibration.t_load_stream` (default `tempctrl_load`) — the knob that makes the hot-swap contingency (LOAD module on the LNA connector, publishing as `tempctrl_lna`) a config edit instead of a code change. Bail reasons name the configured stream.
- **tempctrl_manual**: seed comes up on one live stream (both silent is still a hard SystemExit); a silent channel is marked not-installed and staged with firmware defaults. New hotkeys `t`/`T` (LNA installed on/off), `u`/`U` (LOAD) — the hands-on hot-swap ack. Readout shows client installed state.
- **pico_preflight**: alive-but-absent rows annotated `no stream (channel uninstalled or producer fault)` instead of blank — visible without false-failing a descoped rig.
- **Config**: `installed: true` keys in `obs_config.yaml` / `dummy_config.yaml` (repo main stays behavior-neutral; the field flip — `use_tempctrl: true`, `LNA: {installed: false, enable: false}` — is a separate one-commit deployment PR after firmware flash + picohost upgrade) and the `calibration.t_load_stream` knob.
- **OPERATIONS.md**: new "Tempctrl channel descope and hot-swap" section with the full swap procedure (including the one-time Redis cleanup of the retired stream and the dashboard-config-skew gotcha).
- **Contract/integration pins**: producer-contract test that a descoped channel publishes *nothing* (and the survivor still conforms, with no `installed` field in the stream shape); integration test drives `set_installed(LNA=False)` through the embedded PicoManager and watches `tempctrl_lna`'s snapshot timestamp freeze while `tempctrl_load`'s advances.

## Draft blocker

`pyproject.toml` pins `picohost>=4.2`, which is **unreleased**: it needs EIGSEP/pico-firmware#146 merged and release-please to cut the next minor. CI here will fail on the pin until then. Before un-drafting: confirm the released version number that actually contains the installed flag (4.2.0 if #146 folds into the open release PR, else 4.3.0) and adjust the pin if needed. Local verification ran against picohost installed from the #146 branch.

## Testing

TDD throughout (16 new/extended tests written first and watched fail where the behavior was new; guard/contract tests pin already-shipped producer behavior). Local sweep against branch picohost: `test_tempctrl_client` (41), `test_tempctrl_manual` (17), `test_pico_preflight` (2), `test_integration`, `test_live_status_thresholds` + `test_live_status_app` + `test_live_status_calibration` (97), contract tests, `test_client -k tempctrl` + `test_io -k tempctrl` — **211 passed**. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)