### PR TITLE
feat(motor): per-axis home — 'a'/'e' keys; az single pot-referenced correction + divergence guard

### DIFF
--- a/scripts/motor_home.py
+++ b/scripts/motor_home.py
@@ -57,7 +57,12 @@ def run(transport, *, dry_run=False, override_limits=False):
 
 
 def main():
-    p = ArgumentParser(description="Closed-loop return-to-home")
+    p = ArgumentParser(
+        description=(
+            "Return-to-home (az: single pot-referenced correction; "
+            "el: closed-loop)"
+        )
+    )
     p.add_argument("--dummy", action="store_true")
     p.add_argument(
         "--dry-run",

--- a/scripts/motor_home.py
+++ b/scripts/motor_home.py
@@ -1,11 +1,12 @@
-"""Closed-loop return-to-home. Standalone active driver (claims run_tag);
-talks to hardware only via MotorClient/PicoProxy; requires pico-manager.
+"""Return-to-home (az: single pot-referenced correction; el: closed-loop).
+Standalone active driver (claims run_tag); talks to hardware only via
+MotorClient/PicoProxy; requires pico-manager.
 
 Drives the antenna to the cal-defined home — az where the calibrated pot
-reads 0° (v_home = -b/m from PotCalStore), el at IMU-level — using
-pot-voltage (az) + IMU (el) feedback, settling between moves. Re-zeros the
-step counter on convergence. Run after a motor_scan / motor_manual session
-to re-establish a known position.
+reads 0° (v_home = -b/m from PotCalStore), el at IMU-level — az takes one
+guarded corrective jog off a noise-averaged pot read; el converges
+closed-loop on the IMU. Re-zeros each axis' step counter on success. Run
+after a motor_scan / motor_manual session to re-establish a known position.
 """
 
 import logging
@@ -40,7 +41,8 @@ def run(transport, *, dry_run=False, override_limits=False):
         raise SystemExit(str(exc))
     require_pico(homer.motor_client._proxy)
     if dry_run:
-        pot_v, el_est = homer._read_sensors()
+        pot_v = homer._read_pot_once()
+        el_est = homer._read_el()
         logger.info(
             "Dry run: pot=%s V (home %.3f), el=%s (%s)",
             pot_v,

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -10,9 +10,10 @@ physical position as ``(0, 0)``.
 Zeroing here defines a *scan origin* (an arbitrary lab/scan pattern
 reference), which is distinct from *home*: home is defined by the pot
 calibration (az where the calibrated pot reads 0°, el at IMU-level)
-and is not operator-adjustable — 'h' drives there via the closed-loop
-homer and re-trues the step counters on convergence. Use field_zero
-for the guided home-and-zero flow.
+and is not operator-adjustable — 'h' drives there via the homer (az:
+one pot-referenced corrective jog under the divergence guard; el:
+closed-loop convergence) and re-trues the step counters on success. Use
+field_zero for the guided home-and-zero flow.
 
 Controls:
     u / d  - jog elevation up / down
@@ -89,8 +90,13 @@ def _render(screen, zeroer, deg):
 
 
 def _build_zeroer(transport, args):
-    """Build a ``MotorZeroer``, honouring ``args.override_limits``."""
-    return MotorZeroer(transport, enforce_limits=not args.override_limits)
+    """Build a ``MotorZeroer``, honouring ``args.override_limits`` and
+    ``args.az_step0_fallback``."""
+    return MotorZeroer(
+        transport,
+        enforce_limits=not args.override_limits,
+        az_step0_fallback=args.az_step0_fallback,
+    )
 
 
 def _curses_main(screen, transport, args):
@@ -145,6 +151,15 @@ def _parse_args():
         help=(
             "Disable travel limits for this session"
             " (recovery from out-of-window)."
+        ),
+    )
+    parser.add_argument(
+        "--az-step0-fallback",
+        action="store_true",
+        help=(
+            "If the potmon is not publishing, still park az at step 0"
+            " open-loop when homing (default: skip az — home is"
+            " pot-referenced and the pot fence is inert without it)."
         ),
     )
     return parser.parse_args()

--- a/scripts/motor_manual.py
+++ b/scripts/motor_manual.py
@@ -18,8 +18,12 @@ Controls:
     u / d  - jog elevation up / down
     l / r  - jog azimuth left / right
     + / -  - increase / decrease jog step size
-    h      - go home: pot 0 deg az, IMU-level el (any key cancels;
-             requires a pot calibration)
+    h      - go home on both axes: pot 0 deg az, IMU-level el (any key
+             cancels; requires a pot calibration)
+    a      - go home in azimuth only (pot 0 deg; el never moves and
+             keeps its step counter)
+    e      - go home in elevation only (IMU-level; az never moves and
+             keeps its step counter; needs no pot calibration)
     Enter  - arm zero confirmation (scan origin at current pose)
     y      - confirm and zero (after Enter); any other key cancels
     q      - quit without zeroing
@@ -56,15 +60,21 @@ def _render(screen, zeroer, deg):
         screen.addstr(3, 0, "AZ pos: DISCONNECTED (waiting for reconnect)")
         screen.addstr(4, 0, "EL pos: ---")
     screen.addstr(6, 0, "u/d = jog EL | l/r = jog AZ")
-    screen.addstr(7, 0, "+/- = change step size | h = go home (pot 0 / level)")
+    screen.addstr(7, 0, "+/- = change step size")
     screen.addstr(
-        8, 0, "Enter = zero scan origin (asks to confirm) | q = quit"
+        8,
+        0,
+        "h = home both | a = home AZ | e = home EL (pot 0 / level)",
+    )
+    screen.addstr(
+        9, 0, "Enter = zero scan origin (asks to confirm) | q = quit"
     )
     if zeroer.is_homing:
+        axes = "+".join(a.upper() for a in zeroer.homing_axes)
         screen.addstr(
             10,
             0,
-            ">>> HOMING to cal home... press any key to cancel <<<",
+            f">>> HOMING {axes} to cal home... press any key to cancel <<<",
         )
     elif zeroer.pending_zero:
         screen.addstr(

--- a/src/eigsep_observing/client.py
+++ b/src/eigsep_observing/client.py
@@ -1017,11 +1017,30 @@ class PandaClient:
                             result = self.motor_homer.home(
                                 stop_event=self.stop_client
                             )
-                            if not result.converged and not result.degraded:
+                            if result.degraded:
+                                self._warn_with_status(
+                                    "Post-scan homing degraded (sensor "
+                                    "unavailable); affected axis skipped "
+                                    "or parked unverified."
+                                )
+                            elif not result.converged:
                                 self._warn_with_status(
                                     "Post-scan homing did not converge; "
                                     "motors left parked."
                                 )
+                        except MotorLimitError as guard_exc:
+                            # The divergence guard / sensor fence halted
+                            # a move heading the wrong way — step
+                            # counter or cal is suspect, so do NOT
+                            # re-drive open-loop (that is the exact
+                            # dangerous move); the scan's completion
+                            # park already ran, az stays halted where
+                            # the guard stopped it.
+                            self._warn_with_status(
+                                f"Post-scan homing halted by travel "
+                                f"guard ({guard_exc}); az left halted, "
+                                "no re-park."
+                            )
                         except _MOTOR_LOOP_ERRORS as homer_exc:
                             self._warn_with_status(
                                 f"Post-scan homing failed "

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -35,6 +35,18 @@ class MotorLimitError(ValueError):
     axis outside its configured safe-travel window."""
 
 
+def validate_axes(axes):
+    """Return ``axes`` as a tuple, or raise ``ValueError`` unless it is a
+    non-empty subset of ``("az", "el")``. Shared by the per-axis ``home``
+    entry points (:meth:`MotorClient.home`, ``MotorHomer.home``)."""
+    axes = tuple(axes)
+    if not axes or any(a not in ("az", "el") for a in axes):
+        raise ValueError(
+            f"axes must be a non-empty subset of ('az', 'el'); got {axes!r}"
+        )
+    return axes
+
+
 class MotorClient:
     """Drive the motor pico through ``PicoManager`` via Redis.
 
@@ -196,8 +208,12 @@ class MotorClient:
 
     def reset_step_position(self, az_step=0, el_step=0):
         """Define the current physical pose as the given step counts
-        (default origin). No motion — intentionally bypasses the travel
-        guard; used by MotorHomer to re-zero the count at converged home."""
+        (default origin). ``None`` for either axis leaves that axis'
+        counter untouched (``picohost.PicoMotor.reset_step_position``
+        omits a ``None`` axis from the firmware command) — that is how a
+        single-axis home re-zeros only its own counter. No motion —
+        intentionally bypasses the travel guard; used by MotorHomer to
+        re-zero the count at converged home."""
         self._proxy.send_command(
             "reset_step_position", az_step=az_step, el_step=el_step
         )
@@ -514,32 +530,43 @@ class MotorClient:
                 target_deg=target_deg,
             )
 
-    def home(self, stop_event=None):
-        """Drive both axes to step position 0, one at a time.
+    def home(self, stop_event=None, axes=("az", "el")):
+        """Drive the requested axes to step position 0, one at a time.
 
-        Only one motor moves at once: az homes first, then el. Running
-        both simultaneously is a mechanical-safety hazard on the rig
-        and matches the historical ``picohost`` script behavior.
+        Only one motor moves at once: az homes first, then el (when
+        both are requested). Running both simultaneously is a
+        mechanical-safety hazard on the rig and matches the historical
+        ``picohost`` script behavior.
 
-        ``stop_event`` (optional) enables cooperative cancellation: a
-        set event halts the in-flight axis and skips the next one, so a
-        background home (``motor_manual.py``) can be aborted mid-move.
+        Parameters
+        ----------
+        stop_event : threading.Event or None
+            Cooperative cancellation: a set event halts the in-flight
+            axis and skips any remaining one, so a background home
+            (``motor_manual.py``) can be aborted mid-move.
+        axes : tuple of str
+            Axes to home, a non-empty subset of ``("az", "el")``
+            (default both). The drive order is always az before el
+            regardless of the order given here.
+
+        Raises
+        ------
+        ValueError
+            If ``axes`` is empty or names an unknown axis.
         """
+        axes = validate_axes(axes)
         self._await_initial_status()
-        self._send_and_wait(
-            "az_target_steps",
-            label="home az",
-            target_steps=0,
-            stop_event=stop_event,
-        )
-        if stop_event is not None and stop_event.is_set():
-            return
-        self._send_and_wait(
-            "el_target_steps",
-            label="home el",
-            target_steps=0,
-            stop_event=stop_event,
-        )
+        for axis in ("az", "el"):
+            if axis not in axes:
+                continue
+            if stop_event is not None and stop_event.is_set():
+                return
+            self._send_and_wait(
+                f"{axis}_target_steps",
+                label=f"home {axis}",
+                target_steps=0,
+                stop_event=stop_event,
+            )
 
     def jog_az(self, delta_deg, *, stop_event=None):
         """Jog az by ``delta_deg`` degrees, blocking until the move stops.

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -275,7 +275,9 @@ class MotorClient:
                     return
             time.sleep(self.poll_interval_s)
 
-    def _wait_for_stop(self, timeout=None, stop_event=None, axis=None):
+    def _wait_for_stop(
+        self, timeout=None, stop_event=None, axis=None, guard=None
+    ):
         """Block until the motor's position equals its target on both axes.
 
         Mirrors the progress-reset stall detection in
@@ -293,6 +295,14 @@ class MotorClient:
         iteration. A breach calls :meth:`halt` and re-raises
         :class:`MotorLimitError` immediately, aborting the move
         mid-flight.
+
+        If ``guard`` is supplied it is polled once per iteration,
+        right after the sensor fence and with the same contract: a
+        :class:`MotorLimitError` raised by it calls :meth:`halt` and
+        re-raises, aborting the move mid-flight. Like the fence, the
+        guard is not polled during the start window
+        (:meth:`_wait_for_start`), so pre-poll exposure is bounded by
+        ``start_timeout_s``.
         """
         timeout = self.stall_timeout_s if timeout is None else timeout
         t = time.monotonic()
@@ -304,6 +314,12 @@ class MotorClient:
             if axis is not None:
                 try:
                     self._check_sensor_fence(axis)
+                except MotorLimitError:
+                    self.halt()
+                    raise
+            if guard is not None:
+                try:
+                    guard()
                 except MotorLimitError:
                     self.halt()
                     raise
@@ -350,7 +366,14 @@ class MotorClient:
         )
 
     def _send_and_wait(
-        self, action, *, label, timeout=None, stop_event=None, **kwargs
+        self,
+        action,
+        *,
+        label,
+        timeout=None,
+        stop_event=None,
+        guard=None,
+        **kwargs,
     ):
         """Send a single move command and block until the motor stops.
 
@@ -367,6 +390,7 @@ class MotorClient:
         stale at-rest snapshot read immediately after the send would let
         the next axis command fire mid-move (the home double-move bug).
         ``stop_event`` is forwarded to both for cooperative cancellation.
+        ``guard`` is forwarded to :meth:`_wait_for_stop`.
         """
         axis = (
             "az"
@@ -385,7 +409,7 @@ class MotorClient:
                 self.halt()
                 return
             self._wait_for_stop(
-                timeout=timeout, stop_event=stop_event, axis=axis
+                timeout=timeout, stop_event=stop_event, axis=axis, guard=guard
             )
 
     def _axis_target(self, axis):
@@ -530,7 +554,7 @@ class MotorClient:
                 target_deg=target_deg,
             )
 
-    def home(self, stop_event=None, axes=("az", "el")):
+    def home(self, stop_event=None, axes=("az", "el"), guard=None):
         """Drive the requested axes to step position 0, one at a time.
 
         Only one motor moves at once: az homes first, then el (when
@@ -548,6 +572,11 @@ class MotorClient:
             Axes to home, a non-empty subset of ``("az", "el")``
             (default both). The drive order is always az before el
             regardless of the order given here.
+        guard : callable or None
+            Optional zero-arg callable polled during the move; applies
+            to every axis move in the call, so callers wanting a
+            single-axis guard pass a single-axis ``axes``. See
+            :meth:`_wait_for_stop`.
 
         Raises
         ------
@@ -566,9 +595,10 @@ class MotorClient:
                 label=f"home {axis}",
                 target_steps=0,
                 stop_event=stop_event,
+                guard=guard,
             )
 
-    def jog_az(self, delta_deg, *, stop_event=None):
+    def jog_az(self, delta_deg, *, stop_event=None, guard=None):
         """Jog az by ``delta_deg`` degrees, blocking until the move stops.
 
         Relative to the current az target. Routes through
@@ -577,22 +607,24 @@ class MotorClient:
         returns cannot overlap it. Backs the interactive jogger in
         :class:`~eigsep_observing.motor_zeroer.MotorZeroer` — blocking is
         what enforces one-motor-at-a-time there.
+        ``guard`` — see :meth:`_wait_for_stop`.
         """
-        self._jog("az_move_deg", delta_deg, stop_event=stop_event)
+        self._jog("az_move_deg", delta_deg, stop_event=stop_event, guard=guard)
 
-    def jog_el(self, delta_deg, *, stop_event=None):
+    def jog_el(self, delta_deg, *, stop_event=None, guard=None):
         """Jog el by ``delta_deg`` degrees, blocking until the move stops.
 
         See :meth:`jog_az`.
         """
-        self._jog("el_move_deg", delta_deg, stop_event=stop_event)
+        self._jog("el_move_deg", delta_deg, stop_event=stop_event, guard=guard)
 
-    def _jog(self, action, delta_deg, *, stop_event=None):
+    def _jog(self, action, delta_deg, *, stop_event=None, guard=None):
         self._send_and_wait(
             action,
             label=action,
             delta_deg=float(delta_deg),
             stop_event=stop_event,
+            guard=guard,
         )
 
     def scan(

--- a/src/eigsep_observing/motor_client.py
+++ b/src/eigsep_observing/motor_client.py
@@ -482,7 +482,7 @@ class MotorClient:
             pot_v = None
         # IMU cross-check warning suppressed on the high-frequency fence
         # path (~10 Hz inside _wait_for_stop); the homer's settle-cadence
-        # read (MotorHomer._read_sensors) and the live-status dashboard
+        # read (MotorHomer._read_el) and the live-status dashboard
         # surface IMU disagreement at a sane rate.
         el = read_el_estimate(self._reader, logger=None).el_deg
         return pot_v, el

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -22,7 +22,7 @@ from eigsep_redis import MetadataSnapshotReader
 from picohost.buses import PotCalStore
 
 from .el_sensor import read_el_estimate
-from .motor_client import MotorClient, validate_axes
+from .motor_client import MotorClient, MotorLimitError, validate_axes
 from .motor_limits import read_motor_limits
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,60 @@ class HomeResult:
     residual_el_deg: Optional[float]
     degraded: bool
     reset_count: bool
+
+
+class _AzDivergenceGuard:
+    """Halt an az move that is driving the pot away from home.
+
+    Instances are the zero-arg ``guard`` callables polled by
+    :meth:`MotorClient._wait_for_stop` at fence cadence during a
+    move. The guard tracks the closest approach ``|v - v_home|``
+    seen so far; once the current distance exceeds that minimum by
+    more than ``diverge_deg`` (converted through the cal slope
+    magnitude) it raises :class:`MotorLimitError`, which halts the
+    motor mid-flight. This catches a wrong step counter (post-reboot)
+    or a wrong-signed cal long before the ±limit fence would, and the
+    min-so-far form also stops a move that reaches home and keeps
+    going. Missing pot samples are skipped — the guard only acts on
+    live readings, matching the sensor fence's convention (so it is
+    inert exactly when the pot fence is inert).
+
+    Parameters
+    ----------
+    read_pot : callable
+        Zero-arg callable returning the current pot voltage or
+        ``None`` when unavailable.
+    v_home : float
+        Az home target voltage.
+    slope_deg_per_volt : float
+        Signed cal slope; only its magnitude is used here.
+    diverge_deg : float
+        Allowed growth of ``|v - v_home|`` past the closest approach,
+        in degrees, before the move is halted.
+    """
+
+    def __init__(self, read_pot, v_home, slope_deg_per_volt, diverge_deg):
+        self._read_pot = read_pot
+        self._v_home = v_home
+        self._deg_per_volt = abs(slope_deg_per_volt)
+        self._diverge_deg = diverge_deg
+        self._min_dist_deg = None
+
+    def __call__(self):
+        v = self._read_pot()
+        if v is None:
+            return
+        dist_deg = abs(v - self._v_home) * self._deg_per_volt
+        if self._min_dist_deg is None or dist_deg < self._min_dist_deg:
+            self._min_dist_deg = dist_deg
+            return
+        if dist_deg - self._min_dist_deg > self._diverge_deg:
+            raise MotorLimitError(
+                f"az move diverging from pot home: |pot - home| grew "
+                f"to {dist_deg:.1f} deg from a closest approach of "
+                f"{self._min_dist_deg:.1f} deg "
+                f"(> {self._diverge_deg:.1f} deg allowance); halting."
+            )
 
 
 class MotorHomer:

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -28,6 +28,9 @@ from .motor_limits import read_motor_limits
 logger = logging.getLogger(__name__)
 
 _AZ_GAIN_FALLBACK_DEG_PER_VOLT = 90.0
+# Matches the pico metadata producer cadence (~200 ms) so consecutive
+# integrated-read samples are distinct snapshot frames, not rereads.
+_POT_SAMPLE_INTERVAL_S = 0.2
 
 
 @dataclass
@@ -114,12 +117,30 @@ class MotorHomer:
         Seconds to wait after a jog before re-reading sensors
         (default 10.0).
     damping : float
-        Fraction of the residual applied per corrective jog (default 0.5).
+        Fraction of the residual applied per corrective jog
+        (el loop only; default 0.5).
     max_iters : int
-        Maximum correction iterations before giving up (default 6).
+        Maximum correction iterations before giving up
+        (el loop only; default 6).
+    az_integrate_s : float
+        Seconds of pot samples averaged per az reading (default 2.0,
+        ~10 samples at the 200 ms producer cadence) to beat down pot
+        noise before deciding on the single corrective jog.
+    az_diverge_deg : float
+        Allowed growth of the pot's distance from home past its
+        closest approach during an az move before the divergence
+        guard halts the motor (default 20.0 — above the known ~7°
+        1/rev pot nonlinearity; hardware tuning expected).
+    az_step0_fallback : bool
+        When the potmon is not publishing, ``True`` parks az at step
+        0 open-loop (position unverified, ``degraded``); ``False``
+        (default) skips az motion entirely — with the pot dead the
+        pot-voltage fence is inert too, so a blind move is the
+        dangerous case and must be opted into.
     az_gain_deg_per_volt : float or None
-        Override for the az pot gain (deg/V).  When ``None`` the gain
-        is read from ``PotCalStore`` (``abs(slope)``), with a fallback
+        Signed override for the az pot slope (deg/V); the sign sets
+        the corrective-jog direction.  When ``None`` the slope
+        is read from ``PotCalStore``, with a fallback
         of ``_AZ_GAIN_FALLBACK_DEG_PER_VOLT`` (90.0) when the store is
         empty or unreachable.
     reset_count : bool
@@ -143,6 +164,9 @@ class MotorHomer:
         settle_s=10.0,
         damping=0.5,
         max_iters=6,
+        az_integrate_s=2.0,
+        az_diverge_deg=20.0,
+        az_step0_fallback=False,
         az_gain_deg_per_volt=None,
         reset_count=True,
         enforce_limits=True,
@@ -160,6 +184,9 @@ class MotorHomer:
         self.settle_s = settle_s
         self.damping = damping
         self.max_iters = max_iters
+        self.az_integrate_s = az_integrate_s
+        self.az_diverge_deg = az_diverge_deg
+        self.az_step0_fallback = az_step0_fallback
         self.az_gain_deg_per_volt = az_gain_deg_per_volt
         self.reset_count = reset_count
         self.logger = logger
@@ -222,28 +249,33 @@ class MotorHomer:
                 "re-run calibrate-pot."
             )
 
-    def _az_gain(self):
-        """Deg/volt magnitude for the az potentiometer.
+    def _az_slope(self):
+        """Signed slope (deg/V) of the az potentiometer cal.
 
-        Priority: constructor override → PotCalStore abs(slope) →
-        ``_AZ_GAIN_FALLBACK_DEG_PER_VOLT`` (90.0).
+        Priority: constructor override -> PotCalStore slope ->
+        ``_AZ_GAIN_FALLBACK_DEG_PER_VOLT`` (+90.0). The sign is
+        load-bearing: the single corrective jog has no trial-and-error
+        sign detection, so direction comes entirely from the cal's
+        sign convention (cal angle is fit against motor az degrees,
+        so ``m * dV`` is already a motor-frame jog).
         """
         if self.az_gain_deg_per_volt is not None:
-            return abs(self.az_gain_deg_per_volt)
+            return float(self.az_gain_deg_per_volt)
         cal = self._pot_cal()
         if cal is not None:
-            return abs(cal[0])
+            return cal[0]
         self.logger.warning(
-            "No pot calibration for az gain; using fallback %.1f deg/V",
+            "No pot calibration for az slope; using fallback %.1f deg/V",
             _AZ_GAIN_FALLBACK_DEG_PER_VOLT,
         )
         return _AZ_GAIN_FALLBACK_DEG_PER_VOLT
 
     def _az_residual_deg(self, v_home, pot_v):
-        """Degrees to jog so the pot returns to its home voltage.
+        """Signed degrees to jog so the pot returns to its home voltage.
 
-        The sign convention: positive residual → need to jog positive az.
-        Returns ``None`` when no pot reading is available.
+        ``m * (v_home - pot_v)``, where ``m`` is the signed cal slope
+        — positive residual means jog positive az. Returns ``None``
+        when no pot reading is available.
 
         Parameters
         ----------
@@ -255,7 +287,7 @@ class MotorHomer:
         if pot_v is None:
             return None
         dv = v_home - pot_v
-        return dv * self._az_gain()
+        return dv * self._az_slope()
 
     def _el_residual(self, el_est):
         """Elevation residual in degrees and whether it is magnitude-only.
@@ -302,19 +334,50 @@ class MotorHomer:
     # Task C5: sensor read, settle, and converge loop
     # ------------------------------------------------------------------
 
-    def _read_sensors(self):
-        """Return ``(pot_v, el_est)`` from the snapshot reader.
-
-        ``pot_v`` is the current az pot voltage (``None`` if absent or
-        on exception).  ``el_est`` is an :class:`~.el_sensor.ElEstimate`
-        from the two IMU streams (``el_deg=None`` when both are absent).
-        """
+    def _read_pot_once(self):
+        """Current ``pot_az_voltage`` from the snapshot, or ``None``
+        when absent or on a reader error. Single sample — the guard's
+        per-poll read; see :meth:`_read_pot_integrated` for the
+        noise-averaged version."""
         try:
-            pot_v = (self.snapshot.get("potmon") or {}).get("pot_az_voltage")
+            return (self.snapshot.get("potmon") or {}).get("pot_az_voltage")
         except Exception:
-            pot_v = None
-        el_est = read_el_estimate(self.snapshot, logger=self.logger)
-        return pot_v, el_est
+            return None
+
+    def _read_pot_integrated(self, stop_event=None):
+        """Mean pot voltage over ``az_integrate_s`` seconds of samples.
+
+        Samples :meth:`_read_pot_once` at the producer cadence
+        (``_POT_SAMPLE_INTERVAL_S``); dropped samples (``None``) are
+        skipped. Returns ``None`` when no sample arrived at all. A
+        set ``stop_event`` ends the window early with whatever was
+        collected.
+        """
+        n = max(1, int(round(self.az_integrate_s / _POT_SAMPLE_INTERVAL_S)))
+        samples = []
+        for i in range(n):
+            v = self._read_pot_once()
+            if v is not None:
+                samples.append(float(v))
+            if i + 1 < n:
+                if stop_event is not None:
+                    if stop_event.wait(_POT_SAMPLE_INTERVAL_S):
+                        break
+                else:
+                    time.sleep(_POT_SAMPLE_INTERVAL_S)
+        if not samples:
+            return None
+        return sum(samples) / len(samples)
+
+    def _read_el(self):
+        """Current :class:`~.el_sensor.ElEstimate` from the IMU
+        streams (``el_deg=None`` when both are absent)."""
+        return read_el_estimate(self.snapshot, logger=self.logger)
+
+    def _read_sensors(self):
+        """(pot_v, el_est) — legacy combined read; removal pending the
+        per-axis home() split."""
+        return self._read_pot_once(), self._read_el()
 
     def _settle(self, stop_event):
         """Wait ``settle_s`` seconds; uses ``stop_event.wait`` when present."""

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -22,7 +22,7 @@ from eigsep_redis import MetadataSnapshotReader
 from picohost.buses import PotCalStore
 
 from .el_sensor import read_el_estimate
-from .motor_client import MotorClient
+from .motor_client import MotorClient, validate_axes
 from .motor_limits import read_motor_limits
 
 logger = logging.getLogger(__name__)
@@ -269,51 +269,72 @@ class MotorHomer:
         elif self.settle_s:
             time.sleep(self.settle_s)
 
-    def home(self, stop_event=None):
+    def home(self, stop_event=None, axes=("az", "el")):
         """Drive the motor to the cal-defined home (pot 0°, IMU-level el).
 
         Parameters
         ----------
         stop_event : threading.Event or None
             When set, the loop exits at the next interruptible point.
+        axes : tuple of str
+            Axes to home, a non-empty subset of ``("az", "el")``
+            (default both). An axis not requested is never moved, its
+            residual in the result is ``None``, and its step counter is
+            preserved on the convergence re-zero. An el-only home needs
+            no pot calibration — the cal requirement is purely an az
+            concern.
 
         Returns
         -------
         HomeResult
-            ``converged`` is ``True`` when both residuals are within
-            tolerance; ``degraded`` is ``True`` when sensors were
-            unavailable and open-loop fall-back was used.
+            ``converged`` is ``True`` when every requested axis'
+            residual is within tolerance; ``degraded`` is ``True`` when
+            the requested axes' sensors were unavailable and open-loop
+            fall-back was used.
 
         Raises
         ------
         RuntimeError
-            When no pot calibration is stored, or when the cal's
-            zero-angle voltage falls outside the configured pot limit
-            window (broken cal — refuse before moving).
+            When az is requested and no pot calibration is stored, or
+            when the cal's zero-angle voltage falls outside the
+            configured pot limit window (broken cal — refuse before
+            moving).
+        ValueError
+            If ``axes`` is empty or names an unknown axis.
         """
-        v_home = self.az_home_voltage()
-        self._check_home_in_window(v_home)
+        axes = validate_axes(axes)
+        do_az = "az" in axes
+        do_el = "el" in axes
+        v_home = None
+        if do_az:
+            v_home = self.az_home_voltage()
+            self._check_home_in_window(v_home)
 
         pot_v, el_est = self._read_sensors()
-        if pot_v is None and el_est.el_deg is None:
+        has_feedback = (do_az and pot_v is not None) or (
+            do_el and el_est.el_deg is not None
+        )
+        if not has_feedback:
             self.logger.warning(
                 "Homing sensors unavailable; falling back to open-loop "
                 "home() — position will not be verified."
             )
-            self.motor_client.home(stop_event=stop_event)
+            self.motor_client.home(stop_event=stop_event, axes=axes)
             return HomeResult(
                 False,
                 0,
-                float("nan"),
-                float("nan"),
+                float("nan") if do_az else None,
+                float("nan") if do_el else None,
                 degraded=True,
                 reset_count=False,
             )
 
-        self.motor_client.home(stop_event=stop_event)  # coarse approach
+        # coarse approach
+        self.motor_client.home(stop_event=stop_event, axes=axes)
         az_sign, el_sign = 1.0, 1.0
         last_az = last_el = None
-        res_az = res_el = float("nan")
+        res_az = float("nan") if do_az else None
+        res_el = float("nan") if do_el else None
         converged = False
         i = 0
         for i in range(1, self.max_iters + 1):
@@ -321,8 +342,10 @@ class MotorHomer:
                 break
             self._settle(stop_event)
             pot_v, el_est = self._read_sensors()
-            res_az = self._az_residual_deg(v_home, pot_v)
-            res_el, _ = self._el_residual(el_est)
+            res_az = self._az_residual_deg(v_home, pot_v) if do_az else None
+            res_el = self._el_residual(el_est)[0] if do_el else None
+            # An unrequested axis' residual is None by construction, so
+            # this still means "every requested axis lost feedback".
             if res_az is None and res_el is None:
                 self.logger.warning(
                     "Homing lost all sensor feedback mid-loop; aborting "
@@ -361,7 +384,12 @@ class MotorHomer:
 
         did_reset = False
         if converged and self.reset_count:
-            self.motor_client.reset_step_position(az_step=0, el_step=0)
+            # None preserves the unrequested axis' counter (firmware
+            # omits a None axis from the reset command).
+            self.motor_client.reset_step_position(
+                az_step=0 if do_az else None,
+                el_step=0 if do_el else None,
+            )
             did_reset = True
         if not converged:
             self.logger.warning(

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -320,24 +320,6 @@ class MotorHomer:
             return el_est.el_deg, True
         return -el_est.el_deg, False
 
-    def _within_tol(self, res_az, res_el):
-        """True when both residuals are within their configured tolerances.
-
-        A ``None`` residual (sensor absent) is treated as "within
-        tolerance" so a missing sensor does not block convergence on the
-        axis that is present.
-
-        Parameters
-        ----------
-        res_az : float or None
-            Azimuth residual in degrees (from ``_az_residual_deg``).
-        res_el : float or None
-            Elevation residual in degrees (from ``_el_residual``).
-        """
-        ok_az = res_az is None or abs(res_az) <= self.tol_az_deg
-        ok_el = res_el is None or abs(res_el) <= self.tol_el_deg
-        return ok_az and ok_el
-
     def _read_pot_once(self):
         """Current ``pot_az_voltage`` from the snapshot, or ``None``
         when absent or on a reader error. Single sample — the guard's

--- a/src/eigsep_observing/motor_homer.py
+++ b/src/eigsep_observing/motor_homer.py
@@ -1,16 +1,24 @@
-"""Closed-loop return-to-home for the motor.
+"""Return-to-home for the motor, per axis.
 
-Sibling of MotorZeroer. Home is defined by the pot calibration, not by a
-recorded pose: az home is the voltage where the calibrated pot reads 0°
-(``v_home = -b/m`` from ``PotCalStore``), el home is IMU-level (0°). home()
-runs a coarse-approach → settle → measure → damped-corrective-jog loop
-through MotorClient (inheriting the travel-limit guard) until the pot
-voltage and IMU elevation are within tolerance of those targets, then
-re-zeros the step counter. Az feedback is raw pot voltage; el feedback is
-the redundant imu_el-signed / imu_az-|θ| estimate. Because the targets are
-derived live from the cal, a recalibration (``calibrate-pot``, including
-``--mode rezero``) moves home for every consumer on the next home() call —
-there is no intermediate home-reference K/V to refresh.
+Sibling of MotorZeroer. Home is defined by the pot calibration, not by
+a recorded pose: az home is the voltage where the calibrated pot reads
+0° (``v_home = -b/m`` from ``PotCalStore``), el home is IMU-level (0°).
+
+The two axes deliberately home differently. **Az** is referenced by the
+potmon and takes a coarse open-loop approach to step 0 followed by at
+most ONE corrective jog of the full signed residual, computed from a
+noise-averaged pot read — no convergence loop, because closed-looping
+onto the pot's wander at tolerance scale just hunts sensor noise. Every
+az move runs under a divergence guard that halts the motor if the pot
+is moving *away* from home (wrong step counter or wrong-signed cal).
+**El** keeps the coarse-approach → settle → measure →
+damped-corrective-jog convergence loop against the redundant
+imu_el-signed / imu_az-|θ| estimate. Both paths go through MotorClient
+(inheriting the travel-limit guard) and re-zero their own axis' step
+counter on success. Because the targets are derived live from the cal,
+a recalibration (``calibrate-pot``, including ``--mode rezero``) moves
+home for every consumer on the next home() call — there is no
+intermediate home-reference K/V to refresh.
 """
 
 import logging
@@ -192,7 +200,7 @@ class MotorHomer:
         self.logger = logger
 
     # ------------------------------------------------------------------
-    # Pure helpers (also called by Task C5's home() loop)
+    # Pure helpers (shared by both axis paths)
     # ------------------------------------------------------------------
 
     def _pot_cal(self):
@@ -330,10 +338,6 @@ class MotorHomer:
         ok_el = res_el is None or abs(res_el) <= self.tol_el_deg
         return ok_az and ok_el
 
-    # ------------------------------------------------------------------
-    # Task C5: sensor read, settle, and converge loop
-    # ------------------------------------------------------------------
-
     def _read_pot_once(self):
         """Current ``pot_az_voltage`` from the snapshot, or ``None``
         when absent or on a reader error. Single sample — the guard's
@@ -374,11 +378,6 @@ class MotorHomer:
         streams (``el_deg=None`` when both are absent)."""
         return read_el_estimate(self.snapshot, logger=self.logger)
 
-    def _read_sensors(self):
-        """(pot_v, el_est) — legacy combined read; removal pending the
-        per-axis home() split."""
-        return self._read_pot_once(), self._read_el()
-
     def _settle(self, stop_event):
         """Wait ``settle_s`` seconds; uses ``stop_event.wait`` when present."""
         if stop_event is not None:
@@ -386,28 +385,167 @@ class MotorHomer:
         elif self.settle_s:
             time.sleep(self.settle_s)
 
+    def _home_az(self, stop_event=None):
+        """Single-correction pot-referenced az home.
+
+        Coarse open-loop drive to step 0 under the divergence guard,
+        settle, integrated pot read, then at most ONE corrective jog
+        of the full signed residual (no damping, same guard), settle,
+        final integrated read. There is deliberately no convergence
+        loop — see the module docstring. Re-zeros the az step counter
+        only when the final read is within tolerance.
+
+        Returns ``(residual_deg, converged, degraded, did_reset)``.
+        """
+        v_home = self.az_home_voltage()
+        self._check_home_in_window(v_home)
+        if self._read_pot_once() is None:
+            if self.az_step0_fallback:
+                self.logger.warning(
+                    "potmon unavailable — az home is pot-referenced; "
+                    "az_step0_fallback is set: parking az at step 0 "
+                    "open-loop (position will not be verified)."
+                )
+                self.motor_client.home(stop_event=stop_event, axes=("az",))
+            else:
+                self.logger.warning(
+                    "potmon unavailable — az home is pot-referenced; "
+                    "skipping az (set az_step0_fallback=True to park "
+                    "at step 0 open-loop instead)."
+                )
+            return float("nan"), False, True, False
+        guard = _AzDivergenceGuard(
+            self._read_pot_once,
+            v_home,
+            self._az_slope(),
+            self.az_diverge_deg,
+        )
+        # coarse approach: open-loop to step 0, halted on divergence
+        self.motor_client.home(
+            stop_event=stop_event, axes=("az",), guard=guard
+        )
+        res = float("nan")
+        for attempt in range(2):  # measure, correct once, re-measure
+            if stop_event is not None and stop_event.is_set():
+                return float("nan"), False, False, False
+            self._settle(stop_event)
+            pot_v = self._read_pot_integrated(stop_event)
+            if pot_v is None:
+                self.logger.warning(
+                    "potmon lost during az home; aborting az without "
+                    "re-zero (position unverified)."
+                )
+                return float("nan"), False, True, False
+            res = self._az_residual_deg(v_home, pot_v)
+            if abs(res) <= self.tol_az_deg:
+                break
+            if attempt == 0:
+                # the single corrective jog: full signed residual,
+                # no damping — the same guard carries its closest
+                # approach over from the coarse move
+                self.motor_client.jog_az(
+                    res, stop_event=stop_event, guard=guard
+                )
+        converged = abs(res) <= self.tol_az_deg
+        did_reset = False
+        if converged and self.reset_count:
+            self.motor_client.reset_step_position(az_step=0, el_step=None)
+            did_reset = True
+        elif not converged:
+            self.logger.warning(
+                "az home residual %.1f deg after single corrective "
+                "jog (tol %.1f deg); not re-zeroing.",
+                res,
+                self.tol_az_deg,
+            )
+        return res, converged, False, did_reset
+
+    def _home_el(self, stop_event=None):
+        """Closed-loop el home: coarse approach, then the settle →
+        measure → damped-corrective-jog loop against the IMU
+        elevation, up to ``max_iters`` iterations (semantics
+        unchanged from the original two-axis loop).
+
+        Returns ``(residual_deg, iterations, converged, degraded,
+        did_reset)``.
+        """
+        if self._read_el().el_deg is None:
+            self.logger.warning(
+                "Homing sensors unavailable; falling back to "
+                "open-loop home() — position will not be verified."
+            )
+            self.motor_client.home(stop_event=stop_event, axes=("el",))
+            return float("nan"), 0, False, True, False
+        self.motor_client.home(stop_event=stop_event, axes=("el",))
+        el_sign = 1.0
+        last_el = None
+        res_el = float("nan")
+        converged = False
+        i = 0
+        for i in range(1, self.max_iters + 1):
+            if stop_event is not None and stop_event.is_set():
+                break
+            self._settle(stop_event)
+            res_el, _ = self._el_residual(self._read_el())
+            if res_el is None:
+                self.logger.warning(
+                    "el homing lost sensor feedback mid-loop; "
+                    "aborting without re-zero (position unverified)."
+                )
+                return float("nan"), i, False, True, False
+            if abs(res_el) <= self.tol_el_deg:
+                converged = True
+                break
+            # corrective jog with sign auto-detect (needed in the
+            # magnitude-only failover; harmless when signed)
+            if last_el is not None and abs(res_el) > last_el:
+                el_sign = -el_sign
+            last_el = abs(res_el)
+            self.motor_client.jog_el(
+                el_sign * self.damping * res_el, stop_event=stop_event
+            )
+        did_reset = False
+        if converged and self.reset_count:
+            self.motor_client.reset_step_position(az_step=None, el_step=0)
+            did_reset = True
+        if not converged:
+            self.logger.warning(
+                "el homing did not converge in %d iterations "
+                "(residual %.1f deg).",
+                self.max_iters,
+                res_el if res_el is not None else float("nan"),
+            )
+        return res_el, i, converged, False, did_reset
+
     def home(self, stop_event=None, axes=("az", "el")):
-        """Drive the motor to the cal-defined home (pot 0°, IMU-level el).
+        """Drive the requested axes to the cal-defined home.
+
+        Az first (single pot-referenced correction, see
+        :meth:`_home_az`), then el (closed-loop convergence, see
+        :meth:`_home_el`). Every move blocks, so only one motor moves
+        at a time.
 
         Parameters
         ----------
         stop_event : threading.Event or None
-            When set, the loop exits at the next interruptible point.
+            When set, each axis path exits at its next interruptible
+            point; a set event also skips a not-yet-started el.
         axes : tuple of str
             Axes to home, a non-empty subset of ``("az", "el")``
             (default both). An axis not requested is never moved, its
-            residual in the result is ``None``, and its step counter is
-            preserved on the convergence re-zero. An el-only home needs
-            no pot calibration — the cal requirement is purely an az
-            concern.
+            residual in the result is ``None``, and its step counter
+            is preserved. An el-only home needs no pot calibration —
+            the cal requirement is purely an az concern.
 
         Returns
         -------
         HomeResult
-            ``converged`` is ``True`` when every requested axis'
-            residual is within tolerance; ``degraded`` is ``True`` when
-            the requested axes' sensors were unavailable and open-loop
-            fall-back was used.
+            ``converged`` is ``True`` when every requested axis ended
+            within tolerance; ``iterations`` counts el-loop
+            iterations (0 for an az-only home); ``degraded`` is
+            ``True`` when a requested axis' sensor was unavailable
+            (az: skipped or step-0 fallback per ``az_step0_fallback``;
+            el: open-loop fall-back).
 
         Raises
         ------
@@ -422,105 +560,33 @@ class MotorHomer:
         axes = validate_axes(axes)
         do_az = "az" in axes
         do_el = "el" in axes
-        v_home = None
-        if do_az:
-            v_home = self.az_home_voltage()
-            self._check_home_in_window(v_home)
-
-        pot_v, el_est = self._read_sensors()
-        has_feedback = (do_az and pot_v is not None) or (
-            do_el and el_est.el_deg is not None
-        )
-        if not has_feedback:
-            self.logger.warning(
-                "Homing sensors unavailable; falling back to open-loop "
-                "home() — position will not be verified."
-            )
-            self.motor_client.home(stop_event=stop_event, axes=axes)
-            return HomeResult(
-                False,
-                0,
-                float("nan") if do_az else None,
-                float("nan") if do_el else None,
-                degraded=True,
-                reset_count=False,
-            )
-
-        # coarse approach
-        self.motor_client.home(stop_event=stop_event, axes=axes)
-        az_sign, el_sign = 1.0, 1.0
-        last_az = last_el = None
-        res_az = float("nan") if do_az else None
-        res_el = float("nan") if do_el else None
-        converged = False
-        i = 0
-        for i in range(1, self.max_iters + 1):
-            if stop_event is not None and stop_event.is_set():
-                break
-            self._settle(stop_event)
-            pot_v, el_est = self._read_sensors()
-            res_az = self._az_residual_deg(v_home, pot_v) if do_az else None
-            res_el = self._el_residual(el_est)[0] if do_el else None
-            # An unrequested axis' residual is None by construction, so
-            # this still means "every requested axis lost feedback".
-            if res_az is None and res_el is None:
-                self.logger.warning(
-                    "Homing lost all sensor feedback mid-loop; aborting "
-                    "without re-zero (position unverified)."
-                )
-                return HomeResult(
-                    False,
-                    i,
-                    res_az,
-                    res_el,
-                    degraded=True,
-                    reset_count=False,
-                )
-            if self._within_tol(res_az, res_el):
-                converged = True
-                break
-            # az corrective jog with sign auto-detect
-            if res_az is not None and abs(res_az) > self.tol_az_deg:
-                if last_az is not None and abs(res_az) > last_az:
-                    az_sign = -az_sign
-                last_az = abs(res_az)
-                self.motor_client.jog_az(
-                    az_sign * self.damping * res_az,
-                    stop_event=stop_event,
-                )
-            # el corrective jog with sign auto-detect (needed in the
-            # magnitude-only failover; harmless when signed)
-            if res_el is not None and abs(res_el) > self.tol_el_deg:
-                if last_el is not None and abs(res_el) > last_el:
-                    el_sign = -el_sign
-                last_el = abs(res_el)
-                self.motor_client.jog_el(
-                    el_sign * self.damping * res_el,
-                    stop_event=stop_event,
-                )
-
+        res_az = res_el = None
+        iters = 0
+        az_ok = el_ok = True
+        degraded = False
         did_reset = False
-        if converged and self.reset_count:
-            # None preserves the unrequested axis' counter (firmware
-            # omits a None axis from the reset command).
-            self.motor_client.reset_step_position(
-                az_step=0 if do_az else None,
-                el_step=0 if do_el else None,
-            )
-            did_reset = True
-        if not converged:
-            self.logger.warning(
-                "Homing did not converge in %d iterations "
-                "(residual az=%.1f el=%.1f deg).",
-                self.max_iters,
-                res_az if res_az is not None else float("nan"),
-                res_el if res_el is not None else float("nan"),
-            )
+        if do_az:
+            res_az, az_ok, az_degraded, az_reset = self._home_az(stop_event)
+            degraded = degraded or az_degraded
+            did_reset = did_reset or az_reset
+        if do_el:
+            if stop_event is not None and stop_event.is_set():
+                el_ok = False
+            else:
+                (
+                    res_el,
+                    iters,
+                    el_ok,
+                    el_degraded,
+                    el_reset,
+                ) = self._home_el(stop_event)
+                degraded = degraded or el_degraded
+                did_reset = did_reset or el_reset
         return HomeResult(
-            converged,
-            i,
-            res_az,
-            res_el,
-            degraded=False,
+            converged=(not do_az or az_ok) and (not do_el or el_ok),
+            iterations=iters,
+            residual_az_deg=res_az,
+            residual_el_deg=res_el,
+            degraded=degraded,
             reset_count=did_reset,
         )

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -48,6 +48,8 @@ class MotorZeroer:
     ``enforce_limits`` is passed to the internally built ``MotorClient``;
     it is ignored when an external ``motor_client`` is supplied (that
     client's own ``enforce_limits`` governs).
+    ``az_step0_fallback`` is forwarded to the internally built
+    :class:`MotorHomer` (ignored when an external ``homer`` is supplied).
     """
 
     def __init__(
@@ -60,6 +62,7 @@ class MotorZeroer:
         el_dn_delay_us=600,
         source="motor_zeroer",
         enforce_limits=True,
+        az_step0_fallback=False,
         motor_client=None,
         homer=None,
         confirm_starts_home=False,
@@ -99,6 +102,7 @@ class MotorZeroer:
                 transport,
                 motor_client=motor_client,
                 source=source,
+                az_step0_fallback=az_step0_fallback,
             )
         self._homer = homer
         # Enter/y commit semantics: False (motor_manual) zeroes the
@@ -191,12 +195,13 @@ class MotorZeroer:
 
         No-op if a home is already in flight or the manager is
         unreachable. The thread runs :meth:`MotorHomer.home`
-        (coarse approach, then closed-loop convergence onto the pot's
-        0° voltage and IMU-level el, re-truing the step counters) and
-        clears :attr:`is_homing` when it returns — normally, on a
-        :meth:`cancel_home`, or after a logged error. A missing pot
-        calibration surfaces as an actionable :attr:`notice`; there is
-        deliberately no silent step-0 fallback.
+        (az: coarse approach plus at most one pot-referenced corrective
+        jog; el: closed-loop convergence onto IMU-level — each re-trues
+        its own step counter on success) and clears :attr:`is_homing`
+        when it returns — normally, on a :meth:`cancel_home`, or after a
+        logged error. A missing pot calibration surfaces as an actionable
+        :attr:`notice`; a dead potmon skips az unless
+        ``az_step0_fallback`` was set.
 
         ``axes`` (a non-empty subset of ``("az", "el")``, default both)
         restricts the home to the given axes — the other axis is never

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -108,6 +108,7 @@ class MotorZeroer:
         # last_home_result for the outcome.
         self._confirm_starts_home = confirm_starts_home
         self._homing = False
+        self._homing_axes = ("az", "el")
         self._home_thread = None
         self._home_stop = None
         # HomeResult of the last completed background home; None while
@@ -125,6 +126,14 @@ class MotorZeroer:
         that jog/zero keys are currently inert.
         """
         return self._homing
+
+    @property
+    def homing_axes(self):
+        """Axes targeted by the current (or most recent) background
+        home. The curses layer reads this while :attr:`is_homing` to
+        render an axis-specific banner.
+        """
+        return self._homing_axes
 
     @property
     def pending_zero(self):
@@ -177,7 +186,7 @@ class MotorZeroer:
         self._proxy.send_command("halt")
         self._proxy.send_command("reset_step_position", az_step=0, el_step=0)
 
-    def start_home(self):
+    def start_home(self, axes=("az", "el")):
         """Begin driving to the cal-defined home in a background thread.
 
         No-op if a home is already in flight or the manager is
@@ -188,9 +197,15 @@ class MotorZeroer:
         :meth:`cancel_home`, or after a logged error. A missing pot
         calibration surfaces as an actionable :attr:`notice`; there is
         deliberately no silent step-0 fallback.
+
+        ``axes`` (a non-empty subset of ``("az", "el")``, default both)
+        restricts the home to the given axes — the other axis is never
+        moved and keeps its step counter. See :meth:`MotorHomer.home`.
         """
         if self._homing or not self.is_available:
             return
+        axes = tuple(axes)
+        self._homing_axes = axes
         self._home_stop = threading.Event()
         self._homing = True
         self.last_home_result = None
@@ -198,7 +213,7 @@ class MotorZeroer:
         def _run():
             try:
                 self.last_home_result = self._homer.home(
-                    stop_event=self._home_stop
+                    stop_event=self._home_stop, axes=axes
                 )
             except MotorLimitError as exc:
                 self.logger.warning("home denied: %s", exc)
@@ -309,10 +324,12 @@ class MotorZeroer:
             return deg_state + 1, False, False
         if key == "-":
             return max(0.1, deg_state - 1), False, False
-        if key == "h":
-            # Start driving back to step 0 in the background; start_home
-            # no-ops if the manager is unreachable.
-            self.start_home()
+        if key in ("h", "a", "e"):
+            # Start driving to the cal-defined home in the background:
+            # 'h' homes both axes, 'a' azimuth only, 'e' elevation only.
+            # start_home no-ops if the manager is unreachable.
+            axes = {"h": ("az", "el"), "a": ("az",), "e": ("el",)}[key]
+            self.start_home(axes=axes)
             return deg_state, False, False
         if key in ("u", "d", "l", "r"):
             if not self.is_available:

--- a/src/eigsep_observing/motor_zeroer.py
+++ b/src/eigsep_observing/motor_zeroer.py
@@ -226,6 +226,14 @@ class MotorZeroer:
             except (RuntimeError, TimeoutError) as exc:
                 self.logger.warning("home failed: %s", exc)
                 self.notice = f"home failed: {exc}"
+            else:
+                res = self.last_home_result
+                if not res.converged:
+                    self.notice = (
+                        "home incomplete: sensor unavailable (see log)"
+                        if res.degraded
+                        else "home did not converge; counters not re-zeroed"
+                    )
             finally:
                 self._homing = False
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2066,6 +2066,104 @@ def test_motor_loop_failure_park_stays_open_loop(transport, dummy_cfg):
         client.stop()
 
 
+def test_motor_loop_warns_status_on_degraded_homing(transport, dummy_cfg):
+    """A degraded (but not exception-raising) homer result — e.g. az
+    skipped because the potmon is dead — must still surface a WARNING
+    on the status stream. Field deployments have no alerting besides
+    the status stream, so a silently-skipped axis is invisible without
+    this."""
+    from eigsep_observing.motor_homer import HomeResult
+
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_scan"] = {"repeat_count": 1}
+    cfg["home_after_scan"] = True
+    cfg["motor_homer_kwargs"] = {"settle_s": 0.0, "max_iters": 1}
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+
+        def fake_scan(**kwargs):
+            pass  # scan succeeds
+
+        def degraded_homer_home(stop_event=None):
+            client.stop_client.set()
+            return HomeResult(
+                converged=False,
+                iterations=0,
+                residual_az_deg=float("nan"),
+                residual_el_deg=None,
+                degraded=True,
+                reset_count=False,
+            )
+
+        _arm_status_reader(client)
+        with (
+            patch.object(client.motor_client, "scan", side_effect=fake_scan),
+            patch.object(
+                client.motor_homer, "home", side_effect=degraded_homer_home
+            ),
+        ):
+            client.motor_loop()
+
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.WARNING
+        assert "degraded" in status
+    finally:
+        client.stop()
+
+
+def test_motor_loop_guard_trip_no_repark(transport, dummy_cfg):
+    """A ``MotorLimitError`` raised by the homer itself (the az
+    divergence guard tripping mid-correction) must NOT trigger an
+    open-loop re-park: re-driving az right after the guard halted a
+    move heading the wrong way would repeat the dangerous move. The
+    scan's own completion park already ran; az should stay halted
+    where the guard stopped it."""
+    from eigsep_observing.motor_client import MotorLimitError
+
+    cfg = dict(dummy_cfg)
+    cfg["use_motor"] = True
+    cfg["motor_interval"] = 3600
+    cfg["motor_scan"] = {"repeat_count": 1}
+    cfg["home_after_scan"] = True
+    cfg["motor_homer_kwargs"] = {"settle_s": 0.0, "max_iters": 1}
+    client = DummyPandaClient(transport, cfg=cfg)
+    try:
+        open_loop_calls = []
+
+        def fake_scan(**kwargs):
+            pass  # scan succeeds
+
+        def raising_homer_home(stop_event=None):
+            client.stop_client.set()
+            raise MotorLimitError("az move diverging from pot home")
+
+        def recording_open_home():
+            open_loop_calls.append(True)
+
+        _arm_status_reader(client)
+        with (
+            patch.object(client.motor_client, "scan", side_effect=fake_scan),
+            patch.object(
+                client.motor_homer, "home", side_effect=raising_homer_home
+            ),
+            patch.object(
+                client.motor_client, "home", side_effect=recording_open_home
+            ),
+        ):
+            client.motor_loop()
+
+        assert not open_loop_calls, (
+            "a travel-guard trip must NOT re-drive az open-loop"
+        )
+        level, status = _status_reader(client).read(timeout=1)
+        assert level == logging.WARNING
+        assert "travel guard" in status
+    finally:
+        client.stop()
+
+
 def test_motor_loop_survives_motor_limit_error(transport, dummy_cfg, caplog):
     """A ``MotorLimitError`` from ``scan`` (sensor fence or commanded-target
     guard) must not propagate out of ``motor_loop``.  It must be treated

--- a/tests/test_field_zero.py
+++ b/tests/test_field_zero.py
@@ -180,7 +180,7 @@ def test_curses_main_exits_with_result_on_converged_home(client, monkeypatch):
     monkeypatch.setattr(field_zero.curses, "noecho", lambda: None)
 
     class _Homer:
-        def home(self, stop_event=None):
+        def home(self, stop_event=None, axes=("az", "el")):
             return HomeResult(
                 converged=True,
                 iterations=1,
@@ -206,7 +206,7 @@ def test_curses_main_stays_alive_on_unconverged_home(client, monkeypatch):
     monkeypatch.setattr(field_zero.curses, "noecho", lambda: None)
 
     class _Homer:
-        def home(self, stop_event=None):
+        def home(self, stop_event=None, axes=("az", "el")):
             return HomeResult(
                 converged=False,
                 iterations=6,

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -904,3 +904,46 @@ def test_load_stored_limits_malformed_payload_degrades_to_empty():
     publish_json(t, "motor_limits", ["not", "a", "dict"])
     mc = MotorClient(t)
     assert mc.az_limits_deg == (-200.0, 200.0)
+
+
+# ---------------------------------------------------------------------------
+# Task-1 additions: guard callable plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_stop_guard_halts_and_raises(client):
+    """A guard raising MotorLimitError aborts the wait, halts the
+    motor, and re-raises — same contract as the sensor fence."""
+    motor = _motor(client.transport)
+    assert _wait_until_motor_status_available(motor)
+
+    def tripping_guard():
+        raise MotorLimitError("diverging")
+
+    with patch.object(motor, "halt") as halt:
+        with pytest.raises(MotorLimitError, match="diverging"):
+            motor._wait_for_stop(timeout=0.5, guard=tripping_guard)
+    halt.assert_called_once()
+
+
+def test_home_and_jogs_forward_guard(client):
+    """home() / jog_az() / jog_el() forward ``guard`` to
+    _send_and_wait for every axis move they issue."""
+    motor = _motor(client.transport)
+    assert _wait_until_motor_status_available(motor)
+    seen = []
+
+    def recording_send(action, **kwargs):
+        seen.append((action, kwargs.get("guard")))
+
+    sentinel = object()
+    with patch.object(motor, "_send_and_wait", side_effect=recording_send):
+        motor.home(guard=sentinel)
+        motor.jog_az(1.0, guard=sentinel)
+        motor.jog_el(-1.0, guard=sentinel)
+    assert [(a, g is sentinel) for a, g in seen] == [
+        ("az_target_steps", True),
+        ("el_target_steps", True),
+        ("az_move_deg", True),
+        ("el_move_deg", True),
+    ]

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -794,7 +794,7 @@ def test_fence_sensors_passes_logger_none_to_read_el_estimate():
     """``_read_fence_sensors`` must pass ``logger=None`` to
     ``read_el_estimate`` so the "IMU elevation readings disagree" WARNING
     is not emitted at ~10 Hz on the high-frequency fence-poll path.
-    ``MotorHomer._read_sensors`` keeps ``logger=self.logger`` for the
+    ``MotorHomer._read_el`` keeps ``logger=self.logger`` for the
     settle-cadence read, which surfaces disagreement at a sane rate."""
     mc = MotorClient(DummyTransport())
     mc._reader.get = lambda key: {}

--- a/tests/test_motor_client.py
+++ b/tests/test_motor_client.py
@@ -718,6 +718,74 @@ def test_reset_step_position_sends_command():
 
 
 # ---------------------------------------------------------------------------
+# Per-axis home (axes=...)
+# ---------------------------------------------------------------------------
+
+
+def _wait_until(pred, timeout=2.0, interval=0.05):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_home_az_only_leaves_el(client):
+    """``home(axes=("az",))`` drives az to step 0 and never touches el."""
+    motor_client = _motor(client.transport)
+    motor = client._manager.picos["motor"]
+    motor_client.move_to(az_deg=2.0, el_deg=2.0)
+    el_target = motor._emulator.elevation.target_pos
+    assert el_target != 0
+    motor_client.home(axes=("az",))
+    assert motor._emulator.azimuth.target_pos == 0
+    assert motor._emulator.azimuth.position == 0
+    assert motor._emulator.elevation.target_pos == el_target
+    assert motor._emulator.elevation.position == el_target
+
+
+def test_home_el_only_leaves_az(client):
+    """``home(axes=("el",))`` drives el to step 0 and never touches az."""
+    motor_client = _motor(client.transport)
+    motor = client._manager.picos["motor"]
+    motor_client.move_to(az_deg=2.0, el_deg=2.0)
+    az_target = motor._emulator.azimuth.target_pos
+    assert az_target != 0
+    motor_client.home(axes=("el",))
+    assert motor._emulator.elevation.target_pos == 0
+    assert motor._emulator.elevation.position == 0
+    assert motor._emulator.azimuth.target_pos == az_target
+    assert motor._emulator.azimuth.position == az_target
+
+
+def test_home_invalid_axes_raises():
+    mc = MotorClient(DummyTransport())
+    with pytest.raises(ValueError, match="axes"):
+        mc.home(axes=("foo",))
+    with pytest.raises(ValueError, match="axes"):
+        mc.home(axes=())
+
+
+def test_reset_step_position_none_preserves_other_axis(client):
+    """``az_step``/``el_step`` of ``None`` skips that axis' counter.
+
+    Characterizes the firmware contract the per-axis homer relies on:
+    ``picohost.PicoMotor.reset_step_position`` omits a ``None`` axis
+    from the command, so its counter is untouched.
+    """
+    mc = _motor(client.transport)
+    motor = client._manager.picos["motor"]
+    mc.move_to(az_deg=2.0, el_deg=2.0)
+    el_pos = motor._emulator.elevation.position
+    assert el_pos != 0
+    mc.reset_step_position(az_step=0, el_step=None)
+    assert _wait_until(lambda: motor._emulator.azimuth.position == 0)
+    assert motor._emulator.elevation.position == el_pos
+    assert motor._emulator.elevation.target_pos == el_pos
+
+
+# ---------------------------------------------------------------------------
 # _read_fence_sensors: IMU cross-check logger suppression
 # ---------------------------------------------------------------------------
 

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -5,7 +5,12 @@ from eigsep_redis.testing import DummyTransport
 from picohost.buses import PotCalStore
 
 from eigsep_observing.el_sensor import ElEstimate
-from eigsep_observing.motor_homer import HomeResult, MotorHomer
+from eigsep_observing.motor_client import MotorLimitError
+from eigsep_observing.motor_homer import (
+    HomeResult,
+    MotorHomer,
+    _AzDivergenceGuard,
+)
 from eigsep_observing.motor_limits import publish_motor_limits
 
 
@@ -331,3 +336,53 @@ def test_az_sign_autodetect_flips_when_residual_grows():
 def test_homer_passes_enforce_limits_to_motor_client():
     h = MotorHomer(DummyTransport(), enforce_limits=False)
     assert h.motor_client.enforce_limits is False
+
+
+# ---------------------------------------------------------------------------
+# az divergence guard
+# ---------------------------------------------------------------------------
+
+
+def _guard_over(values, v_home=1.0, slope=100.0, diverge_deg=20.0):
+    it = iter(values)
+    return _AzDivergenceGuard(lambda: next(it), v_home, slope, diverge_deg)
+
+
+def test_divergence_guard_trips_after_min_plus_threshold():
+    # dist(deg): 50, 20, 10(min), 30 (=min+20, no trip), 35 (>min+20)
+    g = _guard_over([1.5, 1.2, 1.1, 1.3, 1.35])
+    for _ in range(4):
+        g()
+    with pytest.raises(MotorLimitError, match="diverging"):
+        g()
+
+
+def test_divergence_guard_monotonic_approach_never_trips():
+    g = _guard_over([1.5, 1.4, 1.3, 1.2, 1.1, 1.0])
+    for _ in range(6):
+        g()  # must not raise
+
+
+def test_divergence_guard_overshoot_past_home_trips():
+    # crosses home (dist -> 0) then keeps going: trips once past
+    # min + threshold. dists: 20, 10, 0(min), 10, 20 (=min+20, no
+    # trip — strictly greater), then 30 trips.
+    g = _guard_over([1.2, 1.1, 1.0, 0.9, 0.8, 0.7])
+    for _ in range(5):
+        g()
+    with pytest.raises(MotorLimitError, match="diverging"):
+        g()
+
+
+def test_divergence_guard_skips_missing_samples():
+    g = _guard_over([1.2, None, 1.19])
+    for _ in range(3):
+        g()  # None sample is skipped, no state change, no trip
+
+
+def test_divergence_guard_negative_slope_uses_magnitude():
+    g = _guard_over([1.2, 1.1, 1.45], slope=-100.0)
+    g()
+    g()  # min dist 10 deg
+    with pytest.raises(MotorLimitError, match="diverging"):
+        g()  # 45 deg > 10 + 20

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -120,14 +120,16 @@ def test_az_home_voltage_raises_without_cal():
 
 
 # ---------------------------------------------------------------------------
-# home() loop tests
+# home() tests — az: single correction; el: convergence loop
 # ---------------------------------------------------------------------------
 
 
 class _FakeMotor:
-    """In-process motor whose jogs move a simulated pot voltage / el toward
-    home, so the homer's loop actually converges. gain matches the homer's
-    az gain so a damped jog shrinks the residual."""
+    """In-process motor: jogs move a simulated pot voltage / el the
+    way the rig would, so az's single correction lands exactly and
+    el's loop converges. ``dpv`` is the SIGNED cal slope the pot
+    simulation honours (positive az motion changes voltage by
+    ``delta/dpv``)."""
 
     def __init__(self, pot=1.30, el=10.0, deg_per_volt=100.0):
         self.pot = pot
@@ -135,16 +137,24 @@ class _FakeMotor:
         self.dpv = deg_per_volt
         self.homed = 0
         self.home_axes = []
+        self.home_guards = []
+        self.az_jogs = []
+        self.az_jog_guards = []
+        self.el_jogs = []
         self.reset = []
 
-    def home(self, stop_event=None, axes=("az", "el")):
+    def home(self, stop_event=None, axes=("az", "el"), guard=None):
         self.homed += 1
         self.home_axes.append(tuple(axes))
+        self.home_guards.append(guard)
 
-    def jog_az(self, delta_deg, stop_event=None):
-        self.pot += delta_deg / self.dpv  # +deg lowers residual toward v0
+    def jog_az(self, delta_deg, stop_event=None, guard=None):
+        self.az_jogs.append(delta_deg)
+        self.az_jog_guards.append(guard)
+        self.pot += delta_deg / self.dpv
 
-    def jog_el(self, delta_deg, stop_event=None):
+    def jog_el(self, delta_deg, stop_event=None, guard=None):
+        self.el_jogs.append(delta_deg)
         self.el += delta_deg  # +deg moves el toward level (0)
 
     def reset_step_position(self, az_step=0, el_step=0):
@@ -152,12 +162,13 @@ class _FakeMotor:
 
 
 def _homer_with_fake(t, fake, **kw):
+    kw.setdefault("az_gain_deg_per_volt", fake.dpv)
+    kw.setdefault("damping", 1.0)
     h = MotorHomer(
         t,
         motor_client=fake,
-        az_gain_deg_per_volt=fake.dpv,
         settle_s=0.0,
-        damping=1.0,
+        az_integrate_s=0.0,  # single pot sample per read: fake is exact
         max_iters=10,
         **kw,
     )
@@ -178,19 +189,139 @@ def test_home_raises_without_cal():
         h.home()
 
 
-def test_home_converges_onto_cal_zero_and_resets_count():
+def test_home_az_single_correction_el_loop_and_per_axis_reset():
+    """Both-axes home: az takes coarse + exactly ONE corrective jog
+    (full signed residual, no damping even though damping=0.5), el
+    converges via its loop; each axis re-zeros only its own counter,
+    az first."""
     t = DummyTransport()
-    _seed_cal(t)  # v_home = 1.0 V; el home is IMU-level (0 deg)
+    _seed_cal(t)  # v_home = 1.0 V
     fake = _FakeMotor(pot=1.30, el=10.0)
-    h = _homer_with_fake(t, fake)
+    h = _homer_with_fake(t, fake, damping=0.5)
     res = h.home()
     assert res.converged is True
-    assert abs(res.residual_az_deg) <= h.tol_az_deg
-    assert abs(res.residual_el_deg) <= h.tol_el_deg
-    # the pot itself landed at the cal's zero-angle voltage
-    assert fake.pot == pytest.approx(1.0, abs=h.tol_az_deg / fake.dpv)
-    assert fake.reset == [(0, 0)]  # re-zeroed on convergence
-    assert fake.homed >= 1  # coarse approach happened
+    assert fake.az_jogs == [pytest.approx(-30.0)]  # one full-residual jog
+    assert fake.pot == pytest.approx(1.0)
+    assert abs(fake.el) <= h.tol_el_deg
+    assert fake.home_axes == [("az",), ("el",)]  # az coarse first
+    assert fake.reset == [(0, None), (None, 0)]  # per-axis re-zero
+    assert res.iterations >= 1  # el loop ran
+
+
+def test_home_az_within_tol_after_coarse_never_jogs():
+    t = DummyTransport()
+    _seed_cal(t)
+    fake = _FakeMotor(pot=1.01, el=0.0)  # 1 deg residual < tol 3
+    h = _homer_with_fake(t, fake)
+    res = h.home(axes=("az",))
+    assert res.converged is True
+    assert fake.az_jogs == []
+    assert fake.reset == [(0, None)]
+
+
+def test_home_az_correction_direction_from_negative_slope():
+    """Negative cal slope flips the jog sign — direction is defined
+    by the pot cal, not trial and error."""
+    t = DummyTransport()
+    _seed_cal(t, m=-100.0, b=100.0)  # v_home = 1.0 V, slope -100
+    fake = _FakeMotor(pot=1.30, el=0.0, deg_per_volt=-100.0)
+    h = _homer_with_fake(t, fake)
+    res = h.home(axes=("az",))
+    assert res.converged is True
+    assert fake.az_jogs == [pytest.approx(30.0)]  # -100 * (1.0-1.3)
+    assert fake.pot == pytest.approx(1.0)
+
+
+def test_home_az_still_out_after_correction_warns_no_rezero(caplog):
+    """A stuck az (jog moves nothing) gets exactly one corrective
+    attempt, then a loud warning and NO re-zero."""
+    t = DummyTransport()
+    _seed_cal(t)
+
+    class _Stuck(_FakeMotor):
+        def jog_az(self, delta_deg, stop_event=None, guard=None):
+            self.az_jogs.append(delta_deg)  # motor doesn't move
+
+    fake = _Stuck(pot=1.30, el=0.0)
+    h = _homer_with_fake(t, fake)
+    with caplog.at_level(logging.WARNING):
+        res = h.home(axes=("az",))
+    assert res.converged is False
+    assert res.degraded is False
+    assert len(fake.az_jogs) == 1  # no second attempt, no hunting
+    assert fake.reset == []
+    assert any("not re-zeroing" in r.message for r in caplog.records)
+
+
+def test_home_az_moves_carry_divergence_guard():
+    t = DummyTransport()
+    _seed_cal(t)
+    fake = _FakeMotor(pot=1.30, el=10.0)
+    h = _homer_with_fake(t, fake)
+    h.home()
+    assert all(g is not None for g in fake.az_jog_guards)
+    # az coarse guarded; el coarse not (pot says nothing about el)
+    assert fake.home_guards[0] is not None
+    assert fake.home_guards[1] is None
+    # coarse and jog share one guard: closest approach carries over
+    assert fake.home_guards[0] is fake.az_jog_guards[0]
+
+
+def test_home_az_pot_lost_after_coarse_aborts_without_rezero(caplog):
+    """Pot dies between the coarse approach and the read: warn,
+    no jog, no re-zero, degraded."""
+    t = DummyTransport()
+    _seed_cal(t)
+
+    class _PotDies(_FakeMotor):
+        def home(self, stop_event=None, axes=("az", "el"), guard=None):
+            super().home(stop_event=stop_event, axes=axes, guard=guard)
+            self.pot = None
+
+    fake = _PotDies(pot=1.30, el=0.0)
+    h = _homer_with_fake(t, fake)
+    with caplog.at_level(logging.WARNING):
+        res = h.home(axes=("az",))
+    assert res.converged is False
+    assert res.degraded is True
+    assert fake.az_jogs == []
+    assert fake.reset == []
+    assert any("potmon lost" in r.message for r in caplog.records)
+
+
+def test_home_az_pot_missing_skips_az_by_default(caplog):
+    """Default az_step0_fallback=False: dead potmon means NO az
+    motion at all — with the pot dead the pot fence is inert too."""
+    t = DummyTransport()
+    _seed_cal(t)
+    fake = _FakeMotor()
+    h = _homer_with_fake(t, fake)
+    h.snapshot.get = lambda key: {"el_deg": fake.el} if key == "imu_el" else {}
+    with caplog.at_level(logging.WARNING):
+        res = h.home(axes=("az",))
+    assert res.degraded is True
+    assert res.converged is False
+    assert fake.home_axes == []  # az never moved
+    assert fake.az_jogs == []
+    assert fake.reset == []
+    assert any("az_step0_fallback" in r.message for r in caplog.records)
+
+
+def test_home_az_pot_missing_step0_fallback_parks_open_loop(caplog):
+    """az_step0_fallback=True: dead potmon still parks az at step 0
+    open-loop, degraded, never re-zeroed."""
+    t = DummyTransport()
+    _seed_cal(t)
+    fake = _FakeMotor()
+    h = _homer_with_fake(t, fake, az_step0_fallback=True)
+    h.snapshot.get = lambda key: {"el_deg": fake.el} if key == "imu_el" else {}
+    with caplog.at_level(logging.WARNING):
+        res = h.home(axes=("az",))
+    assert res.degraded is True
+    assert res.converged is False
+    assert fake.home_axes == [("az",)]  # open-loop park happened
+    assert fake.reset == []
+    assert any("potmon unavailable" in r.message for r in caplog.records)
 
 
 def test_home_tracks_cal_rezero_immediately():
@@ -200,11 +331,13 @@ def test_home_tracks_cal_rezero_immediately():
     _seed_cal(t, m=100.0, b=-100.0)  # v_home 1.0 V
     fake = _FakeMotor(pot=1.30, el=0.0)
     h = _homer_with_fake(t, fake)
+    # az_gain override would pin the slope; let it track the cal too
+    h.az_gain_deg_per_volt = None
     assert h.home().converged is True
-    assert fake.pot == pytest.approx(1.0, abs=h.tol_az_deg / fake.dpv)
+    assert fake.pot == pytest.approx(1.0)
     _seed_cal(t, m=100.0, b=-120.0)  # rezero: v_home now 1.2 V
     assert h.home().converged is True
-    assert fake.pot == pytest.approx(1.2, abs=h.tol_az_deg / fake.dpv)
+    assert fake.pot == pytest.approx(1.2)
 
 
 def test_home_refuses_when_cal_zero_outside_pot_window(caplog):
@@ -227,44 +360,42 @@ def test_home_refuses_when_cal_zero_outside_pot_window(caplog):
 
 
 def test_home_degrades_when_sensors_down(caplog):
+    """All sensors dead: az is skipped (pot-referenced, default no
+    fallback), el falls back to the open-loop el-only park."""
     t = DummyTransport()
     _seed_cal(t)
     fake = _FakeMotor()
-    h = MotorHomer(t, motor_client=fake)
+    h = MotorHomer(t, motor_client=fake, settle_s=0.0, az_integrate_s=0.0)
     h.snapshot.get = lambda key: {}  # nothing published
     with caplog.at_level(logging.WARNING):
         res = h.home()
     assert res.degraded is True
     assert res.converged is False
-    assert fake.homed == 1  # open-loop fallback park
+    assert fake.home_axes == [("el",)]  # el open-loop park only
+    assert fake.reset == []
     assert any("open-loop" in r.message for r in caplog.records)
 
 
-def test_mid_loop_sensor_loss_aborts_without_rezero(caplog):
-    """If all sensors go silent inside the loop, abort with degraded=True and
-    no re-zero — re-zeroing at an unverified position is a silent
-    wrong-success."""
+def test_el_mid_loop_sensor_loss_aborts_without_rezero(caplog):
+    """If the IMUs go silent inside the el loop, abort with
+    degraded=True and no re-zero — re-zeroing at an unverified
+    position is a silent wrong-success."""
     t = DummyTransport()
-    _seed_cal(t)
     fake = _FakeMotor(pot=1.30, el=10.0)
     h = _homer_with_fake(t, fake)
-    # Override _read_sensors so it returns valid data on the first pre-loop
-    # call (which happens before the main loop) and then all-None thereafter,
-    # triggering the mid-loop guard on iteration 1.
     call_count = 0
 
-    def _read_sensors_stub():
+    def _read_el_stub():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            # first call: pre-loop check — sensors look fine, proceed to loop
-            return fake.pot, ElEstimate(fake.el, False, "imu_el")
-        # subsequent calls (inside loop): all sensors lost
-        return None, ElEstimate(None, False, "none")
+            # pre-coarse check: IMU looks fine, proceed to the loop
+            return ElEstimate(fake.el, False, "imu_el")
+        return ElEstimate(None, False, "none")
 
-    h._read_sensors = _read_sensors_stub
+    h._read_el = _read_el_stub
     with caplog.at_level(logging.WARNING):
-        result = h.home()
+        result = h.home(axes=("el",))
     assert result.converged is False
     assert result.degraded is True
     assert fake.reset == []  # step counter must NOT be re-zeroed
@@ -272,7 +403,7 @@ def test_mid_loop_sensor_loss_aborts_without_rezero(caplog):
 
 
 def test_home_az_only_converges_without_touching_el():
-    """``axes=("az",)`` converges az, never jogs el (even though el is
+    """``axes=("az",)`` corrects az, never jogs el (even though el is
     far off level), and preserves el's step counter on the re-zero."""
     t = DummyTransport()
     _seed_cal(t)
@@ -280,9 +411,10 @@ def test_home_az_only_converges_without_touching_el():
     h = _homer_with_fake(t, fake)
     res = h.home(axes=("az",))
     assert res.converged is True
+    assert res.iterations == 0  # no el loop ran
     assert fake.el == 10.0  # el never jogged
     assert res.residual_el_deg is None
-    assert fake.pot == pytest.approx(1.0, abs=h.tol_az_deg / fake.dpv)
+    assert fake.pot == pytest.approx(1.0)
     assert fake.home_axes == [("az",)]  # coarse approach az-only
     assert fake.reset == [(0, None)]  # el counter untouched
 
@@ -310,23 +442,6 @@ def test_home_invalid_axes_raises():
         h.home(axes=())
 
 
-def test_home_az_only_degrades_when_pot_missing(caplog):
-    """An az-only home cares only about the pot: with the pot silent it
-    falls back to the open-loop az-only park even though the IMU is up."""
-    t = DummyTransport()
-    _seed_cal(t)
-    fake = _FakeMotor()
-    h = _homer_with_fake(t, fake)
-    h.snapshot.get = lambda key: {"el_deg": fake.el} if key == "imu_el" else {}
-    with caplog.at_level(logging.WARNING):
-        res = h.home(axes=("az",))
-    assert res.degraded is True
-    assert res.converged is False
-    assert fake.home_axes == [("az",)]  # open-loop fallback, az only
-    assert fake.reset == []  # no re-zero at unverified position
-    assert any("open-loop" in r.message for r in caplog.records)
-
-
 def test_home_el_only_degrades_when_imu_missing(caplog):
     """An el-only home cares only about the IMUs: with both IMUs silent
     it falls back to the open-loop el-only park even though the pot is
@@ -346,19 +461,18 @@ def test_home_el_only_degrades_when_imu_missing(caplog):
     assert any("open-loop" in r.message for r in caplog.records)
 
 
-def test_az_sign_autodetect_flips_when_residual_grows():
-    # fake where +az jog INCREASES the residual (wrong initial sign) until
-    # the homer flips; convergence proves the flip happened.
+def test_el_sign_autodetect_flips_when_residual_grows():
+    # fake where +el jog INCREASES the residual (wrong initial sign)
+    # until the homer flips; convergence proves the flip happened.
     t = DummyTransport()
-    _seed_cal(t)
 
     class _Reversed(_FakeMotor):
-        def jog_az(self, delta_deg, stop_event=None):
-            self.pot -= delta_deg / self.dpv  # opposite sign
+        def jog_el(self, delta_deg, stop_event=None, guard=None):
+            self.el -= delta_deg  # opposite sign
 
-    fake = _Reversed(pot=1.20, el=0.0)
+    fake = _Reversed(pot=1.0, el=8.0)
     h = _homer_with_fake(t, fake)
-    res = h.home()
+    res = h.home(axes=("el",))
     assert res.converged is True
 
 

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -37,6 +37,40 @@ def test_az_residual_none_when_pot_missing():
     assert h._az_residual_deg(1.0, None) is None
 
 
+def test_az_residual_signed_slope_sets_direction():
+    """The corrective jog has no sign auto-detect, so the residual
+    must carry the cal slope's sign: residual = m * (v_home - v)."""
+    h = _homer(az_gain_deg_per_volt=-100.0)
+    # pot 1.1 V, home 1.0 V, negative slope -> +10 deg (jog positive)
+    assert h._az_residual_deg(1.0, 1.1) == pytest.approx(10.0)
+
+
+def test_read_pot_integrated_averages_samples():
+    h = _homer(az_integrate_s=0.6)  # 3 samples at the 0.2 s cadence
+    vals = iter([1.0, 2.0, 3.0, 4.0])
+    h._read_pot_once = lambda: next(vals)
+    assert h._read_pot_integrated() == pytest.approx(2.0)
+
+
+def test_read_pot_integrated_single_sample_when_zero_window():
+    h = _homer(az_integrate_s=0.0)
+    h._read_pot_once = lambda: 1.5
+    assert h._read_pot_integrated() == pytest.approx(1.5)
+
+
+def test_read_pot_integrated_none_when_no_samples():
+    h = _homer(az_integrate_s=0.0)
+    h._read_pot_once = lambda: None
+    assert h._read_pot_integrated() is None
+
+
+def test_read_pot_integrated_skips_dropouts():
+    h = _homer(az_integrate_s=0.6)
+    vals = iter([1.0, None, 3.0])
+    h._read_pot_once = lambda: next(vals)
+    assert h._read_pot_integrated() == pytest.approx(2.0)
+
+
 def test_el_residual_signed_when_primary():
     h = _homer()
     res, mag_only = h._el_residual(ElEstimate(-8.0, False, "imu_el"))

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -86,14 +86,6 @@ def test_el_residual_magnitude_only_failover():
     assert mag_only is True
 
 
-def test_within_tol():
-    h = _homer(tol_az_deg=3.0, tol_el_deg=2.0)
-    assert h._within_tol(2.0, 1.0) is True
-    assert h._within_tol(4.0, 1.0) is False
-    assert h._within_tol(2.0, 3.0) is False
-    assert h._within_tol(None, 1.0) is True  # axis with no reading: skip
-
-
 def test_home_result_constructible():
     r = HomeResult(
         converged=True,

--- a/tests/test_motor_homer.py
+++ b/tests/test_motor_homer.py
@@ -95,10 +95,12 @@ class _FakeMotor:
         self.el = el
         self.dpv = deg_per_volt
         self.homed = 0
+        self.home_axes = []
         self.reset = []
 
-    def home(self, stop_event=None):
+    def home(self, stop_event=None, axes=("az", "el")):
         self.homed += 1
+        self.home_axes.append(tuple(axes))
 
     def jog_az(self, delta_deg, stop_event=None):
         self.pot += delta_deg / self.dpv  # +deg lowers residual toward v0
@@ -228,6 +230,81 @@ def test_mid_loop_sensor_loss_aborts_without_rezero(caplog):
     assert result.degraded is True
     assert fake.reset == []  # step counter must NOT be re-zeroed
     assert any("mid-loop" in r.message for r in caplog.records)
+
+
+def test_home_az_only_converges_without_touching_el():
+    """``axes=("az",)`` converges az, never jogs el (even though el is
+    far off level), and preserves el's step counter on the re-zero."""
+    t = DummyTransport()
+    _seed_cal(t)
+    fake = _FakeMotor(pot=1.30, el=10.0)  # el well outside tol_el_deg
+    h = _homer_with_fake(t, fake)
+    res = h.home(axes=("az",))
+    assert res.converged is True
+    assert fake.el == 10.0  # el never jogged
+    assert res.residual_el_deg is None
+    assert fake.pot == pytest.approx(1.0, abs=h.tol_az_deg / fake.dpv)
+    assert fake.home_axes == [("az",)]  # coarse approach az-only
+    assert fake.reset == [(0, None)]  # el counter untouched
+
+
+def test_home_el_only_needs_no_pot_cal():
+    """``axes=("el",)`` converges el without a stored pot calibration —
+    the pot-cal requirement is purely an az concern — and never jogs az."""
+    t = DummyTransport()  # deliberately no cal seeded
+    fake = _FakeMotor(pot=1.30, el=10.0)
+    h = _homer_with_fake(t, fake)
+    res = h.home(axes=("el",))
+    assert res.converged is True
+    assert fake.pot == pytest.approx(1.30)  # az never jogged
+    assert res.residual_az_deg is None
+    assert abs(fake.el) <= h.tol_el_deg
+    assert fake.home_axes == [("el",)]  # coarse approach el-only
+    assert fake.reset == [(None, 0)]  # az counter untouched
+
+
+def test_home_invalid_axes_raises():
+    h = _homer()
+    with pytest.raises(ValueError, match="axes"):
+        h.home(axes=("foo",))
+    with pytest.raises(ValueError, match="axes"):
+        h.home(axes=())
+
+
+def test_home_az_only_degrades_when_pot_missing(caplog):
+    """An az-only home cares only about the pot: with the pot silent it
+    falls back to the open-loop az-only park even though the IMU is up."""
+    t = DummyTransport()
+    _seed_cal(t)
+    fake = _FakeMotor()
+    h = _homer_with_fake(t, fake)
+    h.snapshot.get = lambda key: {"el_deg": fake.el} if key == "imu_el" else {}
+    with caplog.at_level(logging.WARNING):
+        res = h.home(axes=("az",))
+    assert res.degraded is True
+    assert res.converged is False
+    assert fake.home_axes == [("az",)]  # open-loop fallback, az only
+    assert fake.reset == []  # no re-zero at unverified position
+    assert any("open-loop" in r.message for r in caplog.records)
+
+
+def test_home_el_only_degrades_when_imu_missing(caplog):
+    """An el-only home cares only about the IMUs: with both IMUs silent
+    it falls back to the open-loop el-only park even though the pot is
+    up."""
+    t = DummyTransport()
+    fake = _FakeMotor()
+    h = _homer_with_fake(t, fake)
+    h.snapshot.get = lambda key: (
+        {"pot_az_voltage": fake.pot} if key == "potmon" else {}
+    )
+    with caplog.at_level(logging.WARNING):
+        res = h.home(axes=("el",))
+    assert res.degraded is True
+    assert res.converged is False
+    assert fake.home_axes == [("el",)]  # open-loop fallback, el only
+    assert fake.reset == []
+    assert any("open-loop" in r.message for r in caplog.records)
 
 
 def test_az_sign_autodetect_flips_when_residual_grows():

--- a/tests/test_motor_scripts.py
+++ b/tests/test_motor_scripts.py
@@ -281,7 +281,7 @@ def test_motor_manual_helpers_exist():
 def test_motor_manual_build_zeroer_override_limits():
     """_build_zeroer with override_limits=True builds enforce_limits=False."""
     mm = _load("motor_manual")
-    ns = Namespace(override_limits=True)
+    ns = Namespace(override_limits=True, az_step0_fallback=False)
     zeroer = mm._build_zeroer(DummyTransport(), ns)
     assert zeroer._motor_client.enforce_limits is False
 
@@ -289,7 +289,7 @@ def test_motor_manual_build_zeroer_override_limits():
 def test_motor_manual_build_zeroer_default_enforces_limits():
     """_build_zeroer with override_limits=False preserves enforce_limits=True."""
     mm = _load("motor_manual")
-    ns = Namespace(override_limits=False)
+    ns = Namespace(override_limits=False, az_step0_fallback=False)
     zeroer = mm._build_zeroer(DummyTransport(), ns)
     assert zeroer._motor_client.enforce_limits is True
 
@@ -300,6 +300,23 @@ def test_motor_manual_parse_args_accepts_override_limits(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["motor_manual", "--override-limits"])
     args = mm._parse_args()
     assert args.override_limits is True
+
+
+def test_motor_manual_parse_args_accepts_az_step0_fallback(monkeypatch):
+    """_parse_args recognises --az-step0-fallback flag (default off)."""
+    mm = _load("motor_manual")
+    monkeypatch.setattr(sys, "argv", ["motor_manual", "--az-step0-fallback"])
+    assert mm._parse_args().az_step0_fallback is True
+    monkeypatch.setattr(sys, "argv", ["motor_manual"])
+    assert mm._parse_args().az_step0_fallback is False
+
+
+def test_motor_manual_build_zeroer_forwards_az_step0_fallback():
+    """_build_zeroer threads the flag through to the homer."""
+    mm = _load("motor_manual")
+    ns = Namespace(override_limits=False, az_step0_fallback=True)
+    zeroer = mm._build_zeroer(DummyTransport(), ns)
+    assert zeroer._homer.az_step0_fallback is True
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -651,3 +651,13 @@ def test_last_home_result_reset_on_new_home(client):
     assert _wait_until(lambda: zeroer.is_homing, timeout=1.0)
     assert zeroer.last_home_result is None
     zeroer.cancel_home()
+
+
+def test_zeroer_forwards_az_step0_fallback():
+    z = MotorZeroer(DummyTransport(), az_step0_fallback=True)
+    assert z._homer.az_step0_fallback is True
+
+
+def test_zeroer_default_no_az_step0_fallback():
+    z = MotorZeroer(DummyTransport())
+    assert z._homer.az_step0_fallback is False

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -30,10 +30,12 @@ class _BlockingHomer:
     def __init__(self):
         self.home_calls = 0
         self.last_stop_event = None
+        self.last_axes = None
 
-    def home(self, stop_event=None):
+    def home(self, stop_event=None, axes=("az", "el")):
         self.home_calls += 1
         self.last_stop_event = stop_event
+        self.last_axes = tuple(axes)
         if stop_event is not None:
             stop_event.wait(timeout=2.0)
 
@@ -361,7 +363,7 @@ def test_handle_key_h_runs_homer_in_background(client):
             self.home_calls = 0
             self.last_stop_event = None
 
-        def home(self, stop_event=None):
+        def home(self, stop_event=None, axes=("az", "el")):
             self.home_calls += 1
             self.last_stop_event = stop_event
 
@@ -392,6 +394,40 @@ def test_handle_key_h_sets_homing_and_any_key_cancels(client):
     assert zeroed is False
     assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
     assert motor._emulator.azimuth.target_pos == before
+
+
+def test_handle_key_h_homes_both_axes(client):
+    """'h' keeps its home-both behavior: the homer gets both axes."""
+    fake = _BlockingHomer()
+    zeroer = MotorZeroer(client.transport, homer=fake)
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: fake.last_axes is not None, timeout=1.0)
+    assert fake.last_axes == ("az", "el")
+    assert zeroer.homing_axes == ("az", "el")
+    zeroer.cancel_home()
+
+
+def test_handle_key_a_homes_az_only(client):
+    """'a' starts a background az-only home; ``homing_axes`` feeds the
+    UI banner."""
+    fake = _BlockingHomer()
+    zeroer = MotorZeroer(client.transport, homer=fake)
+    zeroer.handle_key(ord("a"), 1.0)
+    assert _wait_until(lambda: fake.last_axes is not None, timeout=1.0)
+    assert fake.last_axes == ("az",)
+    assert zeroer.homing_axes == ("az",)
+    zeroer.cancel_home()
+
+
+def test_handle_key_e_homes_el_only(client):
+    """'e' starts a background el-only home."""
+    fake = _BlockingHomer()
+    zeroer = MotorZeroer(client.transport, homer=fake)
+    zeroer.handle_key(ord("e"), 1.0)
+    assert _wait_until(lambda: fake.last_axes is not None, timeout=1.0)
+    assert fake.last_axes == ("el",)
+    assert zeroer.homing_axes == ("el",)
+    zeroer.cancel_home()
 
 
 def test_handle_key_h_ignored_when_unavailable(client, monkeypatch):
@@ -471,7 +507,7 @@ def test_zeroer_passes_enforce_limits_to_motor_client():
 class _LimitTrippingHomer:
     """Stand-in ``MotorHomer`` whose ``home`` trips the sensor fence."""
 
-    def home(self, stop_event=None):
+    def home(self, stop_event=None, axes=("az", "el")):
         raise MotorLimitError(
             "pot_az_voltage 2.900 V outside safe window [0.500, 2.500]; "
             "refusing az move."
@@ -546,7 +582,7 @@ class _ConvergingHomer:
     def __init__(self):
         self.home_calls = 0
 
-    def home(self, stop_event=None):
+    def home(self, stop_event=None, axes=("az", "el")):
         from eigsep_observing.motor_homer import HomeResult
 
         self.home_calls += 1

--- a/tests/test_motor_zeroer.py
+++ b/tests/test_motor_zeroer.py
@@ -33,11 +33,25 @@ class _BlockingHomer:
         self.last_axes = None
 
     def home(self, stop_event=None, axes=("az", "el")):
+        from eigsep_observing.motor_homer import HomeResult
+
         self.home_calls += 1
         self.last_stop_event = stop_event
         self.last_axes = tuple(axes)
         if stop_event is not None:
             stop_event.wait(timeout=2.0)
+        # Mirrors the real ``MotorHomer.home``'s cancellation shape: a
+        # stop-event interruption never converges but is not
+        # "degraded" (that flag is reserved for sensor unavailability,
+        # e.g. dead potmon/IMU) — see ``_home_az``/``_home_el``.
+        return HomeResult(
+            converged=False,
+            iterations=0,
+            residual_az_deg=None,
+            residual_el_deg=None,
+            degraded=False,
+            reset_count=False,
+        )
 
 
 def _wait_until(pred, timeout=2.0, interval=0.05):
@@ -364,8 +378,20 @@ def test_handle_key_h_runs_homer_in_background(client):
             self.last_stop_event = None
 
         def home(self, stop_event=None, axes=("az", "el")):
+            from eigsep_observing.motor_homer import HomeResult
+
             self.home_calls += 1
             self.last_stop_event = stop_event
+            # The real homer always returns a HomeResult (never None);
+            # _run's else-branch reads .converged off it.
+            return HomeResult(
+                converged=True,
+                iterations=1,
+                residual_az_deg=0.0,
+                residual_el_deg=0.0,
+                degraded=False,
+                reset_count=False,
+            )
 
     fake = _RecordingHomer()
     zeroer = MotorZeroer(client.transport, homer=fake)
@@ -661,3 +687,77 @@ def test_zeroer_forwards_az_step0_fallback():
 def test_zeroer_default_no_az_step0_fallback():
     z = MotorZeroer(DummyTransport())
     assert z._homer.az_step0_fallback is False
+
+
+# ---------------------------------------------------------------------------
+# start_home notice: unconverged/degraded results must reach the curses UI
+# ---------------------------------------------------------------------------
+
+
+class _ResultHomer:
+    """Stand-in ``MotorHomer`` that returns a fixed ``HomeResult``.
+
+    The manual scripts run with ``console=False``, so log warnings are
+    invisible mid-session; ``notice`` is the curses UI's only channel.
+    """
+
+    def __init__(self, result):
+        self._result = result
+        self.home_calls = 0
+
+    def home(self, stop_event=None, axes=("az", "el")):
+        self.home_calls += 1
+        return self._result
+
+
+def test_home_notice_set_on_degraded_result(client):
+    """A degraded (sensor-unavailable) home result must surface an
+    actionable notice — a dead potmon skipping az must not pass
+    silently in a manual session."""
+    from eigsep_observing.motor_homer import HomeResult
+
+    fake = _ResultHomer(
+        HomeResult(
+            converged=False,
+            iterations=0,
+            residual_az_deg=float("nan"),
+            residual_el_deg=None,
+            degraded=True,
+            reset_count=False,
+        )
+    )
+    zeroer = MotorZeroer(client.transport, homer=fake)
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
+    assert "sensor unavailable" in zeroer.notice
+
+
+def test_home_notice_set_on_unconverged_result(client):
+    """A non-degraded home that simply failed to converge (e.g. the
+    iteration budget was exhausted) must also surface a notice, worded
+    distinctly from the degraded/sensor-unavailable case."""
+    from eigsep_observing.motor_homer import HomeResult
+
+    fake = _ResultHomer(
+        HomeResult(
+            converged=False,
+            iterations=5,
+            residual_az_deg=3.0,
+            residual_el_deg=2.0,
+            degraded=False,
+            reset_count=False,
+        )
+    )
+    zeroer = MotorZeroer(client.transport, homer=fake)
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
+    assert "did not converge" in zeroer.notice
+
+
+def test_home_notice_stays_none_on_converged_result(client):
+    """A converged home must not set any notice."""
+    fake = _ConvergingHomer()
+    zeroer = MotorZeroer(client.transport, homer=fake)
+    zeroer.handle_key(ord("h"), 1.0)
+    assert _wait_until(lambda: not zeroer.is_homing, timeout=2.0)
+    assert zeroer.notice is None


### PR DESCRIPTION
## Summary

Two stacked pieces of per-axis homing work:

**1. Single-axis home keys (`a`/`e`)** in `motor_manual` (and `field_zero`, which shares the key handler): `a` homes azimuth only, `e` elevation only, `h` both (az then el, one motor at a time). The unrequested axis never moves and keeps its step counter. An el-only home needs no pot calibration.

**2. Az homes with a single pot-referenced correction — no convergence loop.** The old damped back-and-forth convergence hunted pot wander on the az axis and isn't needed there; it survives only for el:

- **Az** (`MotorHomer._home_az`): coarse open-loop drive to step 0 → settle → **integrated pot read** (`az_integrate_s`, default 2 s ≈ 10 samples at the 200 ms producer cadence, to beat down pot noise) → at most **one corrective jog of the full signed residual** (`m × (v_home − v̄)` — the cal slope's sign sets the direction, no trial-and-error sign detect) → settle → final integrated read. The az counter is re-zeroed only when the final read is within `tol_az_deg`; otherwise a loud warning and no re-zero.
- **Divergence guard**: every az move (coarse *and* corrective jog, one shared instance) runs under `_AzDivergenceGuard` — if `|pot − v_home|` grows more than `az_diverge_deg` (default 20°, above the known ~7° 1/rev pot nonlinearity) past its closest approach, the motor is halted mid-flight. This catches a wrong step counter (post-reboot) or a wrong-signed cal long before the ±limit fence would, and also stops overshoot past home. Plumbed as a generic `guard` callable through `MotorClient.home()/jog_az()/jog_el()` → `_wait_for_stop`, polled at fence cadence with the fence's halt-and-raise contract.
- **Dead potmon** → az motion is **skipped** by default (with the pot dead, the pot-voltage fence is inert too — a blind move is exactly the dangerous case). `az_step0_fallback=True` (MotorHomer/MotorZeroer kwarg, `--az-step0-fallback` on `motor_manual`, config-selectable via `motor_homer_kwargs`) opts into an open-loop step-0 park, marked degraded, never re-zeroed.
- **El** (`_home_el`): the existing closed-loop convergence, unchanged (settle/measure/damped-jog, sign auto-detect, `max_iters`) — `damping`/`max_iters` are el-only now. Per-axis counter re-zero: az `(0, None)`, el `(None, 0)`; az always first.
- **Operator visibility**: `PandaClient.motor_loop` status-warns on degraded post-scan homing and no longer blind-re-parks after a travel-guard trip (the guard fired because the counter/cal is suspect); `MotorZeroer` sets the curses `notice` when a home returns unconverged, so the manual tools show *why* nothing moved.

`HomeResult` shape is unchanged (`iterations` = el-loop iterations, 0 for az-only). `az_integrate_s` / `az_diverge_deg` / tolerances still need hardware tuning.

## Testing

TDD throughout: new tests written first and watched fail. Coverage: `test_motor_client.py` (guard polled + halt-and-raise, guard forwarding, per-axis home/reset characterization against the emulator), `test_motor_homer.py` (guard unit tests incl. strict-greater boundary and overshoot-past-home; az single-jog with signed direction incl. negative slope; no-jog-when-in-tol; stuck-motor warn + no re-zero; pot-lost mid-sequence; skip-vs-fallback on dead potmon; el loop semantics preserved), `test_motor_zeroer.py` / `test_motor_scripts.py` (fallback-flag plumbing, unconverged-home notices), `test_client.py` (degraded status warning, guard-trip no-re-park). Full motor + field_zero + client test files pass locally; `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
