### PR TITLE
feat(live_status): two-temperature Y-factor for the new noise source (35 dB diode + 30 dB pad)

### DIFF
--- a/src/eigsep_observing/config/obs_config.yaml
+++ b/src/eigsep_observing/config/obs_config.yaml
@@ -75,24 +75,39 @@ vna_position_sweep:
 # live-status first-order Y-factor calibration (display-only).
 # The dashboard's "Calibrated" toggle reads these to convert raw corr
 # power to Kelvin using the most recent RFNON / RFAMB integrations
-# (RFNOFF is still visited each cycle as an offline cross-check).
+# (RFNOFF is still visited each cycle as an offline cross-check; with
+# the diode off it should land near the pad ambient T_ns below).
 # This is intentionally not the science-grade cal — that lives in a
 # separate offline pipeline.
 #
-# Y-factor: G = (P_on − P_amb) / T_ns
-#           T_in = T_ns · (P − P_amb) / (P_on − P_amb) + T_LOAD
-# Assumes the noise diode's off-state physical temperature ≈ the
-# ambient load temperature (both sit at enclosure ambient).
-# T_ns is the diode's excess noise temperature (post-attenuator),
-# derived from the IEEE-standard ENR convention:
-# T_ns = 290 K · 10^(ENR_dB / 10).
+# Noise-source wiring: a noise diode (noise_diode_enr_db, IEEE ENR re
+# 290 K) feeds a noise_source_atten_db pad into the switch's noise
+# port. The pad's own thermal emission cancels in the diode on−off
+# difference, so the excess at the switch is
+#   T_ENR = 290 K · 10^((noise_diode_enr_db − noise_source_atten_db)/10)
+# (35 − 30 dB → effective 5 dB ≈ 917 K). The two reference planes:
+#   T_hot = T_ns + T_ENR   (RFNON; T_ns = pad physical temp, from the
+#                           RF-switch PCB thermistor nearest the pad)
+#   T_amb                  (RFAMB; ambient load temp, from tempctrl)
+# Y-factor: G = (P_on − P_amb) / (T_hot − T_amb)
+#           T_in = P / G − T_rx,  T_rx = P_amb / G − T_amb
 calibration:
-  noise_diode_enr_db: 11.0   # post-attenuator ENR (dB), referenced to 290 K
-  # Which metadata stream carries the calibration load's temperature
-  # (T_LOAD above). Change only for the hot-swap contingency where the
-  # LOAD module rides the LNA connector and publishes as tempctrl_lna —
-  # see OPERATIONS.md "Tempctrl channel descope and hot-swap".
-  t_load_stream: tempctrl_load
+  noise_diode_enr_db: 35.0  # diode ENR at its output plane (dB re 290 K)
+  noise_source_atten_db: 30.0  # pad between diode and switch (dB)
+  # Noise-source pad physical temperature (T_ns above).
+  # !!! UNVERIFIED: temp_therm2 is assumed to be the thermistor nearest
+  # !!! the noise-source pad ("thermistor 3"), but the temp_therm0/1/2
+  # !!! <-> PCB-position mapping has NOT been checked against the
+  # !!! hardware. Verify on the board and fix before field deploy.
+  # temp_therm* may be None (dead/shorted channel, or ADC saturation
+  # below ~8.5 C) — the cal disables cleanly until the reading returns.
+  t_ns_stream: rfswitch_therm
+  t_ns_field: temp_therm2
+  # Ambient-load temperature (T_amb above, the RFAMB path). The
+  # tempctrl hot-swap contingency re-points this at tempctrl_lna — see
+  # OPERATIONS.md "Tempctrl channel descope and hot-swap".
+  t_amb_stream: tempctrl_load
+  t_amb_field: T_now
 
 # tempctrl
 use_tempctrl: false

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 CELSIUS_TO_KELVIN = 273.15
-T_REF_K = 290.0  # IEEE ENR reference temperature
+ENR_REF_K = 290.0  # IEEE ENR reference temperature
 
 
 def _default_ori_motor():
@@ -103,62 +103,133 @@ def _header_input_to_ant(header: Optional[dict]) -> dict[str, str]:
     return _input_to_ant(header.get("wiring"))
 
 
+def _cal_finite_float(cal_cfg: dict, key: str) -> Optional[float]:
+    """Finite-float calibration knob from the config, or ``None``.
+
+    An absent key returns ``None`` silently — a missing cal block is a
+    legitimate "cal off" state. A present but non-coercible or
+    non-finite value is a config contract violation and logs at ERROR.
+    """
+    raw = cal_cfg.get(key)
+    if raw is None:
+        return None
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        logger.error(
+            "Live-status cal: %s=%r is not coercible to float; "
+            "calibration disabled until obs_config is fixed.",
+            key,
+            raw,
+        )
+        return None
+    if not math.isfinite(val):
+        logger.error(
+            "Live-status cal: %s=%r is not finite; "
+            "calibration disabled until obs_config is fixed.",
+            key,
+            raw,
+        )
+        return None
+    return val
+
+
+def _snapshot_temp_c(
+    state: StateSnapshot, stream: str, field: str
+) -> Optional[float]:
+    """Latest ``stream.field`` temperature (°C) from the snapshot.
+
+    Returns ``None`` when the stream or field is absent or ``None`` —
+    ``None`` is contractual for sensor dropouts (e.g. a dead/shorted
+    rfswitch thermistor channel, or ADC saturation below ~8.5 °C; see
+    the ``rfswitch_therm`` schema in ``io.py``), so it disables the cal
+    without an ERROR. A present, non-``None`` value that doesn't
+    coerce to float is a producer/schema contract violation and logs
+    at ERROR.
+    """
+    entry = state.metadata_snapshot.get(stream)
+    raw = entry.get(field) if isinstance(entry, dict) else None
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.error(
+            "Live-status cal: %s.%s=%r is not coercible to float; "
+            "producer/schema contract violation (must be float or None "
+            "per SENSOR_SCHEMAS).",
+            stream,
+            field,
+            raw,
+        )
+        return None
+
+
 def _solve_calibration(
     state: StateSnapshot, obs_cfg: dict, now: float
 ) -> tuple[Optional[dict], dict]:
     """Build per-channel ``(gain, t_rx)`` for the dashboard cal toggle.
 
     Coefficients are solved from the most recent ``RFNON``/``RFAMB``
-    pair — ``RFAMB`` (ambient load) is the cold reference, ``RFNON``
-    (noise diode on) the hot reference. ``RFNOFF`` stays cached and its
-    age is retained in ``meta`` for offline cross-check / API
-    consumers, but it no longer feeds the solve.
+    pair — ``RFAMB`` (ambient load, at the measured ``t_amb_*``
+    temperature) is the cold reference; ``RFNON`` (noise diode on) the
+    hot one, at the noise-source pad's measured physical temperature
+    (``t_ns_*``) plus the attenuated diode excess
+    ``T_ENR = 290 K · 10^((ENR_dB − atten_dB)/10)``. ``RFNOFF`` stays
+    cached and its age is retained in ``meta`` for offline cross-check
+    / API consumers, but it no longer feeds the solve.
 
     Returns ``(coeffs, meta)`` — ``coeffs`` is ``None`` when the cal
-    can't run (missing cache, missing T_LOAD, missing config); the
-    ``meta`` dict is always returned and exposes the cached pair ages
-    so the frontend can render a "cal is N seconds old" indicator. We
-    intentionally do not gate on cache age: the ``RFANT`` dwell is an
-    hour, so any fixed threshold either rejects nearly every antenna
-    integration or is so loose it adds nothing. The "switch has stopped
-    cycling" failure mode is already covered by ``on_schedule`` in the
-    rfswitch payload.
+    can't run (missing cache, missing reference temperature, missing
+    config); the ``meta`` dict is always returned and exposes the
+    cached pair ages so the frontend can render a "cal is N seconds
+    old" indicator. We intentionally do not gate on cache age: the
+    ``RFANT`` dwell is an hour, so any fixed threshold either rejects
+    nearly every antenna integration or is so loose it adds nothing.
+    The "switch has stopped cycling" failure mode is already covered
+    by ``on_schedule`` in the rfswitch payload.
     """
     cal_cfg = obs_cfg.get("calibration") or {}
 
-    raw_enr_db = cal_cfg.get("noise_diode_enr_db")
-    try:
-        enr_db = float(raw_enr_db) if raw_enr_db is not None else None
-    except (TypeError, ValueError):
-        logger.error(
-            "Live-status cal: noise_diode_enr_db=%r is not coercible to "
-            "float; calibration disabled until obs_config is fixed.",
-            raw_enr_db,
-        )
-        enr_db = None
-    if enr_db is not None and not math.isfinite(enr_db):
-        logger.error(
-            "Live-status cal: noise_diode_enr_db=%r is not finite; "
-            "calibration disabled until obs_config is fixed.",
-            raw_enr_db,
-        )
-        enr_db = None
+    enr_db = _cal_finite_float(cal_cfg, "noise_diode_enr_db")
+    atten_db = _cal_finite_float(cal_cfg, "noise_source_atten_db")
+    enr_eff_db = (
+        enr_db - atten_db
+        if enr_db is not None and atten_db is not None
+        else None
+    )
+    t_enr_k = (
+        ENR_REF_K * 10.0 ** (enr_eff_db / 10.0)
+        if enr_eff_db is not None
+        else None
+    )
 
-    t_enr_k = T_REF_K * 10.0 ** (enr_db / 10.0) if enr_db is not None else None
-
-    # Which metadata stream carries the calibration load's temperature.
-    # Default is the LOAD channel's stream; the knob exists for the
-    # hot-swap contingency where the LOAD module rides the LNA connector
-    # and publishes as tempctrl_lna (see OPERATIONS.md "Tempctrl channel
-    # descope and hot-swap").
-    t_load_stream = cal_cfg.get("t_load_stream") or "tempctrl_load"
+    # Which metadata streams carry the two reference temperatures.
+    # t_ns_*: physical temperature of the noise-source attenuator — the
+    # RF-switch PCB thermistor nearest the pad (channel assignment is
+    # config, see obs_config.yaml; the reading may be None when the
+    # channel is dead/shorted or ADC-saturated). t_amb_*: the RFAMB
+    # ambient load, riding the LOAD Peltier stream; the tempctrl
+    # hot-swap contingency re-points it at tempctrl_lna (see
+    # OPERATIONS.md "Tempctrl channel descope and hot-swap").
+    t_ns_stream = cal_cfg.get("t_ns_stream") or "rfswitch_therm"
+    t_ns_field = cal_cfg.get("t_ns_field") or "temp_therm2"
+    t_amb_stream = cal_cfg.get("t_amb_stream") or "tempctrl_load"
+    t_amb_field = cal_cfg.get("t_amb_field") or "T_now"
 
     meta: dict = {
         "stale": True,
         "reason": None,
-        "t_load_k": None,
-        "t_load_stream": t_load_stream,
+        "t_ns_k": None,
+        "t_amb_k": None,
+        "t_hot_k": None,
+        "t_ns_stream": t_ns_stream,
+        "t_ns_field": t_ns_field,
+        "t_amb_stream": t_amb_stream,
+        "t_amb_field": t_amb_field,
         "noise_diode_enr_db": enr_db,
+        "noise_source_atten_db": atten_db,
+        "enr_eff_db": enr_eff_db,
         "t_enr_k": t_enr_k,
         "last_rfnoff_age_s": None,
         "last_rfnon_age_s": None,
@@ -168,6 +239,9 @@ def _solve_calibration(
 
     if enr_db is None:
         meta["reason"] = "noise_diode_enr_db missing or non-numeric"
+        return None, meta
+    if atten_db is None:
+        meta["reason"] = "noise_source_atten_db missing or non-numeric"
         return None, meta
 
     rfamb = state.last_rfamb_pairs
@@ -183,26 +257,43 @@ def _solve_calibration(
     if state.last_rfamb_unix is not None:
         meta["last_rfamb_age_s"] = max(0.0, now - state.last_rfamb_unix)
 
-    load_entry = state.metadata_snapshot.get(t_load_stream)
-    load_t_now = (
-        load_entry.get("T_now") if isinstance(load_entry, dict) else None
-    )
-    try:
-        load_t_now_f = float(load_t_now) if load_t_now is not None else None
-    except (TypeError, ValueError):
-        logger.error(
-            "Live-status cal: %s.T_now=%r is not coercible to "
-            "float; producer/schema contract violation (T_now must be "
-            "float per SENSOR_SCHEMAS).",
-            t_load_stream,
-            load_t_now,
+    t_ns_c = _snapshot_temp_c(state, t_ns_stream, t_ns_field)
+    if t_ns_c is None:
+        meta["reason"] = (
+            f"{t_ns_stream}.{t_ns_field} missing or None "
+            "(sensor dead/saturated, or producer offline)"
         )
-        load_t_now_f = None
-    if load_t_now_f is None:
-        meta["reason"] = f"{t_load_stream}.T_now missing or non-numeric"
         return None, meta
-    t_load_k = load_t_now_f + CELSIUS_TO_KELVIN
-    meta["t_load_k"] = t_load_k
+    t_amb_c = _snapshot_temp_c(state, t_amb_stream, t_amb_field)
+    if t_amb_c is None:
+        meta["reason"] = (
+            f"{t_amb_stream}.{t_amb_field} missing or None "
+            "(sensor dead/saturated, or producer offline)"
+        )
+        return None, meta
+
+    t_ns_k = t_ns_c + CELSIUS_TO_KELVIN
+    t_amb_k = t_amb_c + CELSIUS_TO_KELVIN
+    t_hot_k = t_ns_k + t_enr_k
+    meta["t_ns_k"] = t_ns_k
+    meta["t_amb_k"] = t_amb_k
+    meta["t_hot_k"] = t_hot_k
+
+    if t_hot_k <= t_amb_k:
+        # Reachable from config alone (an oversized noise_source_atten_db
+        # shrinks t_enr_k below the ns/amb temperature gap) — log loudly
+        # so the operator fixes the knobs instead of trusting a junk cal.
+        logger.error(
+            "Live-status cal: hot reference t_hot_k=%r is not above "
+            "ambient t_amb_k=%r; check noise_diode_enr_db / "
+            "noise_source_atten_db in obs_config.",
+            t_hot_k,
+            t_amb_k,
+        )
+        meta["reason"] = (
+            "hot reference not above ambient (check ENR/atten config)"
+        )
+        return None, meta
 
     coeffs: dict[str, tuple[np.ndarray, np.ndarray]] = {}
     for pair, amb_arr in rfamb.items():
@@ -216,16 +307,16 @@ def _solve_calibration(
             p_amb = amb_arr[0].astype(np.float64)
             p_on = on_arr[0].astype(np.float64)
             try:
-                gain, t_rx = compute_gain_trx(p_on, p_amb, t_load_k, t_enr_k)
+                gain, t_rx = compute_gain_trx(p_on, p_amb, t_hot_k, t_amb_k)
             except ValueError as exc:
-                # Outer guards force `t_enr_k` finite and positive, so this
+                # The pre-loop guard forces `t_hot_k > t_amb_k`, so this
                 # path is only reachable via a logic regression — log loudly.
                 logger.error(
                     "Live-status cal: compute_gain_trx failed for pair %r "
-                    "(t_load_k=%r, t_enr_k=%r): %s",
+                    "(t_hot_k=%r, t_amb_k=%r): %s",
                     pair,
-                    t_load_k,
-                    t_enr_k,
+                    t_hot_k,
+                    t_amb_k,
                     exc,
                 )
                 continue

--- a/src/eigsep_observing/live_status/calibration.py
+++ b/src/eigsep_observing/live_status/calibration.py
@@ -4,9 +4,11 @@ Display-only. The "real" calibration (lab-measured ENR, polynomial
 bandpass corrections, etc.) lives elsewhere; this module exists so an
 operator looking at the live dashboard can flip a toggle and see
 spectra in Kelvin, with the built-in sanity check that ``RFAMB``
-calibrates to ``T_LOAD`` and ``RFNON`` to ``T_LOAD + T_ENR``.
-``RFNOFF`` is still measured every cycle and lands near ``T_LOAD``
-as an offline cross-check.
+calibrates to ``T_amb`` (ambient load) and ``RFNON`` to
+``T_hot = T_ns + T_ENR`` (noise-source pad ambient plus the
+attenuated diode excess). ``RFNOFF`` is still measured every cycle
+and lands near ``T_ns`` (the pad ambient, diode off) as an offline
+cross-check.
 
 Pure numpy. No Redis, no Flask, no aggregator — the route handler in
 ``app.py`` and the cache in ``aggregator.py`` are the only callers.
@@ -21,38 +23,39 @@ import numpy as np
 
 def compute_gain_trx(
     p_on,
-    p_off,
-    t_load: float,
-    t_enr_k: float,
+    p_amb,
+    t_hot_k: float,
+    t_cold_k: float,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Y-factor solve for ``(G(ν), T_rx(ν))``.
 
-    ``G(ν)   = (P_on - P_off) / T_ENR``
-    ``T_rx(ν) = P_off / G(ν) - T_LOAD``
+    ``G(ν)   = (P_on - P_amb) / (T_hot - T_cold)``
+    ``T_rx(ν) = P_amb / G(ν) - T_cold``
 
-    Channels with ``P_on <= P_off`` (which would give a non-positive
+    ``t_hot_k`` is the RFNON input temperature (the noise-source pad's
+    physical temperature plus the attenuated diode excess) and
+    ``t_cold_k`` the RFAMB ambient-load temperature. Both references
+    are measured independently — no shared-base-temperature assumption.
+
+    Channels with ``P_on <= P_amb`` (which would give a non-positive
     gain — physically a wiring or producer bug, not a real signal) are
     set to ``NaN`` so callers see a hole in the spectrum rather than
     inverted nonsense.
-
-    Under the RFNON/RFAMB pairing, ``p_off`` is the ambient-load trace;
-    the solve assumes the diode's off-state physical temperature ≈ the
-    ambient load temperature (both at enclosure ambient) — adequate
-    for this display-only first-order cal.
     """
-    if not (t_enr_k > 0):
+    if not (t_hot_k > t_cold_k):
         raise ValueError(
-            f"t_enr_k must be positive (got {t_enr_k!r}); a non-positive "
-            "ENR is a calibration/configuration bug — fix the caller's "
-            "settings, don't paper over it"
+            f"t_hot_k ({t_hot_k!r}) must exceed t_cold_k ({t_cold_k!r}); "
+            "a hot reference at or below ambient is a calibration/"
+            "configuration bug — fix the caller's settings, don't paper "
+            "over it"
         )
     p_on = np.asarray(p_on, dtype=np.float64)
-    p_off = np.asarray(p_off, dtype=np.float64)
-    diff = p_on - p_off
+    p_amb = np.asarray(p_amb, dtype=np.float64)
+    diff = p_on - p_amb
     with np.errstate(divide="ignore", invalid="ignore"):
-        gain_raw = diff / float(t_enr_k)
+        gain_raw = diff / (float(t_hot_k) - float(t_cold_k))
         gain = np.where(gain_raw > 0, gain_raw, np.nan)
-        t_rx = p_off / gain - float(t_load)
+        t_rx = p_amb / gain - float(t_cold_k)
     return gain, t_rx
 
 

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -54,7 +54,13 @@ OBS_CFG = {
     },
     "use_switches": True,
     "calibration": {
-        "noise_diode_enr_db": 10.0 * math.log10(1500.0 / 290.0),
+        # diode − pad → effective ENR with t_enr_k = 1500 K exactly,
+        # while still exercising the two-knob subtraction. The
+        # t_ns_* / t_amb_* knobs are left unset so the route tests
+        # cover the defaults (rfswitch_therm.temp_therm2 /
+        # tempctrl_load.T_now).
+        "noise_diode_enr_db": 10.0 * math.log10(1500.0 / 290.0) + 30.0,
+        "noise_source_atten_db": 30.0,
     },
 }
 
@@ -97,8 +103,9 @@ def _cross_bytes(value=5):
 def agg_primed():
     """Aggregator with state populated by SNAP + panda ticks.
 
-    Producers publish corr + adc_stats + heartbeat + rfswitch + tempctrl
-    + lidar + obs_config; the panda side also drives one observed
+    Producers publish corr + adc_stats + heartbeat + rfswitch (state +
+    PCB thermistors) + tempctrl + lidar + obs_config; the panda side
+    also drives one observed
     rfswitch transition (RFNOFF → RFANT) during the prime so
     ``rfswitch_state_entered_unix`` is latched and the dashboard's
     dwell-time / on-schedule projections have a real entry timestamp
@@ -214,6 +221,24 @@ def agg_primed():
             "clamp": 0.6,
         },
     )
+    # RF-switch PCB thermistors (full production shape per the
+    # rfswitch_therm schema in io.py). temp_therm2 is the cal's default
+    # noise-source pad reference; 25.0 C matches tempctrl_load.T_now so
+    # t_hot - t_amb == t_enr_k exactly and the cal asserts stay simple.
+    # 2.5 V is the divider midpoint a 10k NTC at 25 C actually produces.
+    panda_md.add(
+        "rfswitch_therm",
+        {
+            "sensor_name": "rfswitch_therm",
+            "status": "update",
+            "volt_therm0": 2.5,
+            "volt_therm1": 2.5,
+            "volt_therm2": 2.5,
+            "temp_therm0": 25.0,
+            "temp_therm1": 25.0,
+            "temp_therm2": 25.0,
+        },
+    )
 
     StatusWriter(panda).send("observation started", level=20)
     HeartbeatWriter(panda, name="client").set(ex=60, alive=True)
@@ -231,6 +256,7 @@ def agg_primed():
         [
             "stream:lidar",
             "stream:rfswitch",
+            "stream:rfswitch_therm",
             "stream:tempctrl_lna",
             "stream:tempctrl_load",
             "stream:status",
@@ -1015,7 +1041,7 @@ def _seed_onoff_cache(
     at a deliberately *different* power level (2x — the off-diode
     path and the ambient load genuinely differ in power on hardware)
     so any assert on an RFAMB-derived number (``gain_median``, the
-    T_LOAD round-trip) fails if the solve loop ever iterates the
+    T_amb round-trip) fails if the solve loop ever iterates the
     RFNOFF cache instead.
     """
     auto_off = np.full((1, NCHAN), p_off_value, dtype=np.int32)
@@ -1052,13 +1078,13 @@ def test_corr_route_default_returns_raw_with_no_calibration_meta(client):
     assert data.get("calibration_meta") is None
 
 
-def test_corr_route_calibrated_returns_t_load_for_p_ant_equals_p_off(
+def test_corr_route_calibrated_returns_t_amb_for_p_ant_equals_p_amb(
     agg_primed,
 ):
-    """End-to-end: with a fresh on/off cache and a known T_LOAD, an
-    RFANT integration whose power happens to equal ``P_off`` calibrates
-    out to ``T_LOAD`` (in Kelvin). This is the operator-visible sanity
-    check baked into the cal path.
+    """End-to-end: with a fresh on/amb cache and known reference
+    temperatures, an RFANT integration whose power happens to equal
+    ``P_amb`` calibrates out to ``T_amb`` (in Kelvin). This is the
+    operator-visible sanity check baked into the cal path.
     """
     _seed_onoff_cache(agg_primed, p_off_value=100, p_on_value=250)
     app = create_app(agg_primed)
@@ -1067,16 +1093,24 @@ def test_corr_route_calibrated_returns_t_load_for_p_ant_equals_p_off(
 
     body = client_.get("/api/corr?calibrated=1").get_json()
     data = body["data"]
-    # tempctrl_load T_now is 25.0 C → 298.15 K. P_ant=P_off=100 in the
-    # fixture; T_in collapses to T_LOAD in Kelvin.
+    # tempctrl_load T_now is 25.0 C → 298.15 K. P_ant=P_amb=100 in the
+    # fixture; T_in collapses to T_amb in Kelvin.
     expected_k = 25.0 + 273.15
     assert data["pairs"]["0"]["mag"][0] == pytest.approx(expected_k, rel=1e-6)
     meta = data["calibration_meta"]
     assert meta["stale"] is False
-    assert meta["t_load_k"] == pytest.approx(expected_k, rel=1e-6)
+    assert meta["t_amb_k"] == pytest.approx(expected_k, rel=1e-6)
+    # The noise-source pad rides the fixture's rfswitch_therm entry
+    # (temp_therm2 = 25.0 C, matching tempctrl_load by construction).
+    assert meta["t_ns_k"] == pytest.approx(expected_k, rel=1e-6)
+    assert meta["t_hot_k"] == pytest.approx(expected_k + 1500.0, rel=1e-9)
     assert meta["t_enr_k"] == pytest.approx(1500.0, rel=1e-9)
     assert meta["noise_diode_enr_db"] == pytest.approx(
-        10.0 * math.log10(1500.0 / 290.0), rel=1e-12
+        10.0 * math.log10(1500.0 / 290.0) + 30.0, rel=1e-12
+    )
+    assert meta["noise_source_atten_db"] == pytest.approx(30.0, rel=1e-12)
+    assert meta["enr_eff_db"] == pytest.approx(
+        10.0 * math.log10(1500.0 / 290.0), rel=1e-9
     )
     assert meta["last_rfamb_age_s"] is not None
     assert meta["last_rfnon_age_s"] is not None
@@ -1131,7 +1165,7 @@ def test_corr_route_calibrated_with_aged_cache_still_calibrates_and_exposes_age(
     assert meta["last_rfnon_age_s"] >= 1800.0
 
 
-def test_corr_route_calibrated_without_t_load_returns_raw_and_stale_true(
+def test_corr_route_calibrated_without_t_amb_returns_raw_and_stale_true(
     agg_primed,
 ):
     """If T_now is missing from the snapshot (sensor offline, pico
@@ -1149,6 +1183,31 @@ def test_corr_route_calibrated_without_t_load_returns_raw_and_stale_true(
     data = body["data"]
     assert data["pairs"]["0"]["mag"][0] == pytest.approx(100.0)
     assert data["calibration_meta"]["stale"] is True
+
+
+def test_corr_route_calibrated_with_none_thermistor_returns_raw(
+    agg_primed,
+):
+    """A ``None`` pad thermistor (dead/shorted channel or ADC
+    saturation — a schema-valid producer state, see the
+    ``rfswitch_therm`` schema in io.py) disables the cal cleanly at
+    the route level: raw values pass through, the meta block carries
+    the reason, and nothing crashes or blocks."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot["rfswitch_therm"]["temp_therm2"] = (
+            None
+        )
+
+    app = create_app(agg_primed)
+    app.config.update(TESTING=True)
+    client_ = app.test_client()
+    body = client_.get("/api/corr?calibrated=1").get_json()
+    data = body["data"]
+    assert data["pairs"]["0"]["mag"][0] == pytest.approx(100.0)
+    meta = data["calibration_meta"]
+    assert meta["stale"] is True
+    assert "rfswitch_therm.temp_therm2" in meta["reason"]
 
 
 def test_corr_route_calibrated_scales_cross_magnitudes_by_gain(
@@ -1209,64 +1268,94 @@ def test_solve_calibration_bails_on_non_finite_enr_db(bad_value, agg_primed):
     assert "noise_diode_enr_db" in meta["reason"]
 
 
-def test_solve_calibration_meta_exposes_both_db_and_kelvin(agg_primed):
-    """Meta carries both configured dB and derived K."""
+def test_solve_calibration_bails_on_missing_atten_db(agg_primed):
+    """Cal block without noise_source_atten_db disables cal with a
+    clear reason — the effective ENR needs both knobs; silently
+    assuming a 0 dB pad would misscale the cal by the pad value."""
     _seed_onoff_cache(agg_primed)
-    enr_db = 6.5
-    obs_cfg = {"calibration": {"noise_diode_enr_db": enr_db}}
+    obs_cfg = {"calibration": {"noise_diode_enr_db": 6.5}}
     coeffs, meta = _solve_calibration(
         agg_primed.state, obs_cfg, now=time.time()
     )
-    assert coeffs is not None
-    assert meta["noise_diode_enr_db"] == pytest.approx(enr_db, rel=1e-12)
-    expected_k = 290.0 * 10.0 ** (enr_db / 10.0)
-    assert meta["t_enr_k"] == pytest.approx(expected_k, rel=1e-9)
+    assert coeffs is None
+    assert "noise_source_atten_db" in meta["reason"]
+    assert "missing or non-numeric" in meta["reason"]
 
 
-def test_solve_calibration_honors_t_load_stream_knob(agg_primed):
-    """``calibration.t_load_stream`` re-points the load-temperature
-    reference at another stream — the hot-swap path where the LOAD
-    module rides the LNA connector and publishes as ``tempctrl_lna``.
-    The default ``tempctrl_load`` entry is removed to prove the knob
-    (not a fallback) satisfied the lookup."""
+@pytest.mark.parametrize("bad_value", ["oops", [1, 2], {"x": 1}])
+def test_solve_calibration_bails_on_non_numeric_atten_db(
+    bad_value, agg_primed
+):
     _seed_onoff_cache(agg_primed)
-    with agg_primed._lock:
-        snap = agg_primed.state.metadata_snapshot
-        snap["tempctrl_lna"] = dict(snap["tempctrl_load"])
-        snap.pop("tempctrl_load", None)
     obs_cfg = {
         "calibration": {
             "noise_diode_enr_db": 6.5,
-            "t_load_stream": "tempctrl_lna",
-        }
-    }
-    coeffs, meta = _solve_calibration(
-        agg_primed.state, obs_cfg, now=time.time()
-    )
-    assert coeffs is not None
-    assert meta["t_load_k"] is not None
-
-
-def test_solve_calibration_reason_names_configured_stream(agg_primed):
-    """When the configured temp-reference stream is missing, the bail
-    reason names *that* stream so a mis-typed knob is self-describing."""
-    _seed_onoff_cache(agg_primed)
-    # Remove the configured stream (agg_primed seeds both channels);
-    # tempctrl_load remains, proving the lookup follows the knob and
-    # does not fall back.
-    with agg_primed._lock:
-        agg_primed.state.metadata_snapshot.pop("tempctrl_lna", None)
-    obs_cfg = {
-        "calibration": {
-            "noise_diode_enr_db": 6.5,
-            "t_load_stream": "tempctrl_lna",
-        }
+            "noise_source_atten_db": bad_value,
+        },
     }
     coeffs, meta = _solve_calibration(
         agg_primed.state, obs_cfg, now=time.time()
     )
     assert coeffs is None
-    assert "tempctrl_lna" in meta["reason"]
+    assert "noise_source_atten_db" in meta["reason"]
+
+
+@pytest.mark.parametrize(
+    "bad_value", [float("nan"), float("inf"), float("-inf")]
+)
+def test_solve_calibration_bails_on_non_finite_atten_db(bad_value, agg_primed):
+    _seed_onoff_cache(agg_primed)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": bad_value,
+        },
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is None
+    assert "noise_source_atten_db" in meta["reason"]
+
+
+def test_solve_calibration_meta_exposes_both_db_and_kelvin(agg_primed):
+    """Meta carries the configured dB knobs and the derived values."""
+    _seed_onoff_cache(agg_primed)
+    enr_db = 36.5
+    atten_db = 30.0
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": enr_db,
+            "noise_source_atten_db": atten_db,
+        },
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is not None
+    assert meta["noise_diode_enr_db"] == pytest.approx(enr_db, rel=1e-12)
+    assert meta["noise_source_atten_db"] == pytest.approx(atten_db, rel=1e-12)
+    assert meta["enr_eff_db"] == pytest.approx(enr_db - atten_db, rel=1e-12)
+    expected_k = 290.0 * 10.0 ** ((enr_db - atten_db) / 10.0)
+    assert meta["t_enr_k"] == pytest.approx(expected_k, rel=1e-9)
+
+
+def test_solve_calibration_effective_enr_feeds_t_enr(agg_primed):
+    """The field wiring: 35 dB diode into a 30 dB pad → effective
+    5 dB, T_ENR = 290 · 10^0.5 ≈ 917 K at the switch port."""
+    _seed_onoff_cache(agg_primed)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 35.0,
+            "noise_source_atten_db": 30.0,
+        },
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is not None
+    assert meta["enr_eff_db"] == pytest.approx(5.0, rel=1e-12)
+    assert meta["t_enr_k"] == pytest.approx(290.0 * 10.0**0.5, rel=1e-9)
 
 
 def test_solve_calibration_requires_amb_and_non(agg_primed):
@@ -1276,7 +1365,12 @@ def test_solve_calibration_requires_amb_and_non(agg_primed):
     _seed_onoff_cache(agg_primed)
     with agg_primed._lock:
         agg_primed.state.last_rfamb_pairs = None
-    obs_cfg = {"calibration": {"noise_diode_enr_db": 6.5}}
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+        },
+    }
     coeffs, meta = _solve_calibration(
         agg_primed.state, obs_cfg, now=time.time()
     )
@@ -1292,10 +1386,12 @@ def test_solve_calibration_solves_from_rfamb_not_rfnoff(agg_primed):
     of the RFAMB-derived (250-100)/1500 = 0.1 — this pins the loop's
     data source, not just the presence gate."""
     _seed_onoff_cache(agg_primed, p_off_value=100, p_on_value=250)
-    # t_enr_k = 1500 K exactly, matching OBS_CFG's calibration block.
+    # t_enr_k = 1500 K exactly, matching OBS_CFG's calibration block;
+    # the fixture's t_ns == t_amb so t_hot − t_amb == t_enr_k.
     obs_cfg = {
         "calibration": {
-            "noise_diode_enr_db": 10.0 * math.log10(1500.0 / 290.0),
+            "noise_diode_enr_db": 10.0 * math.log10(1500.0 / 290.0) + 30.0,
+            "noise_source_atten_db": 30.0,
         },
     }
     coeffs, meta = _solve_calibration(
@@ -1305,6 +1401,116 @@ def test_solve_calibration_solves_from_rfamb_not_rfnoff(agg_primed):
     assert meta["gain_median"] == pytest.approx(0.1, rel=1e-6)
     gain, _ = coeffs["0"]
     np.testing.assert_allclose(gain, 0.1, rtol=1e-6)
+
+
+def test_solve_calibration_honors_t_ns_and_t_amb_knobs(agg_primed):
+    """Both reference-temperature sources re-point via config — stream
+    and field — with no silent fallback to the defaults. Both are sent
+    to tempctrl_lna (T_now = 25.1 C in the fixture) while the default
+    streams are removed from the snapshot, so a solve that fell back
+    to rfswitch_therm / tempctrl_load would bail instead of solving."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot.pop("rfswitch_therm", None)
+        agg_primed.state.metadata_snapshot.pop("tempctrl_load", None)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+            "t_ns_stream": "tempctrl_lna",
+            "t_ns_field": "T_now",
+            "t_amb_stream": "tempctrl_lna",
+            "t_amb_field": "T_now",
+        },
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is not None
+    expected_k = 25.1 + 273.15
+    assert meta["t_ns_k"] == pytest.approx(expected_k, rel=1e-9)
+    assert meta["t_amb_k"] == pytest.approx(expected_k, rel=1e-9)
+    assert meta["t_ns_stream"] == "tempctrl_lna"
+    assert meta["t_amb_stream"] == "tempctrl_lna"
+
+
+def test_solve_calibration_none_thermistor_disables_cal_cleanly(
+    agg_primed, caplog
+):
+    """A ``None`` pad thermistor is a schema-valid producer state
+    (dead/shorted channel or ADC saturation below ~8.5 C — see the
+    ``rfswitch_therm`` schema in io.py), not a contract violation:
+    the cal disables with a named reason and NO ERROR log."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot["rfswitch_therm"]["temp_therm2"] = (
+            None
+        )
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+        },
+    }
+    with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
+        coeffs, meta = _solve_calibration(
+            agg_primed.state, obs_cfg, now=time.time()
+        )
+    assert coeffs is None
+    assert meta["stale"] is True
+    assert "rfswitch_therm.temp_therm2" in meta["reason"]
+    assert not caplog.records
+
+
+def test_solve_calibration_reason_names_missing_t_ns_source(agg_primed):
+    """An absent noise-source thermistor stream names the configured
+    stream.field in the reason so the operator knows which producer
+    (or knob) to chase."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot.pop("rfswitch_therm", None)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+        },
+    }
+    coeffs, meta = _solve_calibration(
+        agg_primed.state, obs_cfg, now=time.time()
+    )
+    assert coeffs is None
+    assert "rfswitch_therm.temp_therm2" in meta["reason"]
+
+
+def test_solve_calibration_bails_when_hot_not_above_ambient(
+    agg_primed, caplog
+):
+    """A hot reference at or below the ambient load is reachable from
+    config alone (an oversized pad shrinks T_ENR below the ns/amb
+    temperature gap) — the cal must refuse with an ERROR instead of
+    solving a negative-denominator gain. Board thermistor is set well
+    below the load temp and the pad eats the diode down to ~0.13 K."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot["rfswitch_therm"]["temp_therm2"] = (
+            10.0
+        )
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 40.0,
+        },
+    }
+    with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
+        coeffs, meta = _solve_calibration(
+            agg_primed.state, obs_cfg, now=time.time()
+        )
+    assert coeffs is None
+    assert "hot reference not above ambient" in meta["reason"]
+    assert any(
+        "not above" in r.message and r.levelname == "ERROR"
+        for r in caplog.records
+    )
 
 
 def test_solve_calibration_logs_error_on_non_numeric_enr_db(
@@ -1336,6 +1542,27 @@ def test_solve_calibration_logs_error_on_non_finite_enr_db(agg_primed, caplog):
     )
 
 
+def test_solve_calibration_logs_error_on_non_numeric_atten_db(
+    agg_primed, caplog
+):
+    """Non-coercible noise_source_atten_db is a config contract
+    violation; CLAUDE.md requires it surface at ERROR, not just in
+    meta.reason."""
+    _seed_onoff_cache(agg_primed)
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": "not-a-number",
+        },
+    }
+    with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
+        _solve_calibration(agg_primed.state, obs_cfg, now=time.time())
+    assert any(
+        "noise_source_atten_db" in r.message and r.levelname == "ERROR"
+        for r in caplog.records
+    )
+
+
 def test_solve_calibration_logs_error_on_non_numeric_load_t_now(
     agg_primed, caplog
 ):
@@ -1347,7 +1574,12 @@ def test_solve_calibration_logs_error_on_non_numeric_load_t_now(
         agg_primed.state.metadata_snapshot["tempctrl_load"] = {
             "T_now": "warm-ish",
         }
-    obs_cfg = {"calibration": {"noise_diode_enr_db": 6.5}}
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+        },
+    }
     with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
         _solve_calibration(agg_primed.state, obs_cfg, now=time.time())
     assert any(
@@ -1355,11 +1587,39 @@ def test_solve_calibration_logs_error_on_non_numeric_load_t_now(
     )
 
 
+def test_solve_calibration_logs_error_on_non_numeric_thermistor(
+    agg_primed, caplog
+):
+    """A non-float, non-None pad thermistor value is a producer/schema
+    contract violation (unlike ``None``, which is contractual) — it
+    must surface at ERROR naming the configured stream.field."""
+    _seed_onoff_cache(agg_primed)
+    with agg_primed._lock:
+        agg_primed.state.metadata_snapshot["rfswitch_therm"]["temp_therm2"] = (
+            "warm-ish"
+        )
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+        },
+    }
+    with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
+        coeffs, meta = _solve_calibration(
+            agg_primed.state, obs_cfg, now=time.time()
+        )
+    assert coeffs is None
+    assert any(
+        "rfswitch_therm.temp_therm2" in r.message and r.levelname == "ERROR"
+        for r in caplog.records
+    )
+
+
 def test_solve_calibration_logs_error_on_compute_gain_trx_failure(
     agg_primed, caplog, monkeypatch
 ):
     """The ``compute_gain_trx`` ValueError arm is unreachable in normal
-    operation (the outer guard forces ``t_enr_k`` finite/positive), so
+    operation (the pre-loop guard forces ``t_hot_k > t_amb_k``), so
     this guards a regression of those guards. Force the path with a
     monkeypatched solver."""
     from eigsep_observing.live_status import app as app_mod
@@ -1369,7 +1629,12 @@ def test_solve_calibration_logs_error_on_compute_gain_trx_failure(
 
     monkeypatch.setattr(app_mod, "compute_gain_trx", boom)
     _seed_onoff_cache(agg_primed)
-    obs_cfg = {"calibration": {"noise_diode_enr_db": 6.5}}
+    obs_cfg = {
+        "calibration": {
+            "noise_diode_enr_db": 6.5,
+            "noise_source_atten_db": 0.0,
+        },
+    }
     with caplog.at_level("ERROR", logger="eigsep_observing.live_status.app"):
         _solve_calibration(agg_primed.state, obs_cfg, now=time.time())
     assert any(

--- a/tests/test_live_status_calibration.py
+++ b/tests/test_live_status_calibration.py
@@ -4,8 +4,8 @@ The cal is display-only — operator-visible spectra in Kelvin on the
 live dashboard. The math itself is a pure-Python module so it can be
 unit-tested in isolation, without aggregator / Flask scaffolding.
 
-Round-trip pattern: synthesize ``P_off``, ``P_on``, and a fictitious
-sky/source spectrum from a *known* ``(G, T_rx, T_LOAD, T_ENR)``, run
+Round-trip pattern: synthesize ``P_amb``, ``P_on``, and a fictitious
+sky/source spectrum from a *known* ``(G, T_rx, T_hot, T_cold)``, run
 the cal, and assert we recover the inputs to within a tight tolerance.
 This is the inverse of the contract the field deployment cares about,
 which is the right shape for a contract test.
@@ -30,66 +30,70 @@ def _synthesize(
     *,
     gain: np.ndarray,
     t_rx: np.ndarray,
-    t_load: float,
-    t_enr_k: float,
+    t_hot_k: float,
+    t_cold_k: float,
 ):
-    """Build a (P_on, P_off) pair consistent with the cal model.
+    """Build a (P_on, P_amb) pair consistent with the cal model.
 
-    P_off = G * (T_LOAD + T_rx)
-    P_on  = G * (T_LOAD + T_rx + T_ENR)
+    P_amb = G * (T_cold + T_rx)
+    P_on  = G * (T_hot + T_rx)
     """
-    p_off = gain * (t_load + t_rx)
-    p_on = gain * (t_load + t_rx + t_enr_k)
-    return p_on, p_off
+    p_amb = gain * (t_cold_k + t_rx)
+    p_on = gain * (t_hot_k + t_rx)
+    return p_on, p_amb
 
 
 def test_compute_gain_trx_recovers_inputs_for_well_posed_case():
     """Round-trip: feed the model with known (G, T_rx) and recover them.
 
-    Hand-picked numbers (G=1e6 arb/K, T_rx=80 K, T_LOAD=290 K,
-    T_ENR=1500 K) so the assert can run with a tight relative tolerance
-    and any drift in the math jumps out immediately.
+    Hand-picked numbers (G=1e6 arb/K, T_rx=80 K, T_cold=300.15 K,
+    T_hot=298.15+1500 K) with *distinct* hot/cold base temperatures —
+    the noise-source pad and the ambient load are measured
+    independently — so the assert proves the generalized two-
+    temperature solve, and any drift in the math jumps out immediately.
     """
     gain_in = np.full(NCHAN, 1e6)
     t_rx_in = np.full(NCHAN, 80.0)
-    t_load = 290.0
-    t_enr_k = 1500.0
-    p_on, p_off = _synthesize(
-        gain=gain_in, t_rx=t_rx_in, t_load=t_load, t_enr_k=t_enr_k
+    t_cold_k = 300.15
+    t_hot_k = 298.15 + 1500.0
+    p_on, p_amb = _synthesize(
+        gain=gain_in, t_rx=t_rx_in, t_hot_k=t_hot_k, t_cold_k=t_cold_k
     )
 
-    gain, t_rx = compute_gain_trx(p_on, p_off, t_load, t_enr_k)
+    gain, t_rx = compute_gain_trx(p_on, p_amb, t_hot_k, t_cold_k)
 
     np.testing.assert_allclose(gain, gain_in, rtol=1e-12)
     np.testing.assert_allclose(t_rx, t_rx_in, rtol=1e-12)
 
 
-def test_compute_gain_trx_handles_p_on_equals_p_off_with_nan():
-    """If P_on == P_off, the gain estimate divides by zero — propagate
+def test_compute_gain_trx_handles_p_on_equals_p_amb_with_nan():
+    """If P_on == P_amb, the gain estimate divides by zero — propagate
     NaN per channel rather than crashing or returning ±inf.
 
-    This is the "stale on/off" failure mode: a producer pushed the same
+    This is the "stale on/amb" failure mode: a producer pushed the same
     integration twice (or the diode never fired). Calibrated mode is
     going to fall back to raw at the route level, but the math itself
     still has to be safe so the route can inspect ``calibration_meta``
     rather than catching exceptions.
     """
     p = np.full(NCHAN, 1e9)
-    gain, t_rx = compute_gain_trx(p, p, t_load=290.0, t_enr_k=1500.0)
+    gain, t_rx = compute_gain_trx(p, p, t_hot_k=1798.15, t_cold_k=300.15)
     assert np.all(np.isnan(gain))
     assert np.all(np.isnan(t_rx))
 
 
 def test_compute_gain_trx_marks_negative_diff_as_nan():
-    """If P_on < P_off (noise diode dimmer than the load — physically
-    impossible, so a producer/wiring bug), gain would be negative and
-    the cal would invert the spectrum. Mark those channels NaN so the
-    downstream apply step skips them and the operator sees a hole, not
-    nonsense.
+    """If P_on < P_amb (noise diode dimmer than the ambient load —
+    physically impossible, so a producer/wiring bug), gain would be
+    negative and the cal would invert the spectrum. Mark those channels
+    NaN so the downstream apply step skips them and the operator sees a
+    hole, not nonsense.
     """
-    p_off = np.full(NCHAN, 2e9)
+    p_amb = np.full(NCHAN, 2e9)
     p_on = np.full(NCHAN, 1e9)
-    gain, t_rx = compute_gain_trx(p_on, p_off, t_load=290.0, t_enr_k=1500.0)
+    gain, t_rx = compute_gain_trx(
+        p_on, p_amb, t_hot_k=1798.15, t_cold_k=300.15
+    )
     assert np.all(np.isnan(gain))
     assert np.all(np.isnan(t_rx))
 
@@ -106,19 +110,37 @@ def test_apply_calibration_auto_recovers_t_sky():
     np.testing.assert_allclose(t_in, t_sky, rtol=1e-12)
 
 
-def test_apply_calibration_auto_on_rfnoff_returns_t_load():
-    """Sanity-check baked into the cal: an RFNOFF spectrum, calibrated
-    with the same on/off pair it came from, must return T_LOAD. This is
-    the operator-visible "is the calibration sane" check on the
-    dashboard."""
+def test_apply_calibration_auto_on_rfamb_returns_t_cold():
+    """Sanity-check baked into the cal: an RFAMB spectrum, calibrated
+    with the same on/amb pair it came from, must return the ambient
+    load temperature. This is the operator-visible "is the calibration
+    sane" check on the dashboard."""
     gain = np.full(NCHAN, 1e6)
     t_rx = np.full(NCHAN, 80.0)
-    t_load = 290.0
-    p_off = gain * (t_load + t_rx)
+    t_cold_k = 300.15
+    p_amb = gain * (t_cold_k + t_rx)
 
-    t_in = apply_calibration_auto(p_off, gain, t_rx)
+    t_in = apply_calibration_auto(p_amb, gain, t_rx)
 
-    np.testing.assert_allclose(t_in, t_load, rtol=1e-12)
+    np.testing.assert_allclose(t_in, t_cold_k, rtol=1e-12)
+
+
+def test_apply_calibration_auto_on_rfnon_returns_t_hot():
+    """Companion sanity check on the hot side: an RFNON spectrum,
+    calibrated with coefficients solved from its own on/amb pair, must
+    return T_hot (pad ambient + attenuated diode excess)."""
+    gain_in = np.full(NCHAN, 1e6)
+    t_rx_in = np.full(NCHAN, 80.0)
+    t_cold_k = 300.15
+    t_hot_k = 298.15 + 1500.0
+    p_on, p_amb = _synthesize(
+        gain=gain_in, t_rx=t_rx_in, t_hot_k=t_hot_k, t_cold_k=t_cold_k
+    )
+    gain, t_rx = compute_gain_trx(p_on, p_amb, t_hot_k, t_cold_k)
+
+    t_in = apply_calibration_auto(p_on, gain, t_rx)
+
+    np.testing.assert_allclose(t_in, t_hot_k, rtol=1e-12)
 
 
 def test_apply_calibration_auto_propagates_nan_gain():
@@ -167,21 +189,30 @@ def test_compute_gain_trx_accepts_lists():
     massages them). Accept anything ``np.asarray`` can swallow rather
     than forcing the caller to pre-cast.
     """
-    p_off = [1e9] * NCHAN
+    p_amb = [1e9] * NCHAN
     p_on = [2.5e9] * NCHAN
-    gain, t_rx = compute_gain_trx(p_on, p_off, t_load=290.0, t_enr_k=1500.0)
+    gain, t_rx = compute_gain_trx(
+        p_on, p_amb, t_hot_k=1798.15, t_cold_k=300.15
+    )
     assert gain.shape == (NCHAN,)
     assert t_rx.shape == (NCHAN,)
     assert np.all(np.isfinite(gain))
 
 
-@pytest.mark.parametrize("t_enr_k", [0.0, -1500.0])
-def test_compute_gain_trx_invalid_t_enr_raises(t_enr_k):
-    """A non-positive ``T_ENR`` is a config bug — refuse to run rather
-    than silently produce garbage. The route falls back to raw on
-    ``ValueError`` so the dashboard keeps painting; the producer is
+@pytest.mark.parametrize(
+    "t_hot_k,t_cold_k",
+    [
+        (300.15, 300.15),  # hot == cold: zero denominator
+        (290.0, 300.15),  # hot below ambient
+    ],
+)
+def test_compute_gain_trx_hot_not_above_cold_raises(t_hot_k, t_cold_k):
+    """A hot reference at or below the cold one is a config bug (e.g.
+    an oversized noise_source_atten_db) — refuse to run rather than
+    silently produce garbage. The route falls back to raw on
+    ``ValueError`` so the dashboard keeps painting; the config is
     fixed by the operator.
     """
     p = np.full(NCHAN, 1e9)
-    with pytest.raises(ValueError, match="t_enr_k"):
-        compute_gain_trx(p, p * 0.5, t_load=290.0, t_enr_k=t_enr_k)
+    with pytest.raises(ValueError, match="t_hot_k"):
+        compute_gain_trx(p, p * 0.5, t_hot_k=t_hot_k, t_cold_k=t_cold_k)


### PR DESCRIPTION
## Summary

Stacked on #195 (RFNON+RFAMB Y-factor). The field noise source changed: it is now a **35 dB ENR noise diode behind a 30 dB attenuator** on the switch's noise port. This PR replaces #195's single-base-temperature approximation (diode-off phys temp ≈ ambient load temp, single `noise_diode_enr_db: 11.0` knob) with the measured two-temperature model:

```
T_ENR = 290 K · 10^((noise_diode_enr_db − noise_source_atten_db)/10)   # 35−30 dB → ~917 K
T_hot = T_ns + T_ENR    # RFNON; T_ns = pad physical temp (RF-switch PCB thermistor)
T_amb                   # RFAMB; ambient load temp (tempctrl_load.T_now)
G     = (P_on − P_amb) / (T_hot − T_amb)
T_rx  = P_amb / G − T_amb
```

The pad's own thermal emission cancels in the diode on−off difference, so only the dB subtraction enters T_ENR; the pad's physical temperature enters through T_hot.

## Changes

- `calibration.py`: `compute_gain_trx(p_on, p_amb, t_hot_k, t_cold_k)` — explicit hot/cold references; guard is now `t_hot_k > t_cold_k`.
- `app.py::_solve_calibration`:
  - Two dB knobs (`noise_diode_enr_db`, `noise_source_atten_db`) via a shared `_cal_finite_float` helper (absent → silent cal-off; non-coercible/non-finite → ERROR).
  - Two reference-temperature knob pairs via `_snapshot_temp_c`: `t_ns_stream`/`t_ns_field` (default `rfswitch_therm.temp_therm2`) and `t_amb_stream`/`t_amb_field` (default `tempctrl_load.T_now`).
  - `None` thermistor readings are **contractual** (dead/shorted channel or ADC saturation below ~8.5 °C per the `rfswitch_therm` schema) → cal disables cleanly with a named reason, no ERROR. Non-float non-None still logs the producer contract violation.
  - Pre-loop guard: hot reference at or below ambient (reachable from config alone via an oversized pad value) → ERROR + named reason.
  - Meta now carries `t_ns_k`/`t_amb_k`/`t_hot_k`, both dB knobs, `enr_eff_db`, and the four stream/field knobs. The cal bar reads only `stale`/`reason`/ages/`gain_median` — no JS change.
- `obs_config.yaml`: documents the wiring and ships `35.0` / `30.0` / `rfswitch_therm.temp_therm2` / `tempctrl_load.T_now`.

## ⚠️ Hardware verification needed before field deploy

`t_ns_field: temp_therm2` assumes "thermistor 3" (nearest the noise-source pad) is ADC channel 2. The `temp_therm0/1/2` ↔ PCB-position mapping has **not** been checked against the hardware — verify on the board and fix the knob if wrong (flagged loudly in the YAML).

## Reconciliation note (for the #195 → main merge)

`main` has since added a `calibration.t_load_stream` knob (tempctrl hot-swap contingency) that this branch supersedes: the hot-swap now re-points `t_amb_stream: tempctrl_lna` instead. When reconciling with main, resolve that region in favor of this branch and update the OPERATIONS.md hot-swap bullet accordingly (that section doesn't exist on this branch).

## Test plan

- `pytest tests/test_live_status_calibration.py` — 12 passed (generalized solve round-trip with distinct hot/cold temps, RFAMB→T_amb and RFNON→T_hot sanity checks, hot-not-above-cold guard).
- `pytest tests/test_live_status_app.py` — 90 passed (fixture publishes a production-shaped `rfswitch_therm` entry; new coverage: missing/non-numeric/non-finite atten knob, effective-ENR derivation, knob re-pointing with no fallback, None-thermistor clean degradation at unit + route level, hot-below-ambient bail).
- `pytest tests/test_live_status_aggregator.py -k "rfamb or rfnon or rfnoff"` — 3 passed.
- `ruff check` / `ruff format --check` clean.
- Live smoke with the shipped config through a real aggregator + Flask test client: `t_enr_k ≈ 917.06 K`, `t_hot_k = 307.25 + 917.06`, correct gain, and clean raw fallback with named reason on a dead thermistor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)