### PR TITLE
feat(live_status): raise raw corr mag y-range floor to 1e1

### DIFF
--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -250,8 +250,8 @@ const corrXaxis = {
   nticks: 8,
 };
 
-// Plotly log axes take ranges in log10. [-2, 9] mirrors the legacy
-// live_plotter ylim of (1e-2, 1e9); fixed range avoids autoscale jitter.
+// Plotly log axes take ranges in log10. [1, 9] spans 1e1–1e9, keeping
+// raw counts well in view; fixed range avoids autoscale jitter.
 // ``exponentformat: "e"`` renders ticks as 1e6 / 1e9 (matplotlib-style)
 // rather than plotly's default SI suffixes (1M / 1G / 1B).
 // Calibrated mode swaps to a linear y-axis in Kelvin and lets plotly
@@ -263,7 +263,7 @@ const magLayoutRaw = {
   yaxis: {
     title: "Amplitude [arb. units]",
     type: "log",
-    range: [-2, 9],
+    range: [1, 9],
     exponentformat: "e",
   },
   showlegend: true,


### PR DESCRIPTION
## Summary
- Pin the live-status raw corr magnitude plot's fixed log y-range to `[1, 9]` (1e1–1e9) instead of `[-2, 9]` (1e-2–1e9), which mirrored the legacy `live_plotter` ylim and wasted three empty decades below any real raw corr counts.
- Update the adjacent comment that documented the legacy range.

## Test plan
- No test surface: the range is a JS layout constant in `dashboard.js` with no test coverage referencing it (verified by grep).
- Visual check: load the dashboard, confirm the raw mag plot y-axis spans 1e1–1e9 and traces/linear-range bounds render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)