### PR TITLE
feat(vna_manual): one-off switch-path probes + --once mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   # >=4.2: tempctrl per-channel installed flag (set_installed command +
   # fan-out stream suppression for descoped channels).
   "picohost>=4.2",
-  "eigsep-vna>=1.3",
+  # >=1.4: measure_dut (vna_manual one-off switch-path probes).
+  "eigsep-vna>=1.4",
   "eigsep_redis>=2.3",
 ]
 

--- a/scripts/vna_manual.py
+++ b/scripts/vna_manual.py
@@ -10,6 +10,12 @@ first-order-calibrated S11 (ideal +1/-1/0 OSL — the same calibration
 ``eigsep_observing.vna_calibration.calibrate_s11`` applies on the
 dashboard).
 
+``d STATE`` (e.g. ``d VNAANT``) takes a one-off raw probe of a single
+switch path via ``cmt_vna.VNA.measure_dut`` — no OSL, saved locally
+only (the VNA stream protocol is bundle-shaped, so probes are not
+published). ``--once`` runs any one command non-interactively and
+exits, e.g. ``vna_manual.py --once d VNAANT``.
+
 Follows the bring-up contract in ``scripts/CLAUDE.md``: builds only
 the minimal VNA producer subsystem via
 :func:`eigsep_observing.vna.build_vna_subsystem`, never a
@@ -41,7 +47,9 @@ from eigsep_observing._scripts_util import (
 from eigsep_observing.utils import configure_eig_logger, get_config_path
 from eigsep_observing.vna import (
     build_vna_subsystem,
+    measure_dut,
     measure_s11,
+    save_vna_dut_h5,
     save_vna_manual_h5,
 )
 
@@ -83,6 +91,8 @@ def _print_menu(last_summary):
         print(f"Last bundle: {last_summary}")
     print("  [a] antenna bundle  (OSL + VNAANT + VNANOFF + VNANON)")
     print("  [r] receiver bundle (OSL + VNARF)")
+    print('  [d STATE] one-off probe of one switch path (e.g. "d VNAANT");')
+    print("            raw-only local .h5, no OSL, not published to Redis")
     print("  [q] quit")
 
 
@@ -113,28 +123,65 @@ def _run_bundle(subsystem, cfg, transport, mode, save_dir):
     return f"{mode} saved {path.name}  (|Γ|_{mode}_mean={db:.1f} dB)"
 
 
+def _run_dut(subsystem, cfg, transport, state, save_dir):
+    try:
+        s11, header, metadata = measure_dut(
+            subsystem.vna,
+            state,
+            cfg=cfg,
+            transport=transport,
+            metadata_snapshot=subsystem.metadata_snapshot,
+        )
+    except (RuntimeError, TimeoutError, ValueError) as exc:
+        return f"!! dut {state} probe failed: {type(exc).__name__}: {exc}"
+    try:
+        path = save_vna_dut_h5(
+            s11, header, metadata, save_dir=save_dir, state=state
+        )
+    except OSError as exc:
+        return f"!! dut {state} measured but local save failed: {exc}"
+    db = _summary_db(s11)
+    return f"dut {state} saved {path.name}  (|Γ|_mean={db:.1f} dB)"
+
+
+def _dispatch(tokens, subsystem, cfg, transport, save_dir):
+    """Run one command; ``tokens`` is the whitespace-split input.
+
+    Shared by the REPL and ``--once``: ``("a",)`` / ``("r",)`` run a
+    bundle, ``("d", "<STATE>")`` runs a one-off probe. Returns a
+    one-line summary; failures start with ``!!``, unrecognized input
+    with ``??``.
+    """
+    cmd = tokens[0].lower()
+    if cmd in ("a", "r") and len(tokens) == 1:
+        mode = "ant" if cmd == "a" else "rec"
+        return _run_bundle(subsystem, cfg, transport, mode, save_dir)
+    if cmd == "d" and len(tokens) == 2:
+        state = tokens[1].upper()
+        return _run_dut(subsystem, cfg, transport, state, save_dir)
+    return f"?? unrecognized command: {' '.join(tokens)!r}"
+
+
 def _repl(subsystem, cfg, transport, save_dir):
     last = ""
     while True:
         _print_menu(last)
         try:
-            choice = input("Select> ").strip().lower()
+            choice = input("Select> ").strip()
         except (EOFError, KeyboardInterrupt):
             print()
             return
         if choice == "":
             continue
-        if choice == "q":
+        if choice.lower() == "q":
             return
-        if choice in ("a", "r"):
-            mode = "ant" if choice == "a" else "rec"
-            try:
-                last = _run_bundle(subsystem, cfg, transport, mode, save_dir)
-            except KeyboardInterrupt:
-                last = f"!! {mode} bundle interrupted"
-            print(last)
-            continue
-        print(f"  ?? unrecognized input: {choice!r}")
+        try:
+            last = _dispatch(
+                tuple(choice.split()), subsystem, cfg, transport, save_dir
+            )
+        except KeyboardInterrupt:
+            last = f"!! {choice} interrupted"
+        print(last)
 
 
 def _parse_args():
@@ -166,6 +213,17 @@ def _parse_args():
             "obs_config.yaml, or dummy_config.yaml with --dummy."
         ),
     )
+    parser.add_argument(
+        "--once",
+        nargs="+",
+        default=None,
+        metavar="CMD",
+        help=(
+            "Run one command non-interactively and exit (non-zero on "
+            "failure). Same tokens as the REPL: 'a', 'r', or 'd STATE' "
+            "— e.g. --once d VNAANT for a one-off antenna-path probe."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -195,8 +253,20 @@ def main():
     )
     with run_tag.session(transport, "vna_manual"):
         try:
-            _print_banner(cfg, args.save_dir)
-            _repl(subsystem, cfg, transport, args.save_dir)
+            if args.once is not None:
+                line = _dispatch(
+                    tuple(args.once),
+                    subsystem,
+                    cfg,
+                    transport,
+                    args.save_dir,
+                )
+                print(line)
+                if line.startswith(("!!", "??")):
+                    raise SystemExit(1)
+            else:
+                _print_banner(cfg, args.save_dir)
+                _repl(subsystem, cfg, transport, args.save_dir)
         finally:
             subsystem.cleanup()
 

--- a/src/eigsep_observing/vna.py
+++ b/src/eigsep_observing/vna.py
@@ -264,6 +264,39 @@ def build_vna_subsystem(transport, cfg, *, source, dummy=False):
     )
 
 
+def _stamp_provenance(header, transport, cfg):
+    """Overlay Redis-side provenance onto a VNA header, in place.
+
+    The shared header block for every VNA capture: snapshot timestamp,
+    active ``run_tag``, ``obs_config`` ownership, the full ``cfg``, and
+    the IMU calibration. Absent Redis state lands as the sentinel
+    ``"UNKNOWN"`` / ``0.0`` values so headers stay schema-shaped.
+    """
+    header["metadata_snapshot_unix"] = time.time()
+    tag = run_tag.read(transport)
+    owner = obs_config_owner.read_owner(transport)
+    header["run_tag"] = (
+        tag["run_tag"] if tag["run_tag"] is not None else "UNKNOWN"
+    )
+    header["run_started_at_unix"] = (
+        tag["run_started_at_unix"]
+        if tag["run_started_at_unix"] is not None
+        else 0.0
+    )
+    header["obs_config_owner"] = (
+        owner["owner"] if owner["owner"] is not None else "UNKNOWN"
+    )
+    header["obs_config_owner_uploaded_unix"] = (
+        owner["uploaded_at_unix"]
+        if owner["uploaded_at_unix"] is not None
+        else 0.0
+    )
+    header["obs_config"] = dict(cfg)
+    cal = imu_calibration.read_calibration(transport)
+    header["imu_calibration"] = cal
+    header["imu_calibration_upload_unix"] = imu_calibration.upload_unix(cal)
+
+
 def measure_s11(
     vna,
     mode,
@@ -365,29 +398,7 @@ def measure_s11(
 
     header = vna.header
     header["mode"] = mode
-    header["metadata_snapshot_unix"] = time.time()
-    tag = run_tag.read(transport)
-    owner = obs_config_owner.read_owner(transport)
-    header["run_tag"] = (
-        tag["run_tag"] if tag["run_tag"] is not None else "UNKNOWN"
-    )
-    header["run_started_at_unix"] = (
-        tag["run_started_at_unix"]
-        if tag["run_started_at_unix"] is not None
-        else 0.0
-    )
-    header["obs_config_owner"] = (
-        owner["owner"] if owner["owner"] is not None else "UNKNOWN"
-    )
-    header["obs_config_owner_uploaded_unix"] = (
-        owner["uploaded_at_unix"]
-        if owner["uploaded_at_unix"] is not None
-        else 0.0
-    )
-    header["obs_config"] = dict(cfg)
-    cal = imu_calibration.read_calibration(transport)
-    header["imu_calibration"] = cal
-    header["imu_calibration_upload_unix"] = imu_calibration.upload_unix(cal)
+    _stamp_provenance(header, transport, cfg)
     metadata = metadata_snapshot.get()
 
     violations = _validate_vna_s11_header(header) + _validate_vna_s11_data(
@@ -403,6 +414,78 @@ def measure_s11(
     vna_writer.add(s11, header=header, metadata=metadata)
     logger.info("Vna data added to redis")
     return s11, header, metadata
+
+
+def measure_dut(vna, state, *, cfg, transport, metadata_snapshot):
+    """Run one one-off S11 probe of an arbitrary switch path.
+
+    The bring-up companion to :func:`measure_s11`: routes the RF
+    switch to ``state`` via ``cmt_vna.VNA.measure_dut`` and takes a
+    single sweep — no OSL standards and no publish on the VNA stream.
+    The stream protocol is bundle-shaped (OSL + DUT + validated
+    header), so a lone probe trace is a local artifact only; keep it
+    with :func:`save_vna_dut_h5`.
+
+    Power is whatever the VNA is currently set to
+    (``build_vna_subsystem`` applies ``vna_settings`` with the ``ant``
+    power); set ``vna.power_dBm`` first if a different level is
+    needed.
+
+    Parameters
+    ----------
+    vna : cmt_vna.VNA
+        Configured VNA instance with ``switch_fn`` already wired.
+    state : str
+        Switch path name, passed verbatim to the switch (e.g.
+        ``"VNAANT"``, ``"VNANON"``).
+    cfg : dict
+        Observing config, embedded into the header as ``obs_config``.
+    transport : eigsep_redis.Transport
+        Used to read the active ``run_tag`` for the header overlay.
+    metadata_snapshot : eigsep_redis.MetadataSnapshotReader
+        Captures the panda-side metadata at the moment of the probe.
+
+    Returns
+    -------
+    s11 : np.ndarray
+        Complex S11 sweep of the selected path.
+    header : dict
+        Instrument header plus the provenance overlays of
+        :func:`measure_s11`; ``mode`` is ``"dut:<state>"``.
+    metadata : dict
+        Panda-side metadata snapshot captured at probe time.
+
+    Raises
+    ------
+    RuntimeError
+        If ``vna`` is ``None``.
+    """
+    if vna is None:
+        raise RuntimeError(
+            "VNA not initialized. Open a VNA session first "
+            "(PandaClient.vna_open()/vna_session(), or "
+            "build_vna_subsystem)."
+        )
+    logger.info("Measuring one-off DUT S11: %s", state)
+    s11 = vna.measure_dut(state)
+    header = vna.header
+    header["mode"] = f"dut:{state}"
+    _stamp_provenance(header, transport, cfg)
+    metadata = metadata_snapshot.get()
+    return s11, header, metadata
+
+
+def _write_json_attrs(target, mapping, skip=()):
+    """Write a dict onto an h5 node's attrs, JSON-encoding nested values."""
+    for k, v in mapping.items():
+        if k in skip:
+            continue
+        if isinstance(v, (dict, list, tuple)):
+            target.attrs[k] = json.dumps(v)
+        elif isinstance(v, np.ndarray):
+            target.attrs[k] = json.dumps(v.tolist())
+        else:
+            target.attrs[k] = v
 
 
 def save_vna_manual_h5(s11, header, metadata, *, save_dir, mode):
@@ -480,23 +563,51 @@ def save_vna_manual_h5(s11, header, metadata, *, save_dir, mode):
         f.create_dataset(
             "freqs", data=np.asarray(header["freqs"], dtype=float)
         )
-        for k, v in header.items():
-            if k in {"freqs", "mode"}:
-                continue
-            if isinstance(v, (dict, list, tuple)):
-                f.attrs[k] = json.dumps(v)
-            elif isinstance(v, np.ndarray):
-                f.attrs[k] = json.dumps(v.tolist())
-            else:
-                f.attrs[k] = v
+        _write_json_attrs(f, header, skip={"freqs", "mode"})
         f.attrs["mode"] = mode
         f.attrs["vna_manual_script_version"] = "1"
-        meta_grp = f.create_group("metadata_snapshot")
-        for k, v in (metadata or {}).items():
-            if isinstance(v, (dict, list, tuple)):
-                meta_grp.attrs[k] = json.dumps(v)
-            elif isinstance(v, np.ndarray):
-                meta_grp.attrs[k] = json.dumps(v.tolist())
-            else:
-                meta_grp.attrs[k] = v
+        _write_json_attrs(f.create_group("metadata_snapshot"), metadata or {})
+    return path
+
+
+def save_vna_dut_h5(s11, header, metadata, *, save_dir, state):
+    """Write one one-off DUT probe to a local HDF5 file.
+
+    Raw-only companion to :func:`save_vna_manual_h5` for
+    :func:`measure_dut` captures: the sweep under ``/raw/<state>``,
+    the freq axis under ``/freqs``, the header on root attrs, and the
+    metadata snapshot under ``/metadata_snapshot/`` attrs. There is no
+    ``/calibrated/`` group — a probe carries no OSL standards to
+    calibrate against.
+
+    Parameters
+    ----------
+    s11 : np.ndarray
+        Complex S11 sweep from :func:`measure_dut`.
+    header : dict
+        Header from :func:`measure_dut`. Must contain ``"freqs"``.
+    metadata : dict
+        Panda metadata snapshot captured at probe time.
+    save_dir : pathlib.Path
+        Directory the file is written into. Must already exist.
+    state : str
+        Switch path name; used in the filename and dataset name.
+
+    Returns
+    -------
+    pathlib.Path
+        The path of the file that was written.
+    """
+    save_dir = Path(save_dir)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = save_dir / f"vna_dut_{state}_{stamp}.h5"
+    with h5py.File(path, "w") as f:
+        f.create_group("raw").create_dataset(state, data=np.asarray(s11))
+        f.create_dataset(
+            "freqs", data=np.asarray(header["freqs"], dtype=float)
+        )
+        _write_json_attrs(f, header, skip={"freqs", "mode"})
+        f.attrs["mode"] = header.get("mode", f"dut:{state}")
+        f.attrs["vna_manual_script_version"] = "1"
+        _write_json_attrs(f.create_group("metadata_snapshot"), metadata or {})
     return path

--- a/tests/test_vna_helper.py
+++ b/tests/test_vna_helper.py
@@ -19,7 +19,7 @@ from picohost.buses import ImuCalStore
 from eigsep_observing import obs_config_owner, run_tag
 from eigsep_observing._test_fixtures import IMU_CALIBRATION
 from eigsep_observing.keys import VNA_STREAM
-from eigsep_observing.vna import VnaWriter, measure_s11
+from eigsep_observing.vna import VnaWriter, measure_dut, measure_s11
 
 
 def _make_vna(cfg, switch_fn=lambda state: None):
@@ -397,3 +397,41 @@ def test_build_vna_subsystem_real_stops_service_on_build_failure(
         assert events == ["start", "stop"]
     finally:
         mgr.stop()
+
+
+def test_measure_dut_helper_probes_state_no_publish(transport, dummy_cfg):
+    switched = []
+    vna = _make_vna(dummy_cfg, switch_fn=switched.append)
+    _, snap = _make_sinks(transport)
+
+    s11, header, metadata = measure_dut(
+        vna,
+        "VNAAMB",
+        cfg=dummy_cfg,
+        transport=transport,
+        metadata_snapshot=snap,
+    )
+
+    assert switched == ["VNAAMB"]
+    assert np.iscomplexobj(s11)
+    assert len(s11) == dummy_cfg["vna_settings"]["npoints"]
+    assert header["mode"] == "dut:VNAAMB"
+    # same provenance overlays as measure_s11 (empty redis → sentinels)
+    assert header["run_tag"] == "UNKNOWN"
+    assert header["obs_config"] == dict(dummy_cfg)
+    assert "metadata_snapshot_unix" in header
+    assert isinstance(metadata, dict)
+    # a lone probe is a local artifact only: nothing on the VNA stream
+    assert transport.r.xlen(VNA_STREAM) == 0
+
+
+def test_measure_dut_helper_requires_initialized_vna(transport, dummy_cfg):
+    _, snap = _make_sinks(transport)
+    with pytest.raises(RuntimeError, match="VNA not initialized"):
+        measure_dut(
+            None,
+            "VNAANT",
+            cfg=dummy_cfg,
+            transport=transport,
+            metadata_snapshot=snap,
+        )

--- a/tests/test_vna_manual.py
+++ b/tests/test_vna_manual.py
@@ -5,7 +5,7 @@ import json
 import h5py
 import numpy as np
 
-from eigsep_observing.vna import save_vna_manual_h5
+from eigsep_observing.vna import save_vna_dut_h5, save_vna_manual_h5
 
 
 def _ant_payload(nfreq=8):
@@ -140,3 +140,42 @@ def test_save_vna_manual_h5_keeps_raw_when_calibration_fails(tmp_path, caplog):
         "calibration failed" in rec.getMessage().lower()
         for rec in caplog.records
     )
+
+
+def _dut_payload(nfreq=8, state="VNAAMB"):
+    """Synthesize a payload shaped like measure_dut(state) would return."""
+    rng = np.random.default_rng(2)
+    s11 = rng.standard_normal(nfreq) + 1j * rng.standard_normal(nfreq)
+    header = {
+        "mode": f"dut:{state}",
+        "freqs": np.linspace(1e6, 250e6, nfreq).tolist(),
+        "fstart": 1e6,
+        "fstop": 250e6,
+        "npoints": nfreq,
+        "ifbw": 100.0,
+        "power_dBm": 0.0,
+        "metadata_snapshot_unix": 1716304400.0,
+        "run_tag": "vna_manual_test",
+        "run_started_at_unix": 1716304200.0,
+        "obs_config": {"vna_ip": "127.0.0.1"},
+    }
+    metadata = {"rfswitch": {"sw_state_name": state}}
+    return s11, header, metadata
+
+
+def test_save_vna_dut_h5_round_trips(tmp_path):
+    s11, header, metadata = _dut_payload(state="VNAAMB")
+    path = save_vna_dut_h5(
+        s11, header, metadata, save_dir=tmp_path, state="VNAAMB"
+    )
+    assert path.name.startswith("vna_dut_VNAAMB_")
+    with h5py.File(path, "r") as f:
+        np.testing.assert_array_equal(f["raw/VNAAMB"][:], s11)
+        np.testing.assert_allclose(f["freqs"][:], header["freqs"])
+        # a probe has no OSL standards: no calibrated group
+        assert "calibrated" not in f
+        assert f.attrs["mode"] == "dut:VNAAMB"
+        assert f.attrs["run_tag"] == "vna_manual_test"
+        assert json.loads(f.attrs["obs_config"]) == header["obs_config"]
+        meta = f["metadata_snapshot"]
+        assert json.loads(meta.attrs["rfswitch"]) == metadata["rfswitch"]

--- a/uv.lock
+++ b/uv.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "eigsep-observing"
-version = "2.10.0"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },
@@ -382,14 +382,14 @@ interactive = [
 [package.metadata]
 requires-dist = [
     { name = "eigsep-redis", specifier = ">=2.3" },
-    { name = "eigsep-vna", specifier = ">=1.3" },
+    { name = "eigsep-vna", specifier = ">=1.4" },
     { name = "fakeredis", marker = "extra == 'dev'" },
     { name = "flask" },
     { name = "h5py" },
     { name = "ipython", marker = "extra == 'interactive'" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "picohost", specifier = ">=4.1" },
+    { name = "picohost", specifier = ">=4.2" },
     { name = "plotly" },
     { name = "pyserial-mock", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "eigsep-vna"
-version = "1.3.1"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -428,9 +428,9 @@ dependencies = [
     { name = "pyvisa" },
     { name = "pyvisa-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/b3/4d1c2be3c77dbe6703cdbbff8ff2590562550f9dff5fd4c0f9582d9900c5/eigsep_vna-1.3.1.tar.gz", hash = "sha256:64849a0d158617ad521b9b7c56ee26a0720d431bcea8467222cf67cc5ed7573a", size = 21523, upload-time = "2026-05-23T00:50:58.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/59/a30b8943111f903335831c10016a7329c73aad519e8ddf8f3e0df7fdd96c/eigsep_vna-1.4.0.tar.gz", hash = "sha256:dcfeefdadecf3a1fb0b6999cc4473b623de6c4032216a5248f09f2260f1070be", size = 21919, upload-time = "2026-07-08T17:00:30.765Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/74/ce95924844a3ea7bda4262f37120b12ba21e45c3b6f024ea0cff442e21b7/eigsep_vna-1.3.1-py3-none-any.whl", hash = "sha256:42f6087b1f99a812c4a9784aeac6d4bea19eb467b6ed5103852ed5fd5199ee00", size = 13673, upload-time = "2026-05-23T00:50:56.957Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e8/1f7aad61fe815f89fe819a075fd541e16615d65deba32e53943047e2f678/eigsep_vna-1.4.0-py3-none-any.whl", hash = "sha256:aee6b55554f4bffeca34b1cffc6869070efb8ad667e593cd0701099326c09bd5", size = 13864, upload-time = "2026-07-08T17:00:29.71Z" },
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eigsep-redis" },
@@ -1347,9 +1347,9 @@ dependencies = [
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pyserial" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/47/ffc02fc9d191df421372321ad5a298333889c23f1f7d42cc4f9b4fcfb032/picohost-4.1.0.tar.gz", hash = "sha256:78f87fa4a2a4400cbc4adfc60b3d4105fb0ceda7930d84d38fb6940ddd4b8ec3", size = 189324, upload-time = "2026-07-03T05:30:54.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e4/797c1638a077c4991fb62d4cf4c3edb7c58c5e6c72bdd71ca7eee89fea3c/picohost-4.2.0.tar.gz", hash = "sha256:be4583b77e4dc41d65e50691c78082e1be1820915003af1a798d1fa595908ef4", size = 193005, upload-time = "2026-07-08T16:58:50.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/52/8d76202026a90a37dcf9751195382de77a00ed6cda33e4f3873f1d3f5636/picohost-4.1.0-py3-none-any.whl", hash = "sha256:9073e191b7b871d43f32c7c3b71875f144c7faeda63040b29a96a45036317499", size = 111604, upload-time = "2026-07-03T05:30:52.97Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ec/f87ab73efed4ab529b1830a0524ff222d8acbebb54db30bd3837f7cbd67f/picohost-4.2.0-py3-none-any.whl", hash = "sha256:1afe9f9b62687edf47f8ff138dbba633733e6b1bfb358063585cf7aed82854d9", size = 113070, upload-time = "2026-07-08T16:58:49.451Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`vna_manual` can now take a **one-off raw S11 probe of any switch path** — no OSL bundle, no REPL babysitting:

```
# in the REPL
Select> d VNAANT

# or fully non-interactive
python scripts/vna_manual.py --once d VNAANT
python scripts/vna_manual.py --once a          # full antenna bundle, one shot
```

Built on `cmt_vna` 1.4.0's `VNA.measure_dut` (generic switch-path measurement).

## What changed

- **`eigsep_observing.vna.measure_dut`** — module-level bring-up protocol: route switch → one sweep → header with the same provenance overlays as `measure_s11` (`run_tag`, `obs_config` ownership, IMU cal, metadata snapshot; overlay block extracted into a shared `_stamp_provenance`). **Not published** to the VNA stream: the stream protocol is bundle-shaped (OSL + DUT + schema-validated header), so a lone probe is a local artifact only.
- **`save_vna_dut_h5`** — raw-only companion to `save_vna_manual_h5` (`/raw/<STATE>`, `/freqs`, header attrs, metadata snapshot; no `/calibrated/` group since a probe has no standards). Root-attr/metadata JSON encoding deduplicated into `_write_json_attrs`.
- **`vna_manual`**: `d STATE` menu entry; REPL and the new `--once` flag share a `_dispatch`; `--once` exits non-zero on failure for scripting. `run_tag.session` claim and `cmtvna.service` start/stop lifecycle are identical to before on both paths.
- **`eigsep-vna>=1.4`** (measure_dut) with the pin-comment convention; `uv.lock` refreshed (also picks up the already-pinned `picohost 4.2.0` that the lock was missing).

## Contract check (`scripts/CLAUDE.md`)

Still a composable bring-up tool: producer-surface-only via `build_vna_subsystem`, snapshot-stamped captures, switch driven through the PicoProxy arbiter, active-driver `run_tag` claim, no heartbeat/upload/coord-lock.

## Testing

- `measure_dut`: switch called with the state, complex sweep of `npoints`, `mode="dut:<STATE>"`, sentinel overlays on empty Redis, **nothing lands on the VNA stream**, `RuntimeError` on uninitialized VNA.
- `save_vna_dut_h5`: full round-trip (raw dataset, freqs, JSON attrs, metadata group, no calibrated group).
- Guard suites pass: `test_obs_config_uploaders` (run_tag active-driver enforcement) and `test_record_vna`. 29 tests total on the touched surface; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)