### PR TITLE
feat(io): sensor_rejects in _PELTIER_SCHEMA with max reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ directly from `SENSOR_SCHEMAS`:
 | schema type | reduction                                       | rationale |
 |-------------|-------------------------------------------------|-----------|
 | `float`     | `np.mean` over non-error survivors              | the actual averaging path; matches the integration's physical meaning |
-| `int`       | `min` over non-error survivors                  | every int field today is an invariant constant (`app_id`, `watchdog_timeout_ms`, the motor's per-boot `boot_id`) — `min` is a no-op on agreement, and a disagreement is caught by the throttled invariant ERROR log path |
+| `int`       | `min` over non-error survivors; `max` for fields in `_MAX_REDUCED_FIELDS` | invariant constants (`app_id`, `watchdog_timeout_ms`, the motor's per-boot `boot_id`) — `min` is a no-op on agreement, and a disagreement is caught by the throttled invariant ERROR log path. Worst-case counters that reset on every good sample (tempctrl's `sensor_rejects` rate-guard reject counter) take `max` instead, so an any-reject-in-window integration stays identifiable — `min` would wash the marker back to 0 |
 | `bool`      | `any` over non-error survivors                  | bool fields are fault flags (`watchdog_tripped`); `any` preserves a fault that occurred mid-integration |
 | `str`       | first value if unanimous, else `"UNKNOWN"`      | matches the rfswitch convention |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=4.2",
+  # >=4.3: tempctrl per-channel sensor_rejects in the stream fan-out
+  # (pico-firmware #150); _PELTIER_SCHEMA requires the key.
+  "picohost>=4.3",
   "eigsep-vna>=1.4",
   "eigsep_redis>=2.3",
 ]

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -33,7 +33,13 @@ import numpy as np
 import pytest
 import yaml
 from picohost import PicoPotentiometer
-from picohost.base import PicoIMU, PicoLidar, PicoPeltier, PicoRFSwitch
+from picohost.base import (
+    PicoIMU,
+    PicoLidar,
+    PicoPeltier,
+    PicoRFSwitch,
+    redis_handler,
+)
 from picohost.motor import PicoMotor
 from picohost.testing import (
     ImuEmulator,
@@ -94,21 +100,30 @@ def _potmon_post_handler_reading():
 
 
 def _motor_post_handler_reading():
-    """Return a motor reading after _motor_redis_handler.
+    """Return a motor reading after the full publish boundary.
 
     The actual ``motor`` producer is the composition
     ``MotorEmulator.get_status()`` + ``PicoMotor._motor_redis_handler``
-    — the emulator (and the C firmware) emit position fields as
-    ``int`` (raw step counts), and the device handler is where they
-    are coerced to ``float`` so the consumer-side reduction picks the
-    float→mean policy rather than int→min. The contract this test
-    enforces is the *post-handler* shape (what reaches Redis), so the
-    fixture has to compose the two. Mirrors
-    ``_potmon_post_handler_reading``.
+    + the ``picohost.base.redis_handler`` publish closure. The emulator
+    (and the C firmware) emit position fields as ``int`` (raw step
+    counts); since picohost 4.3 the float cast lives in the publish
+    closure (``PicoMotor._REDIS_FLOAT_FIELDS``), not in
+    ``_motor_redis_handler`` itself, so the consumer-side reduction
+    picks the float→mean policy rather than int→min. The contract this
+    test enforces is the shape that reaches Redis, so the fixture
+    composes all three, with a capture-only writer standing in for the
+    ``MetadataWriter``. Mirrors ``_potmon_post_handler_reading``.
     """
+
+    class _CaptureWriter:
+        def add(self, name, data):
+            captured.update(data)
+
     motor = PicoMotor.__new__(PicoMotor)
     captured = {}
-    motor._base_redis_handler = lambda d: captured.update(d)
+    motor._base_redis_handler = redis_handler(
+        _CaptureWriter(), PicoMotor._REDIS_FLOAT_FIELDS
+    )
     # The handler also drives the position checkpoint / boot-detection
     # path (picohost 3.7.0); a None store makes it inert. This test is
     # about the published payload shape, not the checkpoint logic —

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -802,8 +802,9 @@ def _validate_corr_header(header):
 #
 # Type → averaging policy in _avg_sensor_values:
 #   float → np.mean over non-error samples (the "real" averaging path)
-#   int   → min over non-error samples (worst-case for cal levels;
-#           no-op for the constants)
+#   int   → min over non-error samples (no-op for the invariant
+#           constants), except _MAX_REDUCED_FIELDS → max (worst-case
+#           for reject counters)
 #   bool  → any over non-error samples (worst-case for fault flags)
 #   str   → first value if unanimous, else "UNKNOWN"
 # See _avg_sensor_values for details and the rationale per type.
@@ -887,6 +888,16 @@ _PELTIER_SCHEMA = {
     "sensor_tripped": bool,
     "stall_tripped": bool,
     "runaway_tripped": bool,
+    # Rate-guard reject counter (pico-firmware #150): the rate guard is
+    # control-only, so rejected-but-plausible conversions are still
+    # reported (status="update", real values) with this per-channel
+    # counter as the cross-check marker. It increments once per
+    # consecutive rejected sample and resets to 0 on an accepted one,
+    # so any nonzero value inside an integration means at least one
+    # averaged-in sample was rate-guard-rejected. Reduces via max —
+    # see _MAX_REDUCED_FIELDS; the default int min would wash a
+    # mid-integration burst back to 0 and delete the marker.
+    "sensor_rejects": int,
     # Asymmetric-clamp safety setting (False forbids drive<0). Reduces
     # via `any` like every other bool config field; a mid-integration
     # toggle is an operator action and rare enough that surfacing
@@ -1361,18 +1372,30 @@ def _avg_rfswitch_metadata(value):
 # reduction in _avg_sensor_values already encodes the disagreement in
 # the saved value (`any` for bools, `"UNKNOWN"` for strings) so
 # downstream can detect the issue from the file alone. Note that
-# post-picohost-1.0.0, every `int` field in SENSOR_SCHEMAS reaching
-# _avg_sensor_values is in _INVARIANT_FIELDS — rfswitch's raw
-# `sw_state` int and human-readable `sw_state_name` are both handled
-# by _avg_rfswitch_metadata, not _avg_sensor_values. The int `min`
-# reduction is therefore a no-op-on-agreement safety net behind the
-# invariant ERROR log path; if a future schema adds a legitimately
-# varying int, the disagreement is silently captured by `min` rather
-# than logged.
+# rfswitch's raw `sw_state` int and human-readable `sw_state_name` are
+# both handled by _avg_rfswitch_metadata, not _avg_sensor_values. Every
+# int field reaching _avg_sensor_values is either in _INVARIANT_FIELDS
+# (where `min` is a no-op-on-agreement safety net behind the invariant
+# ERROR log path) or in _MAX_REDUCED_FIELDS (legitimately-varying
+# worst-case counters, where the saved `max` encodes the disagreement
+# silently, like bool `any`). A future schema int that is neither gets
+# `min` with the disagreement silently captured rather than logged —
+# decide which set it belongs in when adding it.
 # ----------------------------------------------------------------------
 _INVARIANT_FIELDS = frozenset(
     {"sensor_name", "app_id", "watchdog_timeout_ms", "boot_id"}
 )
+
+# Int fields that reduce via max() instead of min(). These are the
+# legitimately-varying ints: worst-case counters where an integration
+# that saw even one nonzero sample must stay identifiable after
+# reduction. The producer resets such counters to 0 on every good
+# sample, so `min` would wash a mid-integration burst back to 0 and
+# delete the marker from the corr record. Disagreement is silent by
+# design — the saved max already encodes it, exactly like bool `any`.
+# Today: tempctrl's per-channel rate-guard reject counter (issue #207,
+# pico-firmware #150).
+_MAX_REDUCED_FIELDS = frozenset({"sensor_rejects"})
 _INVARIANT_LOG_THROTTLE_S = 60.0
 _last_invariant_log = {}  # {(app_name, field): unix_timestamp}
 
@@ -1429,7 +1452,8 @@ def _avg_sensor_values(value, schema=None, *, app_name=""):
     type  reduction                                              filter errored?
     ====  ====================================================  =========================
     float ``np.mean`` over surviving samples                    yes
-    int   ``min`` over surviving samples (worst-case)           yes
+    int   ``min`` over surviving samples (worst-case); ``max``  yes
+          for :data:`_MAX_REDUCED_FIELDS` (reject counters)
     bool  ``any`` over surviving samples (fault-flag worst-case)yes
     str   first value if unanimous, else ``"UNKNOWN"``          yes
     ====  ====================================================  =========================
@@ -1528,7 +1552,10 @@ def _avg_sensor_values(value, schema=None, *, app_name=""):
             else:
                 if data_key in _INVARIANT_FIELDS and len(set(ints)) > 1:
                     _log_invariant_disagreement(app_name, data_key, ints)
-                avg[data_key] = min(ints)
+                if data_key in _MAX_REDUCED_FIELDS:
+                    avg[data_key] = max(ints)
+                else:
+                    avg[data_key] = min(ints)
         elif typ is bool:
             bools = [s for s in survivors if isinstance(s, bool)]
             avg[data_key] = any(bools) if bools else None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -897,7 +897,8 @@ def test_avg_metadata_tempctrl_watchdog_fields_survive_split():
 # Per-type reduction policy in _avg_sensor_values (Design C):
 #
 #   float → np.mean over non-error survivors
-#   int   → min over non-error survivors (worst-case for cal levels)
+#   int   → min over non-error survivors (no-op for the invariant
+#           constants); max for _MAX_REDUCED_FIELDS (reject counters)
 #   bool  → any over non-error survivors (worst-case for fault flags)
 #   str   → first if unanimous, else "UNKNOWN"
 #
@@ -951,6 +952,25 @@ def test_avg_metadata_bool_any_on_disagreement():
     ]
     result = io.avg_metadata(data)
     assert result["watchdog_tripped"] is True
+
+
+def test_avg_metadata_sensor_rejects_max_on_disagreement():
+    """``sensor_rejects`` reduces via max() — the any-reject-in-window
+    cross-check marker (issue #207). The firmware counter resets to 0
+    on every accepted sample, so the default int reduction (min, a
+    no-op for the invariant constants) would wash a mid-integration
+    reject burst back to 0 and delete the marker from the corr record."""
+    base = tempctrl_post_handler_reading("tempctrl_lna")
+    base["T_now"] = 30.0
+    base["timestamp"] = 1.0
+    data = [
+        {**base, "sensor_rejects": 0},
+        {**base, "sensor_rejects": 2},  # reject burst mid-integration
+        {**base, "sensor_rejects": 0},  # accepted sample reset the counter
+    ]
+    result = io.avg_metadata(data)
+    assert result["sensor_rejects"] == 2
+    assert isinstance(result["sensor_rejects"], int)
 
 
 def test_avg_metadata_str_unknown_on_disagreement_for_non_invariant():


### PR DESCRIPTION
Closes #207.

## What

EIGSEP/pico-firmware#150 (merged 2026-07-09) makes the tempctrl rate guard control-only: every plausible ADC conversion is reported (`status="update"`, real values), with a per-channel `sensor_rejects` counter marking rejected-but-reported samples. `status="error"` is now reserved for cycles with no measurement at all.

- **`"sensor_rejects": int` added to `_PELTIER_SCHEMA`** so the marker lands in the corr record instead of tripping the extra-keys contract warning.
- **`max` reduction instead of the default int `min`.** The firmware counter resets to 0 on every accepted sample, so `min` over an averaging window washes a mid-integration reject burst back to 0 — deleting exactly the marker the field exists to carry. A new `_MAX_REDUCED_FIELDS` set routes it through `max` (any-reject-in-window stays identifiable), mirroring the bool `any` worst-case policy. Disagreement is silent by design: the saved max already encodes it.
- **Reduction-policy docs updated** (CLAUDE.md table, `_avg_sensor_values` docstring, the `_INVARIANT_FIELDS` comment block — which claimed every int reaching `_avg_sensor_values` is invariant; `sensor_rejects` is the first legitimately-varying int).
- **`picohost>=4.3` pin** — the release that carries the stream fan-out for the new field.
- **Motor contract fixture composes the picohost 4.3 publish closure** (second commit): 4.3 moves the motor position float cast out of `_motor_redis_handler` into the shared `redis_handler(writer, float_fields)` closure; the fixture's raw capture lambda bypassed exactly that layer, so `az_pos` surfaced as int and the fixture's float-or-None assertion failed. The stub is now built from picohost's own `redis_handler` factory. In scope here because the pin bump is what pulls in 4.3.

## Merge gate

**Blocked on the picohost 4.3.0 release** (pico-firmware main is still versioned 4.2.0). CI runs `uv sync --frozen`, so it installs picohost 4.2.0 from the lock and the tempctrl contract tests fail with `missing keys: ['sensor_rejects']` — the honest red for this gate. Once 4.3.0 is on PyPI: `uv lock --upgrade-package picohost`, push, CI goes green. Same shape as #192.

## Verification

Run locally against picohost built from pico-firmware main (tarball install):

- `tests/test_io.py` + `contract_tests/test_producer_contracts.py`: 121 passed (including the new `test_avg_metadata_sensor_rejects_max_on_disagreement`, watched fail first: `KeyError: 'sensor_rejects'` pre-schema, then `0 != 2` under `min`)
- All tempctrl-touching test files (`test_tempctrl_manual`, `test_live_status_{aggregator,app,thresholds}`, `test_integration`, `test_tempctrl_client`, `test_client`, `test_io`): 424 passed
- `ruff check` / `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)