### PR TITLE
fix(fpga): 0.25 s TAPCP timeout + slow-transaction log

### DIFF
--- a/src/eigsep_observing/config/corr_config.yaml
+++ b/src/eigsep_observing/config/corr_config.yaml
@@ -1,4 +1,14 @@
 snap_ip: "10.10.10.12"
+# Per-transfer TAPCP/tftpy socket timeout [s]. tftpy recovers a lost
+# UDP packet only by waiting out this timeout before retransmitting,
+# so it sets the stall cost of a single lost packet on the SNAP link.
+# casperfpga's default of 3 s spans 2-3 integration windows at
+# corr_acc_len 2**28 and was the root cause of the periodic
+# "Dropped 2 integration(s)" warnings (issue #204). 0.25 s is ~100x
+# the observed per-block readout cadence, so only a genuinely lost
+# packet ever waits this long; casperfpga's 8 transaction-level
+# retries are unaffected. Absent -> defaults to 0.25.
+tapcp_timeout_s: 0.25
 fpg_file: "eigsep_fengine_1g_v2_4_2026-06-23_2052.fpg"  # path to fpg file
 fpg_version: [2, 4]  # major, minor
 sample_rate: 500.0  # in MHz

--- a/src/eigsep_observing/fpga.py
+++ b/src/eigsep_observing/fpga.py
@@ -109,21 +109,53 @@ class _FpgaLockProxy:
     Non-callable attributes are returned without locking — they're
     pure state lookups (``host``, ``snap_ip``, etc.) that don't touch
     the transport.
+
+    Every locked call is timed, and one that waits on or holds the
+    lock longer than ``slow_call_s`` logs a WARNING with both
+    durations. This is the in-band stall detector for issue #204: a
+    lost UDP packet blocks the caller for the full tftpy timeout
+    before the retransmit (casperfpga itself only logs after a *full*
+    multi-retry ``TftpTimeout``, never for a single recovered resend),
+    and whichever thread eats that stall holds the shared lock — so a
+    long *hold* means this call stalled on the wire, while a long
+    *wait* means another thread's call did. Normal transactions are
+    single-digit ms, so the detector is silent at the corr poll's
+    ~100 Hz cadence and fires roughly once per stall event.
     """
 
-    def __init__(self, fpga, lock):
+    def __init__(self, fpga, lock, slow_call_s=0.25):
         self._fpga = fpga
         self._lock = lock
+        self._slow_call_s = slow_call_s
 
     def __getattr__(self, name):
         attr = getattr(self._fpga, name)
         if not callable(attr):
             return attr
         lock = self._lock
+        slow_call_s = self._slow_call_s
 
         def wrapped(*args, **kwargs):
+            t_request = time.perf_counter()
             with lock:
-                return attr(*args, **kwargs)
+                t_acquire = time.perf_counter()
+                try:
+                    return attr(*args, **kwargs)
+                finally:
+                    t_done = time.perf_counter()
+                    waited = t_acquire - t_request
+                    held = t_done - t_acquire
+                    if max(waited, held) > slow_call_s:
+                        logger.warning(
+                            "Slow FPGA transaction: %s held the TAPCP "
+                            "lock for %.0f ms (waited %.0f ms to "
+                            "acquire it). A hold near tapcp_timeout_s "
+                            "is a lost-packet retransmit stall "
+                            "(issue #204).",
+                            name,
+                            held * 1e3,
+                            waited * 1e3,
+                        )
 
         return wrapped
 
@@ -257,9 +289,22 @@ class EigsepFpga:
         Construct the underlying CasperFpga object. Hookable so tests
         can substitute an in-memory register backend without patching
         casperfpga itself (which may not be importable in dev envs).
+
+        ``timeout`` reaches ``TapcpTransport`` through ``CasperFpga``'s
+        kwarg forwarding (contract pinned in
+        ``tests/test_casperfpga_api.py``) and sets the per-transfer
+        tftpy socket timeout — the stall a single lost UDP packet
+        costs before the retransmit. The casperfpga default of 3 s
+        spans 2–3 integration windows at ``corr_acc_len=2**28``, which
+        was the periodic "Dropped 2 integration(s)" of issue #204.
+        Transaction-level retries (8 in the fork's ``read``) are
+        unaffected, so a genuinely dead SNAP still fails loudly —
+        only ~10x faster.
         """
         return casperfpga.CasperFpga(
-            self.cfg["snap_ip"], transport=TapcpTransport
+            self.cfg["snap_ip"],
+            transport=TapcpTransport,
+            timeout=self.cfg.get("tapcp_timeout_s", 0.25),
         )
 
     def _wrap_fpga(self, raw):

--- a/tests/test_casperfpga_api.py
+++ b/tests/test_casperfpga_api.py
@@ -195,3 +195,31 @@ def test_casperfpga_constructor_uses_transport_kwarg():
         casperfpga.CasperFpga("dummyhost", transport=RecorderTransport)
 
     assert instances, "CasperFpga.__init__ did not honor transport=... kwarg"
+
+
+def test_casperfpga_forwards_timeout_kwarg_to_transport():
+    # ``EigsepFpga._make_fpga`` passes ``timeout=cfg["tapcp_timeout_s"]``
+    # relying on ``CasperFpga.__init__`` forwarding its ``**kwargs`` to
+    # the transport constructor (``transport(**kwargs)``), where
+    # ``TapcpTransport`` reads ``kwargs.get('timeout', 3)`` — the 3 s
+    # default being the per-lost-packet stall behind issue #204. Same
+    # recording-stub pattern as the transport-kwarg test above; if the
+    # fork ever stops forwarding constructor kwargs, ``timeout`` goes
+    # missing here and the field silently reverts to 3 s stalls.
+    instances = []
+
+    class RecorderTransport:
+        def __init__(self, **kwargs):
+            instances.append(kwargs)
+            raise RuntimeError("stop after transport ctor")
+
+    with pytest.raises(RuntimeError, match="stop after transport ctor"):
+        casperfpga.CasperFpga(
+            "dummyhost", transport=RecorderTransport, timeout=0.25
+        )
+
+    assert instances, "CasperFpga.__init__ did not honor transport=... kwarg"
+    assert instances[0].get("timeout") == 0.25, (
+        "CasperFpga.__init__ did not forward timeout=... to the "
+        "transport constructor"
+    )

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -5,11 +5,13 @@ from contextlib import contextmanager
 from copy import deepcopy
 from queue import Queue
 from threading import Event
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import Mock, patch
 
 from eigsep_observing import corr as corr_mod
+from eigsep_observing import fpga as fpga_mod
 from eigsep_observing.fpga import _FpgaLockProxy, default_config
 from eigsep_observing.keys import CORR_STREAM
 from eigsep_observing.testing import DummyEigsepFpga, utils
@@ -1241,6 +1243,106 @@ class TestFpgaLockProxy:
         lookups on the underlying object."""
         # DummyFpga sets ``snap_ip`` as a plain attribute.
         assert fpga_instance.fpga.snap_ip == fpga_instance.fpga._fpga.snap_ip
+
+    def test_slow_transaction_logs_warning(self, caplog):
+        """A locked call that exceeds ``slow_call_s`` logs a WARNING
+        naming the method. This is the in-band stall detector for
+        issue #204: a tftpy lost-packet retransmit blocks the caller
+        for the full TAPCP timeout, and without this log the stall is
+        invisible (casperfpga only logs after a *full* 5-retry
+        TftpTimeout, never for a single recovered resend)."""
+
+        class SlowFpga:
+            def read_int(self, reg):
+                time.sleep(0.05)
+                return 7
+
+        proxy = _FpgaLockProxy(SlowFpga(), threading.Lock(), slow_call_s=0.01)
+        with caplog.at_level(logging.WARNING, logger="eigsep_observing"):
+            assert proxy.read_int("corr_acc_cnt") == 7
+        slow_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "read_int" in r.message
+        ]
+        assert len(slow_records) == 1
+        # Both durations ride in the message: a long *hold* means this
+        # call stalled on the wire; a long *wait* means another thread
+        # held the lock. The distinction is the whole point of the
+        # instrumentation, so both must be visible to the operator.
+        assert "held" in slow_records[0].message
+        assert "waited" in slow_records[0].message
+
+    def test_fast_transaction_logs_nothing(self, caplog):
+        """Normal-speed calls (the ~100 Hz corr poll) stay silent —
+        the detector must not spam the journal at the poll cadence."""
+
+        class FastFpga:
+            def read_int(self, reg):
+                return 7
+
+        proxy = _FpgaLockProxy(FastFpga(), threading.Lock())
+        with caplog.at_level(logging.WARNING, logger="eigsep_observing"):
+            assert proxy.read_int("corr_acc_cnt") == 7
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestMakeFpgaTapcpTimeout:
+    """``EigsepFpga._make_fpga`` must plumb ``cfg["tapcp_timeout_s"]``
+    into the casperfpga transport (issue #204). The transport's
+    default tftpy timeout of 3 s makes any single lost UDP packet
+    stall the caller across 2–3 integration windows at
+    ``corr_acc_len=2**28`` — the periodic "Dropped 2 integration(s)"
+    signature. ``CasperFpga`` forwards ``**kwargs`` to the transport
+    constructor, which reads ``kwargs.get('timeout', 3)``; the
+    forwarding contract is pinned in ``test_casperfpga_api.py``."""
+
+    def _record_make_fpga(self, fpga_instance, monkeypatch):
+        """Run the *production* ``_make_fpga`` against a recording
+        CasperFpga stub. The stub replaces the module-level
+        ``casperfpga`` symbol (absent entirely when the optional
+        hardware dep isn't installed, hence ``raising=False``) — the
+        same boundary-recorder pattern as ``test_casperfpga_api.py``,
+        because ``DummyFpga`` substitutes the whole factory and can't
+        see these kwargs."""
+        calls = []
+
+        class RecorderCasperFpga:
+            def __init__(self, *args, **kwargs):
+                calls.append((args, kwargs))
+
+        monkeypatch.setattr(
+            fpga_mod,
+            "casperfpga",
+            SimpleNamespace(CasperFpga=RecorderCasperFpga),
+            raising=False,
+        )
+        sentinel_transport = object()
+        monkeypatch.setattr(fpga_mod, "TapcpTransport", sentinel_transport)
+        fpga_mod.EigsepFpga._make_fpga(fpga_instance)
+        assert len(calls) == 1
+        args, kwargs = calls[0]
+        assert args == (fpga_instance.cfg["snap_ip"],)
+        assert kwargs["transport"] is sentinel_transport
+        return kwargs
+
+    def test_timeout_plumbed_from_config(self, fpga_instance, monkeypatch):
+        fpga_instance.cfg["tapcp_timeout_s"] = 0.5
+        kwargs = self._record_make_fpga(fpga_instance, monkeypatch)
+        assert kwargs["timeout"] == 0.5
+
+    def test_timeout_defaults_when_key_absent(
+        self, fpga_instance, monkeypatch
+    ):
+        """Configs predating the knob get the fix, not the old 3 s."""
+        fpga_instance.cfg.pop("tapcp_timeout_s", None)
+        kwargs = self._record_make_fpga(fpga_instance, monkeypatch)
+        assert kwargs["timeout"] == 0.25
+
+    def test_default_config_ships_the_knob(self):
+        """The shipped corr_config.yaml sets the knob explicitly so
+        the field value is visible in the file, not just in code."""
+        assert default_config["tapcp_timeout_s"] == 0.25
 
 
 _MUX_DEPLOY_WIRING = {


### PR DESCRIPTION
Fixes #204.

## Root cause

Field runs at `corr_acc_len=2**28` dropped almost exactly 2 integrations every ~10–20 s despite a 103 ms readout. tftpy recovers a lost UDP packet only by waiting out the per-transfer socket timeout before retransmitting, and casperfpga's default is **3 s** — spanning 2–3 of the true ~1.07 s integration windows, i.e. exactly the "Dropped 2 integration(s)" signature. The corr poll's ~100 TAPCP transactions/s dominate the traffic (the 1 Hz diagnostics thread is only ~4%), so most stalls hit the poll itself; a stall inside `read_data` additionally produces the observed occasional torn-read drop.

Note the issue text's arithmetic needs correcting: the true v2.4 tick is ~1.074 s (the 0.537 s header value is the known 2×-compression), so the loss was ~19%, not 9% — and a 3 s stall at the true tick predicts "Dropped 2", which is what pins this root cause.

## Changes

- **`tapcp_timeout_s` config knob (default 0.25 s)**, plumbed `_make_fpga` → `CasperFpga(**kwargs)` → `TapcpTransport`. A single lost packet now costs 250 ms — inside the integration window, so no drop. casperfpga's 8 transaction-level retries are unaffected; a dead SNAP still fails loudly, just ~10× faster.
- **Slow-transaction detector in `_FpgaLockProxy`**: any locked call that waits for or holds the lock longer than `slow_call_s` (0.25 s) logs a WARNING with the method name and both durations. A single recovered tftpy resend is otherwise invisible (casperfpga only logs full multi-retry `TftpTimeout`s). Long *hold* = this call stalled on the wire; long *wait* = another thread's call did.
- **Consumer-contract test** in `test_casperfpga_api.py` pinning that `CasperFpga.__init__` forwards `timeout=` to the transport constructor (runs in the `test-with-casperfpga` CI job).

## Field validation plan

- Fix arm (~30–60 min): expect zero "Dropped"/torn-read warnings (baseline ~5 events/min), flat `dropped_integrations` in `eigsep:corr_health`, and occasional `Slow FPGA transaction: read_int held ~250–300 ms` warnings at roughly the old stall rate — each one a caught-and-neutralized packet loss.
- Reverse A/B (conclusive): set `tapcp_timeout_s: 3.0`, restart — drops should return at the old rate, now attributed by ~3000 ms slow-transaction warnings. Flip back to 0.25.

## Tests

TDD: the timeout plumb (recorder stub at the casperfpga boundary, watched fail first), slow-call warning + silence-when-fast, and the shipped-config knob. `tests/test_fpga.py`: 74 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)