### PR TITLE
fix(fpga): integration_time is the fabric-clock dump period, not per-bank

### DIFF
--- a/src/eigsep_observing/config/corr_config.yaml
+++ b/src/eigsep_observing/config/corr_config.yaml
@@ -7,8 +7,8 @@ use_ref: false  # use synth on snap to generate adc clock from 10 MHz ref
 use_noise: false  # use digital noise instead of ADC data
 adc_gain: 4
 fft_shift: 0x015F
-corr_acc_len: 0x10000000  # 2**28 - increment corr_acc_cnt by ~2/second (v2.4)
-#corr_acc_len: 0x04000000  # 2**26 - increment corr_acc_cnt by ~8/second
+corr_acc_len: 0x10000000  # 2**28 fabric clocks (250 MHz): 1 tick / 1.074 s
+#corr_acc_len: 0x04000000  # 2**26 fabric clocks: 1 tick / 0.268 s
 corr_scalar: 512  # 2**9 - 8 bits after binary point so 2**9 = 1
 corr_word: 4  # 4 bytes per word
 # acc_bins / avg_even_odd are DECLARED defaults only. The producer

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -359,7 +359,6 @@ class EigsepFpga:
         self.cfg["integration_time"] = calc_inttime(
             self.cfg["sample_rate"] * 1e6,
             self.cfg["corr_acc_len"],
-            acc_bins=acc_bins,
         )
 
     @property
@@ -421,7 +420,6 @@ class EigsepFpga:
         t_int = calc_inttime(
             sample_rate * 1e6,  # in Hz
             corr_acc_len,
-            acc_bins=acc_bins,
         )
         m = {
             "snap_ip": self.cfg["snap_ip"],

--- a/src/eigsep_observing/utils.py
+++ b/src/eigsep_observing/utils.py
@@ -63,9 +63,24 @@ def calc_freqs_dfreq(sample_rate_Hz, nchan):
     return freqs, dfreq
 
 
-def calc_inttime(sample_rate_Hz, acc_len, acc_bins=2):
-    """Calculate time per integration [s] from sample_freq and acc_len."""
-    inttime = 1 / sample_rate_Hz * acc_len * acc_bins
+# The SNAP ADC delivers ADC_DEMUX samples per FPGA fabric clock
+# (demux-2: 500 Msps ADC, 250 MHz fabric). Registers that count
+# "clocks" (corr_acc_len, sync uptime) tick at sample_rate / ADC_DEMUX.
+ADC_DEMUX = 2
+
+
+def calc_inttime(sample_rate_Hz, acc_len):
+    """
+    Calculate time per integration [s] from sample_freq and acc_len.
+
+    ``acc_len`` (the ``corr_acc_len`` register) sets the vacc dump
+    period in FPGA fabric clocks, which run at
+    ``sample_rate / ADC_DEMUX``. The number of accumulator bins the
+    firmware emits per dump (even/odd in v2.3, one spectrum in v2.4)
+    does not enter the timing: v2.4 accumulates the same window into
+    one full-duty bin instead of two half-duty banks.
+    """
+    inttime = 1 / sample_rate_Hz * acc_len * ADC_DEMUX
     return inttime
 
 
@@ -113,7 +128,7 @@ def load_config(name, compute_inttime=True):
         Path to the configuration file.
     compute_inttime : bool
         If True, compute and inject ``integration_time`` from
-        ``sample_rate``, ``corr_acc_len``, and ``acc_bins``.
+        ``sample_rate`` and ``corr_acc_len``.
 
     Returns
     -------
@@ -127,11 +142,9 @@ def load_config(name, compute_inttime=True):
     if compute_inttime:
         sample_rate = config["sample_rate"]
         corr_acc_len = config["corr_acc_len"]
-        acc_bins = config["acc_bins"]
         config["integration_time"] = calc_inttime(
             sample_rate * 1e6,  # in Hz
             corr_acc_len,
-            acc_bins=acc_bins,
         )
     return config
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,11 +6,44 @@ import pytest
 from unittest.mock import Mock, patch
 
 from eigsep_observing.utils import (
+    calc_inttime,
     configure_eig_logger,
     get_config_path,
+    load_config,
     require_panda,
     require_snap,
 )
+
+
+class TestCalcInttime:
+    """Vacc dump-period semantics of calc_inttime.
+
+    ``corr_acc_len`` counts FPGA fabric clocks, and the SNAP fabric
+    runs at ``sample_rate / 2`` (demux-2: the ADC delivers two samples
+    per fabric clock). The dump period is therefore
+    ``acc_len * 2 / sample_rate`` regardless of whether the firmware
+    emits even/odd banks (v2.3, acc_bins=2) or a single spectrum
+    (v2.4, acc_bins=1). Measured on hardware 2026-07-09 (fpg v2.4):
+    240-row files land every ~257.7 s = 240 x 1.0737 s.
+    """
+
+    def test_dump_period_production_registers(self):
+        assert calc_inttime(500e6, 2**28) == pytest.approx(
+            1.073741824, rel=1e-12
+        )
+
+    def test_readout_mode_cannot_enter_timing(self):
+        # acc_bins describes the readout payload structure, not the
+        # timing; the v2.4 header bug (t_int halved, times drifting to
+        # 2x wall clock) came from multiplying it into this formula.
+        with pytest.raises(TypeError):
+            calc_inttime(500e6, 2**28, acc_bins=1)
+
+    def test_load_config_computes_dump_period(self):
+        # corr_config.yaml declares the v2.4 layout (acc_bins: 1); the
+        # computed integration_time must still be the dump period.
+        cfg = load_config(get_config_path("corr_config.yaml"))
+        assert cfg["integration_time"] == pytest.approx(1.073741824, rel=1e-12)
 
 
 class TestRequirePandaDecorator:


### PR DESCRIPTION
## Summary

- `corr_acc_len` sets the vacc dump period in **FPGA fabric clocks** (250 MHz = `sample_rate / 2`, the SNAP's demux-2), so the true integration cadence is `acc_len * 2 / sample_rate` — independent of how many accumulator bins the firmware emits per dump.
- `calc_inttime` multiplied by `acc_bins` instead. That gave the right answer on v2.3 firmware only because `acc_bins` (2) happened to equal the demux factor (2). On v2.4 (`acc_bins=1`) the header `integration_time` halved to 0.5369 s while the SNAP kept dumping every 1.0737 s, so file `times` ran 2x faster than wall clock (+129 s drift per 240-row file; a file written 18:26Z carried times of 00:39Z after 18 h).
- Fix: `calc_inttime(sample_rate_Hz, acc_len)` uses the new `ADC_DEMUX = 2` constant and no longer accepts `acc_bins`; `acc_bins` keeps describing the readout payload structure (`calc_integration_len`, `avg_even_odd`) where it belongs. Also corrects the stale `corr_acc_len` comment in `corr_config.yaml` ("~2/second" — the measured rate is ~0.93/s).

## Evidence (2026-07-09 v2.4 field data)

- Mean corr-file spacing 257.7 s / 240 rows = **1.0738 s/row** (vs 2^28/250 MHz = 1.07374 s); `acc_cnt` contiguous +1 across files.
- Radiometer check on RFANT rows (150–220 MHz): sigma/mu ~ 2.0e-3 -> tau_eff ~ 1 s per row. The v2.4 single bin is **full-duty** over the dump window — no data was lost, only the header cadence was wrong.
- v2.3 `avg_even_odd` files already carried the correct 1.0737 s.

## Test plan

- New `TestCalcInttime` in `tests/test_utils.py` (written first, watched fail):
  - pins the production dump period `calc_inttime(500e6, 2**28) == 1.073741824`
  - asserts `acc_bins` can no longer be passed into the timing formula (`TypeError`)
  - end-to-end: `load_config(corr_config.yaml)` (which declares `acc_bins: 1`) computes `integration_time == 1.0737`
- `pytest tests/test_utils.py tests/test_fpga.py tests/test_io.py` green locally (203 tests); CI runs the full suite.

Existing on-disk v2.4 files are unaffected by design (test data only); offline correction is `times = sync_time + acc_cnt * 1.073741824`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)