### PR TITLE
feat(live_status): gate signals/thresholds from panda's Redis config upload

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -353,9 +353,16 @@ the LNA connector):**
    stream key (`stream:tempctrl_load`), its `metadata` hash fields
    (`tempctrl_load`, `tempctrl_load_ts`), and its `metadata_streams`
    set entry.
-5. Restart `panda_observe`, and restart the live-status dashboard after
-   updating **its** copy of `obs_config.yaml` too — signal gating reads
-   the dashboard host's local file, not the panda's upload.
+5. Restart `panda_observe`. The live-status dashboard follows on its
+   own: signal gating, tempctrl bands, and the display calibration's
+   `t_load_stream` prefer the panda's Redis config upload over the
+   dashboard host's local file, so the restarted `panda_observe`'s
+   upload re-gates the dashboard within a tick — no dashboard-side
+   config edit or restart. During the swap window itself the dashboard
+   still renders the *last* upload's tiles (empty for the retired
+   channel); they self-heal at this step. Still sync the dashboard
+   host's `obs_config.yaml` when convenient — it remains the fallback
+   when no upload has ever landed on the panda Redis.
 6. Verify with `pico_preflight` (the retired row reads "no stream
    (channel uninstalled or producer fault)") and the dashboard cal
    panel.

--- a/src/eigsep_observing/live_status/__init__.py
+++ b/src/eigsep_observing/live_status/__init__.py
@@ -4,6 +4,7 @@ from .signals import (
     Signal,
     SIGNAL_REGISTRY,
     default_thresholds,
+    effective_obs_cfg,
     enabled_signals,
 )
 from .thresholds import Thresholds
@@ -16,5 +17,6 @@ __all__ = [
     "Thresholds",
     "create_app",
     "default_thresholds",
+    "effective_obs_cfg",
     "enabled_signals",
 ]

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -24,10 +24,15 @@ Design notes
   VNA thread (:data:`_VNA_BLOCK_S`), which parks inside Redis between
   ~1/hour sweeps and wakes for the stop check on each timeout.
 
-- **Threshold recompute.** When ``corr_header["integration_time"]``
-  changes (re-sync), :meth:`_recompute_thresholds` rebuilds
-  :attr:`thresholds` so cadence and file-heartbeat bands track the
-  current run.
+- **Threshold recompute.** Two independent dirty flags rebuild
+  :attr:`thresholds`: when ``corr_header["integration_time"]``
+  changes (re-sync; :meth:`_maybe_recompute_thresholds`, SNAP tick),
+  cadence and file-heartbeat bands track the current run; when the
+  panda's Redis config upload changes
+  (:meth:`_maybe_recompute_config`, panda tick), signal gating and
+  the config-derived bands follow :attr:`obs_cfg_effective` — the
+  local YAML with the panda-reality slice overridden by the upload
+  (prefer-Redis-with-local-fallback, issue #194).
 
 - **Exception policy.** A transient reader exception (network blip,
   stream not yet registered, JSON decode hiccup) is caught per-call so
@@ -72,7 +77,7 @@ from ..snap_reinit import read as read_snap_reinit
 from ..utils import calc_freqs_dfreq
 from ..vna import VnaReader
 from ..vna_calibration import VnaCache
-from .signals import SIGNAL_REGISTRY
+from .signals import SIGNAL_REGISTRY, effective_obs_cfg
 from .snap_probe import probe_snap_fpga
 from .thresholds import Thresholds
 
@@ -219,7 +224,12 @@ class StateSnapshot:
     # (key ``"config"``). ``None`` when no panda script has ever uploaded
     # its config to this Redis. The dashboard reads ``switch_schedule``
     # from here rather than from the on-disk YAML, so a parked switch
-    # with no panda running shows no countdown.
+    # with no panda running shows no countdown. The panda-reality slice
+    # (``tempctrl_settings``, ``use_*`` gates, ``corr_ntimes``,
+    # ``calibration.t_load_stream``) is additionally merged over the
+    # local YAML into ``aggregator.obs_cfg_effective`` so signal gating
+    # and config-derived bands follow what panda is actually running
+    # (issue #194).
     # ``panda_config_upload_unix`` carries the ``upload_time`` field that
     # ``Transport.upload_dict`` stamps on every upload, so the dashboard
     # can show operators how old the published config is.
@@ -329,10 +339,16 @@ class LiveStatusAggregator:
     obs_cfg
         Loaded ``obs_config.yaml``. Read for ``corr_save_dir``,
         ``corr_ntimes``, ``use_tempctrl``, ``tempctrl_settings``
-        — Thresholds/signal-enablement plumbing. The active
-        ``switch_schedule`` comes from the panda's ``ConfigStore``
-        (Redis), not from this dict, so the dashboard's "next change"
-        countdown reflects what panda is actually running.
+        — Thresholds/signal-enablement plumbing. This dict is the
+        *local-fallback* layer only: once a panda script uploads its
+        config to the panda ``ConfigStore`` (Redis), the panda-reality
+        slice of that upload is merged over it into
+        :attr:`obs_cfg_effective` (see
+        :func:`signals.effective_obs_cfg`), which is what gating,
+        bands, and the display calibration actually consume. The
+        active ``switch_schedule`` likewise comes from the upload, so
+        the dashboard's "next change" countdown reflects what panda is
+        actually running.
     thresholds
         Optional pre-built :class:`Thresholds`. If ``None``, one is
         built from the bundled YAML and the first corr header seen.
@@ -361,6 +377,16 @@ class LiveStatusAggregator:
         self.transport_snap = transport_snap
         self.transport_panda = transport_panda
         self.obs_cfg = dict(obs_cfg)
+        # Effective config = local YAML with the panda-reality slice
+        # overridden by the panda's Redis upload once one lands (issue
+        # #194). Starts as a plain copy; _maybe_recompute_config swaps
+        # in a freshly-merged dict (never mutated in place, so Flask
+        # handlers can read the reference without the lock).
+        self.obs_cfg_effective = effective_obs_cfg(self.obs_cfg, None)
+        # Last upload merged into obs_cfg_effective — the dirty flag
+        # for _maybe_recompute_config (dict equality; uploads land once
+        # per panda session against a ~4 Hz tick).
+        self._merged_panda_cfg: Optional[dict] = None
         self._snap_tick_s = snap_tick_s
         self._panda_tick_s = panda_tick_s
         self._snap_fpga_probe_interval_s = snap_fpga_probe_interval_s
@@ -884,6 +910,49 @@ class LiveStatusAggregator:
         self.thresholds = self.thresholds.with_header(header)
         self._thresholds_int_time = new_int_time
 
+    def _maybe_recompute_config(self, panda_cfg: dict) -> None:
+        """Refresh obs_cfg_effective + thresholds on a new upload.
+
+        Called under ``self._lock`` from ``_panda_tick`` whenever the
+        panda ``ConfigStore`` read returned a config. Dirty flag is
+        dict equality against the last upload merged — cheap at the
+        ~4 Hz tick (uploads change once per panda session), and robust
+        to a producer that violates the ``upload_time`` stamp contract
+        (the stamp is display plumbing, not the change detector).
+
+        Rebuilding via :meth:`Thresholds.with_obs_cfg` preserves the
+        YAML override layer and the current corr header; the sibling
+        integration-time flag (``_thresholds_int_time``) is untouched
+        because the header didn't change. Both rebuild sites swap the
+        ``self.thresholds`` reference under the same lock, so the two
+        drain threads can't lose each other's update.
+        """
+        if panda_cfg == self._merged_panda_cfg:
+            return
+        # Record the upload before attempting the rebuild so a junk
+        # config logs one ERROR, not one per ~4 Hz tick; a corrected
+        # upload differs and retries.
+        self._merged_panda_cfg = panda_cfg
+        merged = effective_obs_cfg(self.obs_cfg, panda_cfg)
+        try:
+            thresholds = self.thresholds.with_obs_cfg(merged)
+        except Exception as exc:
+            # Narrow safety net (logs loudly per CLAUDE.md): the
+            # dashboard is the field's only alerting surface, so a
+            # malformed upload must not half-apply — keep the previous
+            # gating/bands/effective-config trio intact until the
+            # producer is fixed.
+            logger.error(
+                "panda config upload cannot build thresholds (%s); "
+                "keeping previous gating and bands. Producer contract: "
+                "obs_config tempctrl_settings/corr_ntimes must be "
+                "numeric per config/obs_config.yaml.",
+                exc,
+            )
+            return
+        self.obs_cfg_effective = merged
+        self.thresholds = thresholds
+
     def _maybe_load_linear_range(self, s: StateSnapshot) -> None:
         """Populate the per-channel linear-range bounds on ``s``.
 
@@ -1094,6 +1163,7 @@ class LiveStatusAggregator:
                         exc,
                     )
                     s.panda_config_upload_unix = None
+                self._maybe_recompute_config(panda_cfg)
 
             if host_h is not None:
                 s.host_health_panda = host_h
@@ -1301,6 +1371,7 @@ class LiveStatusAggregator:
             "transport_snap",
             "transport_panda",
             "obs_cfg",
+            "obs_cfg_effective",
             "corr_reader",
             "corr_config",
             "adc_snapshot_reader",

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -36,7 +36,6 @@ from .calibration import (
 from ..io import pair_label
 from ..vna_calibration import VnaCache, calibrate_s11
 from .orientation import compute_orientation
-from .signals import enabled_signals
 from .thresholds import Thresholds
 
 
@@ -391,9 +390,13 @@ def _metadata_payload(state: StateSnapshot, thresholds: Thresholds) -> dict:
             age_s = None
         status = value.get("status") if isinstance(value, dict) else None
         classify_by_sig: dict[str, str] = {}
-        # For every registered signal whose "domain" matches this
-        # sensor, run the classifier on the matching field.
-        for sig_name, sig in enabled_signals(thresholds.obs_cfg).items():
+        # For every enabled signal whose "domain" matches this sensor,
+        # run the classifier on the matching field. ``registry`` is the
+        # enabled-filtered view of the signal registry, built from the
+        # same obs_cfg the Thresholds instance was — the aggregator
+        # rebuilds it when the panda's config upload changes, so gating
+        # follows panda reality (issue #194).
+        for sig_name, sig in thresholds.registry.items():
             domain, _, field_ = sig_name.partition(".")
             if domain != sensor:
                 continue
@@ -717,19 +720,29 @@ def _config_payload(
 ) -> dict:
     """Surface configuration to the dashboard.
 
-    ``switch_schedule`` and ``config_upload_unix`` come from the
-    panda-side ``ConfigStore`` (Redis), so the panel shows what panda
-    last uploaded. They persist after panda exits — operators can read
-    ``config_upload_unix`` to see how stale the published config is.
-    The other fields (``tempctrl_settings``, ``corr_*``, ``use_*``)
-    still come from the on-disk ``obs_config.yaml`` the dashboard was
-    started with; they drive ``Thresholds`` rendering decisions, not
-    runtime claims about what panda is doing.
+    ``obs_cfg`` here is the aggregator's *effective* config: the local
+    YAML with the panda-reality slice (``tempctrl_settings``, ``use_*``
+    gates, ``corr_ntimes``, ``calibration.t_load_stream``) overridden
+    by the panda's Redis ``ConfigStore`` upload once one has landed
+    (issue #194). ``config_source`` records which side supplied that
+    slice — ``"panda_upload"`` when an upload has been seen on this
+    Redis, ``"local_file"`` when none ever has — and
+    ``config_upload_unix`` dates it (the upload persists after panda
+    exits, so during a manual-swap window it reflects last-run intent).
+
+    ``switch_schedule`` keeps its stricter no-fallback contract: it
+    comes only from the upload, so a parked switch with no panda ever
+    running shows no countdown.
     """
     panda_cfg = state.panda_config_latest or {}
     return {
         "switch_schedule": panda_cfg.get("switch_schedule", {}) or {},
         "config_upload_unix": state.panda_config_upload_unix,
+        "config_source": (
+            "panda_upload"
+            if state.panda_config_latest is not None
+            else "local_file"
+        ),
         "tempctrl_settings": obs_cfg.get("tempctrl_settings", {}) or {},
         "corr_save_dir": obs_cfg.get("corr_save_dir"),
         "corr_ntimes": obs_cfg.get("corr_ntimes"),
@@ -754,9 +767,12 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
 
     @app.route("/")
     def index():
+        # Effective view so any future template use of obs_cfg follows
+        # panda reality like the API routes do. Rendered once per page
+        # load — freshness rides on the aggregator's panda tick.
         return render_template(
             "index.html",
-            obs_cfg=aggregator.obs_cfg,
+            obs_cfg=aggregator.obs_cfg_effective,
         )
 
     @app.route("/plotly.min.js")
@@ -776,10 +792,14 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
     def api_corr():
         state = aggregator.snapshot()
         calibrated = request.args.get("calibrated") == "1"
+        # Effective config so the display calibration's t_load_stream
+        # follows a hot-swap announced via the panda's config upload.
         return jsonify(
             _envelope(
                 _corr_payload(
-                    state, calibrated=calibrated, obs_cfg=aggregator.obs_cfg
+                    state,
+                    calibrated=calibrated,
+                    obs_cfg=aggregator.obs_cfg_effective,
                 )
             )
         )
@@ -823,7 +843,9 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
         return jsonify(
             _envelope(
                 _config_payload(
-                    state, aggregator.obs_cfg, aggregator.thresholds
+                    state,
+                    aggregator.obs_cfg_effective,
+                    aggregator.thresholds,
                 )
             )
         )

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -229,6 +229,61 @@ SIGNAL_REGISTRY: dict[str, Signal] = {
 }
 
 
+# Top-level obs_config keys that describe panda-side reality: the
+# dashboard prefers the panda's Redis ConfigStore upload for these and
+# falls back to its local YAML when no upload has ever landed (issue
+# #194). ``switch_schedule`` is deliberately absent — it keeps the
+# stricter no-fallback contract in ``_rfswitch_payload`` (a parked
+# switch with no panda shows no countdown). ``corr_ntimes`` rides along
+# because the file-heartbeat band derives from it and the upload is the
+# obs_config actually embedded in file headers.
+PANDA_REALITY_KEYS = (
+    "use_switches",
+    "use_vna",
+    "use_motor",
+    "use_tempctrl",
+    "tempctrl_settings",
+    "corr_ntimes",
+)
+
+# Nested (section, field) pairs plucked individually from the upload.
+# Only ``calibration.t_load_stream`` follows panda reality (it names
+# the stream the hot-swapped LOAD module publishes on);
+# ``calibration.noise_diode_enr_db`` stays dashboard-local — it's a
+# display-cal tuning knob, not a claim about what panda is running.
+PANDA_REALITY_NESTED = (("calibration", "t_load_stream"),)
+
+
+def effective_obs_cfg(local_cfg: dict, panda_cfg: Optional[dict]) -> dict:
+    """Merge the panda-reality slice of the Redis upload over local.
+
+    Returns a new dict: ``local_cfg`` with every
+    :data:`PANDA_REALITY_KEYS` key (and :data:`PANDA_REALITY_NESTED`
+    field) that is present in ``panda_cfg`` overridden by the upload's
+    value. ``panda_cfg`` falsy (no upload ever landed on this Redis)
+    returns a plain copy of ``local_cfg`` — the local fallback is
+    load-bearing: the dashboard is precisely the tool you reach for
+    when ``panda_observe`` isn't running.
+
+    Keys absent from the upload keep their local value, so an older
+    producer that predates a config field degrades to local rather
+    than dropping the field.
+    """
+    out = dict(local_cfg)
+    if not panda_cfg:
+        return out
+    for key in PANDA_REALITY_KEYS:
+        if key in panda_cfg:
+            out[key] = panda_cfg[key]
+    for section, field_ in PANDA_REALITY_NESTED:
+        panda_section = panda_cfg.get(section)
+        if isinstance(panda_section, dict) and field_ in panda_section:
+            merged_section = dict(out.get(section) or {})
+            merged_section[field_] = panda_section[field_]
+            out[section] = merged_section
+    return out
+
+
 def enabled_signals(
     obs_cfg: dict, registry: Optional[dict[str, Signal]] = None
 ) -> dict[str, Signal]:

--- a/src/eigsep_observing/live_status/thresholds.py
+++ b/src/eigsep_observing/live_status/thresholds.py
@@ -143,17 +143,38 @@ class Thresholds:
         Used by the aggregator when ``integration_time`` changes (e.g.
         after a re-sync). The old instance is discarded.
         """
-        # Reconstruct self._yaml_overrides with the danger-k entry if it
-        # was supplied — __init__ consumes it via dict.pop.
-        overrides = dict(self._yaml_overrides)
-        if self.tempctrl_danger_k_C != _DEFAULT_TEMPCTRL_DANGER_K_C:
-            overrides["tempctrl.danger_k_C"] = self.tempctrl_danger_k_C
         return Thresholds(
             obs_cfg=self.obs_cfg,
             corr_header=corr_header,
-            yaml_overrides=overrides,
+            yaml_overrides=self._rebuild_overrides(),
             registry=self._registry_arg,
         )
+
+    def with_obs_cfg(self, obs_cfg: dict) -> "Thresholds":
+        """Return a new Thresholds reflecting an updated obs_config.
+
+        Used by the aggregator when the panda's Redis config upload
+        changes (issue #194), so signal gating and the config-derived
+        bands follow the merged effective config. The old instance is
+        discarded.
+        """
+        return Thresholds(
+            obs_cfg=obs_cfg,
+            corr_header=self.corr_header,
+            yaml_overrides=self._rebuild_overrides(),
+            registry=self._registry_arg,
+        )
+
+    def _rebuild_overrides(self) -> dict:
+        """Reconstruct the yaml_overrides dict for a with_* rebuild.
+
+        ``__init__`` consumes the danger-k entry via ``dict.pop``, so a
+        non-default value must be re-injected for the new instance.
+        """
+        overrides = dict(self._yaml_overrides)
+        if self.tempctrl_danger_k_C != _DEFAULT_TEMPCTRL_DANGER_K_C:
+            overrides["tempctrl.danger_k_C"] = self.tempctrl_danger_k_C
+        return overrides
 
     def _resolve_band(self, name: str, derived: dict) -> dict:
         """Merge derived + YAML override for one signal."""

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -8,6 +8,7 @@ are deterministic.
 
 from __future__ import annotations
 
+import logging
 import math
 import time
 
@@ -922,6 +923,9 @@ def test_config_route_surfaces_redis_schedule_and_upload_time(client):
     assert data["config_upload_unix"] is not None
     # upload_time must be a Unix timestamp near now.
     assert abs(data["config_upload_unix"] - time.time()) < 60.0
+    # Provenance: an upload has landed, so the panda-reality slice of
+    # the config panel comes from it (issue #194).
+    assert data["config_source"] == "panda_upload"
 
 
 def test_config_route_schedule_empty_when_no_config_in_redis():
@@ -943,16 +947,224 @@ def test_config_route_schedule_empty_when_no_config_in_redis():
     try:
         agg._panda_tick()
         assert agg.state.panda_config_latest is None
+        # Local fallback is load-bearing: with no upload ever seen the
+        # effective config is exactly the local file (issue #194).
+        assert agg.obs_cfg_effective == OBS_CFG
         app = create_app(agg)
         app.config.update(TESTING=True)
         data = app.test_client().get("/api/config").get_json()["data"]
         assert data["switch_schedule"] == {}
         assert data["config_upload_unix"] is None
+        assert data["config_source"] == "local_file"
         # But disk-backed fields still come through (Thresholds-driving
         # rendering decisions, not runtime claims).
         assert data["use_tempctrl"] is True
     finally:
         agg.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------
+# panda config upload → gating/thresholds (issue #194)
+# ---------------------------------------------------------------------
+
+
+def _tempctrl_row(stream: str, t_now: float) -> dict:
+    """One post-handler tempctrl metadata row (same shape as the
+    agg_primed fixture's)."""
+    return {
+        "sensor_name": stream,
+        "status": "update",
+        "app_id": 4,
+        "watchdog_tripped": False,
+        "watchdog_timeout_ms": 30000,
+        "T_now": t_now,
+        "timestamp": time.time(),
+        "T_target": 25.0,
+        "drive_level": 0.25,
+        "enabled": True,
+        "active": True,
+        "sensor_tripped": False,
+        "runaway_tripped": False,
+        "hysteresis": 0.5,
+        "clamp": 0.6,
+    }
+
+
+def test_panda_upload_regates_signals_and_thresholds():
+    """A panda upload that descopes LNA and moves the LOAD setpoint
+    re-gates the dashboard without a restart (issue #194): signal
+    gating, tempctrl bands, the cal-load stream, and /api/config all
+    follow the upload, while dashboard-local knobs stay from the
+    on-disk obs_cfg.
+    """
+    snap = DummyTransport()
+    panda = DummyTransport()
+    CorrConfigStore(snap).upload(CORR_CONFIG)
+
+    panda_md = MetadataWriter(panda)
+    panda_md.add("tempctrl_lna", _tempctrl_row("tempctrl_lna", 25.1))
+    panda_md.add("tempctrl_load", _tempctrl_row("tempctrl_load", 25.0))
+    _rewind(
+        panda,
+        ["stream:tempctrl_lna", "stream:tempctrl_load", "stream:status"],
+    )
+
+    agg = LiveStatusAggregator(
+        transport_snap=snap,
+        transport_panda=panda,
+        obs_cfg=OBS_CFG,
+    )
+    try:
+        # Baseline: no upload yet — the local file gates.
+        agg._panda_tick()
+        assert agg.obs_cfg_effective == OBS_CFG
+        assert "tempctrl_lna.T_now" in agg.thresholds.registry
+
+        # panda_observe restarts with a diverged config: LNA descoped,
+        # LOAD setpoint moved, cal-load stream re-pointed (hot-swap).
+        upload = {
+            **OBS_CFG,
+            "tempctrl_settings": {
+                "LNA": {
+                    "installed": False,
+                    "enable": False,
+                    "target_C": 25.0,
+                    "hysteresis_C": 0.5,
+                    "clamp": 0.6,
+                },
+                "LOAD": {"target_C": 30.0, "hysteresis_C": 0.5, "clamp": 0.6},
+            },
+            "calibration": {
+                **OBS_CFG["calibration"],
+                "t_load_stream": "tempctrl_lna",
+            },
+        }
+        ConfigStore(panda).upload(upload)
+        th_before = agg.thresholds
+        agg._panda_tick()
+
+        # Gating followed the upload: LNA tiles gone, LOAD band moved.
+        assert agg.thresholds is not th_before
+        assert "tempctrl_lna.T_now" not in agg.thresholds.registry
+        assert agg.thresholds.bands["tempctrl_load.T_now"]["healthy"] == [
+            29.0,
+            31.0,
+        ]
+        # calibration.t_load_stream was plucked from the upload; the
+        # ENR knob stays dashboard-local.
+        cal = agg.obs_cfg_effective["calibration"]
+        assert cal["t_load_stream"] == "tempctrl_lna"
+        assert (
+            cal["noise_diode_enr_db"]
+            == OBS_CFG["calibration"]["noise_diode_enr_db"]
+        )
+
+        app = create_app(agg)
+        app.config.update(TESTING=True)
+        client_ = app.test_client()
+
+        # /api/metadata: the descoped channel's snapshot entry lingers
+        # in the Redis hash until the OPERATIONS.md cleanup step, but
+        # it classifies against nothing; the live channel still does.
+        md = client_.get("/api/metadata").get_json()["data"]
+        assert md["tempctrl_lna"]["classify"] == {}
+        assert "tempctrl_load.T_now" in md["tempctrl_load"]["classify"]
+
+        # /api/config: effective values + provenance.
+        cfg_data = client_.get("/api/config").get_json()["data"]
+        assert cfg_data["config_source"] == "panda_upload"
+        assert cfg_data["tempctrl_settings"]["LNA"]["installed"] is False
+        assert cfg_data["tempctrl_settings"]["LOAD"]["target_C"] == 30.0
+        assert "tempctrl_lna.T_now" not in cfg_data["thresholds"]
+    finally:
+        agg.stop(timeout=1.0)
+
+
+def test_panda_config_recompute_only_on_upload_change(agg_primed):
+    """The merge is dirty-flagged on the upload content: re-reading the
+    same upload every tick must not churn out new Thresholds
+    instances, and a genuinely new upload must swap them."""
+    agg = agg_primed
+    th1 = agg.thresholds
+    cfg1 = agg.obs_cfg_effective
+    agg._panda_tick()  # same upload still in Redis
+    assert agg.thresholds is th1
+    assert agg.obs_cfg_effective is cfg1
+
+    # New upload with a different corr_ntimes: the file-heartbeat band
+    # follows (integration_time 0.27 came from the SNAP-side header and
+    # is preserved across the config rebuild).
+    ConfigStore(agg.transport_panda).upload({**OBS_CFG, "corr_ntimes": 480})
+    agg._panda_tick()
+    assert agg.thresholds is not th1
+    assert agg.obs_cfg_effective["corr_ntimes"] == 480
+    file_dur = 0.27 * 480
+    assert agg.thresholds.bands["file.seconds_since_write"][
+        "healthy"
+    ] == pytest.approx([0.0, 1.5 * file_dur])
+
+
+def test_panda_upload_malformed_keeps_previous_gating(agg_primed, caplog):
+    """A junk upload (non-numeric target_C) must not half-apply: the
+    effective config and thresholds keep the last-good state, one
+    ERROR names the contract violation (not one per ~4 Hz tick), and
+    a corrected upload recovers."""
+    agg = agg_primed
+    th_good = agg.thresholds
+    cfg_good = agg.obs_cfg_effective
+    bad = {
+        **OBS_CFG,
+        "tempctrl_settings": {
+            "LNA": {"target_C": "not-a-number", "hysteresis_C": 0.5},
+            "LOAD": {"target_C": 25.0, "hysteresis_C": 0.5},
+        },
+    }
+    ConfigStore(agg.transport_panda).upload(bad)
+    with caplog.at_level(logging.ERROR):
+        agg._panda_tick()
+        assert agg.thresholds is th_good
+        assert agg.obs_cfg_effective is cfg_good
+        assert any(
+            "cannot build thresholds" in r.getMessage() for r in caplog.records
+        )
+
+        # Dirty flag remembers the bad upload: no repeat ERROR spam.
+        caplog.clear()
+        agg._panda_tick()
+        assert not any(
+            "cannot build thresholds" in r.getMessage() for r in caplog.records
+        )
+
+    # A corrected upload differs from the recorded bad one → recovers.
+    ConfigStore(agg.transport_panda).upload({**OBS_CFG, "corr_ntimes": 480})
+    agg._panda_tick()
+    assert agg.obs_cfg_effective["corr_ntimes"] == 480
+    assert agg.thresholds is not th_good
+
+
+def test_corr_route_calibrated_t_load_stream_follows_upload(agg_primed):
+    """Hot-swap contingency end-to-end: the panda upload names
+    ``tempctrl_lna`` as the cal-load stream; the calibrated corr route
+    must read T_LOAD from that stream without a dashboard restart."""
+    _seed_onoff_cache(agg_primed, p_off_value=100, p_on_value=250)
+    upload = {
+        **OBS_CFG,
+        "calibration": {
+            **OBS_CFG["calibration"],
+            "t_load_stream": "tempctrl_lna",
+        },
+    }
+    ConfigStore(agg_primed.transport_panda).upload(upload)
+    agg_primed._panda_tick()
+
+    app = create_app(agg_primed)
+    app.config.update(TESTING=True)
+    body = app.test_client().get("/api/corr?calibrated=1").get_json()
+    meta = body["data"]["calibration_meta"]
+    assert meta["t_load_stream"] == "tempctrl_lna"
+    # tempctrl_lna's T_now is 25.1 C in the fixture (vs LOAD's 25.0) —
+    # proof the solve read the swapped stream, not the default.
+    assert meta["t_load_k"] == pytest.approx(25.1 + 273.15, rel=1e-9)
 
 
 def test_file_route(client):

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -13,6 +13,7 @@ from eigsep_observing.live_status import (
     SIGNAL_REGISTRY,
     Thresholds,
     default_thresholds,
+    effective_obs_cfg,
     enabled_signals,
 )
 
@@ -402,3 +403,169 @@ def test_rfswitch_therm_classifies_unknown_without_band():
     # No config-derived and no bundled-YAML band -> grey "unknown" tile.
     th = Thresholds(OBS_CFG_TEMPCTRL_OFF, CORR_HEADER)
     assert th.classify("rfswitch_therm.temp_therm0", 30.0) == "unknown"
+
+
+# ---------------------------------------------------------------------
+# effective_obs_cfg — prefer-Redis-with-local-fallback (issue #194)
+# ---------------------------------------------------------------------
+
+
+# Local-file layer for the merge tests. Carries the panda-reality keys
+# (use_* gates, tempctrl_settings, corr_ntimes, calibration) plus a
+# dashboard-local key (corr_save_dir) and switch_schedule, which is
+# deliberately NOT merged — the rfswitch payload reads the schedule
+# straight from the upload with no local fallback.
+OBS_CFG_LOCAL = {
+    "corr_save_dir": "/media/eigsep/T7/data",
+    "corr_ntimes": 240,
+    "use_switches": True,
+    "use_vna": True,
+    "use_motor": False,
+    "use_tempctrl": True,
+    "switch_schedule": {"RFANT": 3600, "RFNON": 60},
+    "calibration": {
+        "noise_diode_enr_db": 11.0,
+        "t_load_stream": "tempctrl_load",
+    },
+    "tempctrl_settings": {
+        "LNA": {"installed": True, "target_C": 25.0, "hysteresis_C": 0.5},
+        "LOAD": {"installed": True, "target_C": 25.0, "hysteresis_C": 0.5},
+    },
+}
+
+
+def _panda_upload(**overrides):
+    """A full-obs_config upload as ``ConfigStore.get`` returns it: the
+    panda uploads its entire config dict and ``Transport.upload_dict``
+    stamps ``upload_time``. Built from the local fixture so
+    unspecified keys agree — the realistic field case is two copies of
+    the same file drifting on a few keys.
+    """
+    cfg = {**OBS_CFG_LOCAL, "upload_time": 1e9}
+    cfg.update(overrides)
+    return cfg
+
+
+def test_effective_obs_cfg_no_upload_returns_local_copy():
+    out = effective_obs_cfg(OBS_CFG_LOCAL, None)
+    assert out == OBS_CFG_LOCAL
+    assert out is not OBS_CFG_LOCAL  # copy, not alias
+    # An empty dict (never a real upload shape) also means "no upload".
+    assert effective_obs_cfg(OBS_CFG_LOCAL, {}) == OBS_CFG_LOCAL
+
+
+def test_effective_obs_cfg_upload_wins_on_panda_reality_keys():
+    upload = _panda_upload(
+        use_tempctrl=False,
+        use_motor=True,
+        corr_ntimes=480,
+        tempctrl_settings={
+            "LNA": {"installed": False},
+            "LOAD": {"installed": True, "target_C": 30.0},
+        },
+    )
+    out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
+    assert out["use_tempctrl"] is False
+    assert out["use_motor"] is True
+    assert out["corr_ntimes"] == 480
+    assert out["tempctrl_settings"] == upload["tempctrl_settings"]
+
+
+def test_effective_obs_cfg_dashboard_local_keys_survive():
+    # corr_save_dir is not panda reality (the corr writer runs on the
+    # ground PC); the upload_time stamp must not leak into the merged
+    # config either.
+    upload = _panda_upload(corr_save_dir="/panda/side/path")
+    out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
+    assert out["corr_save_dir"] == OBS_CFG_LOCAL["corr_save_dir"]
+    assert "upload_time" not in out
+
+
+def test_effective_obs_cfg_missing_upload_keys_fall_back_to_local():
+    # Deliberately partial upload (production uploads carry the full
+    # obs_config): models an older producer that predates a key — the
+    # local value must survive rather than the field dropping.
+    upload = {"upload_time": 1e9, "use_tempctrl": False}
+    out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
+    assert out["use_tempctrl"] is False
+    assert out["corr_ntimes"] == OBS_CFG_LOCAL["corr_ntimes"]
+    assert out["tempctrl_settings"] == OBS_CFG_LOCAL["tempctrl_settings"]
+
+
+def test_effective_obs_cfg_plucks_only_t_load_stream_from_calibration():
+    upload = _panda_upload(
+        calibration={
+            "noise_diode_enr_db": 99.0,  # panda copy drifted
+            "t_load_stream": "tempctrl_lna",  # hot-swap step 3
+        }
+    )
+    out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
+    cal = out["calibration"]
+    assert cal["t_load_stream"] == "tempctrl_lna"
+    # The ENR is a dashboard-local display-cal knob, not panda reality.
+    assert cal["noise_diode_enr_db"] == 11.0
+    # The local dict's nested section was copied, not mutated in place.
+    assert OBS_CFG_LOCAL["calibration"]["t_load_stream"] == "tempctrl_load"
+
+
+def test_effective_obs_cfg_switch_schedule_not_merged():
+    # switch_schedule keeps its stricter no-fallback contract in
+    # _rfswitch_payload (read straight from the upload); the merged
+    # config must not paper over that with the upload's copy.
+    upload = _panda_upload(switch_schedule={"RFANT": 60})
+    out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
+    assert out["switch_schedule"] == OBS_CFG_LOCAL["switch_schedule"]
+
+
+# ---------------------------------------------------------------------
+# with_obs_cfg (panda config upload path)
+# ---------------------------------------------------------------------
+
+
+def test_thresholds_with_obs_cfg_recomputes_bands_and_gating():
+    th = Thresholds(OBS_CFG_TEMPCTRL_ON, CORR_HEADER)
+    assert "tempctrl_lna.T_now" in th.registry
+
+    new_cfg = {
+        "use_tempctrl": True,
+        "corr_ntimes": 240,
+        "tempctrl_settings": {
+            "LNA": {
+                "installed": False,
+                "enable": False,
+                "target_C": 25.0,
+                "hysteresis_C": 0.5,
+                "clamp": 0.6,
+            },
+            "LOAD": {"target_C": 30.0, "hysteresis_C": 0.5, "clamp": 0.6},
+        },
+    }
+    th2 = th.with_obs_cfg(new_cfg)
+    # Gating followed the new config: the descoped channel is gone...
+    assert "tempctrl_lna.T_now" not in th2.registry
+    # ...and the live channel's band moved to the new setpoint.
+    assert th2.bands["tempctrl_load.T_now"]["healthy"] == [29.0, 31.0]
+    # The corr header carried over — cadence band unchanged.
+    assert th2.bands["corr.acc_cadence_s"] == th.bands["corr.acc_cadence_s"]
+
+
+def test_thresholds_with_obs_cfg_preserves_yaml_override_and_danger_k():
+    yaml_overrides = {
+        "adc.rms": {"healthy": [10.0, 20.0], "danger": [5.0, 30.0]},
+        "tempctrl.danger_k_C": 7.0,
+    }
+    th = Thresholds(
+        OBS_CFG_TEMPCTRL_ON, CORR_HEADER, yaml_overrides=yaml_overrides
+    )
+    new_cfg = {
+        "use_tempctrl": True,
+        "corr_ntimes": 240,
+        "tempctrl_settings": {
+            "LNA": {"target_C": 25.0, "hysteresis_C": 0.5, "clamp": 0.6},
+            "LOAD": {"target_C": 30.0, "hysteresis_C": 0.5, "clamp": 0.6},
+        },
+    }
+    th2 = th.with_obs_cfg(new_cfg)
+    assert th2.bands["adc.rms"]["healthy"] == [10.0, 20.0]
+    # Non-default danger half-width survived the rebuild (30 ± 7).
+    assert th2.bands["tempctrl_load.T_now"]["danger"] == [23.0, 37.0]


### PR DESCRIPTION
Closes #194.

## Problem

The dashboard's signal gating (`enabled_signals`) and config-derived threshold bands read the **dashboard-local** `obs_config.yaml`, so a panda running a diverged config left tiles permanently empty (descoped tempctrl channel) or bands out of sync (moved setpoint) on the field deployment's only alerting surface. This is why the OPERATIONS.md hot-swap procedure needed its manual "edit the dashboard host's copy and restart" step.

## Approach: prefer-Redis-with-local-fallback

Extends the existing `switch_schedule` precedent to the rest of the panda-reality slice, exactly as scoped in #194:

- **`signals.effective_obs_cfg`** merges the upload's panda-reality keys (`use_*` gates, `tempctrl_settings`, `corr_ntimes`) plus the individually-plucked `calibration.t_load_stream` over the local YAML. Dashboard-local knobs (`corr_save_dir`, empirical thresholds, `noise_diode_enr_db`) stay local; `switch_schedule` keeps its stricter no-fallback contract in the rfswitch payload (a parked switch with no panda shows no countdown). No upload ever seen → plain copy of the local file (the fallback is load-bearing per the issue).
- **`LiveStatusAggregator`** gains `obs_cfg_effective` and a second thresholds dirty flag: `_maybe_recompute_config` (panda tick, dict-equality on the upload) rebuilds via the new `Thresholds.with_obs_cfg`, sibling to the existing `integration_time` flag (`with_header`). Both swaps happen under the state lock, and each rebuild preserves the other's input (YAML override layer, danger-k, corr header).
- **Defensive:** a malformed upload (e.g. non-numeric `target_C`) logs **one** ERROR naming the producer contract and keeps the last-good gating/bands/effective-config trio intact — no half-application, no ~4 Hz log spam; a corrected upload recovers.
- **Consumers:** `/api/metadata` gating (now via `thresholds.registry` — single source with the bands), `/api/corr` display-cal `t_load_stream`, `/api/config`, and the index render all take the effective view. `/api/config` adds `config_source` (`"panda_upload"` | `"local_file"`) beside the existing `config_upload_unix` age for provenance.
- **OPERATIONS.md** hot-swap step 5 rewritten: the dashboard now follows the `panda_observe` restart automatically.

## Testing

- Unit: `effective_obs_cfg` merge semantics (fallback, per-key wins, partial/old uploads, `t_load_stream` pluck, `upload_time` never leaks, schedule not merged) and `with_obs_cfg` (regating, band recompute, header + YAML-override preservation).
- Integration (DummyTransport + Flask test client): upload-driven regating end-to-end (`/api/metadata` classify, `/api/config` provenance + effective values), dirty-flag identity across ticks, `corr_ntimes` → file-heartbeat band with preserved `integration_time`, calibrated corr route reading the swapped load stream, malformed-upload resilience + recovery.
- Live verification against the real `scripts/live_status.py` on two local redis-servers, driving `ConfigStore` uploads and curling the HTTP API: local fallback → hot-swap regating within a tick → junk upload (server keeps serving last-good, exactly 1 ERROR after 8+ ticks) → recovery, and `/` still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)