### PR TITLE
feat: imu_az azimuth descope — schema, live_status, picohost>=4.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,14 +295,19 @@ absence, never a sentinel or error stream; see OPERATIONS.md
 app_id 3; `imu_az` antenna azimuth, app_id 6) emit BNO085 UART RVC payloads:
 just `yaw`/`pitch`/`roll` (degrees) and `accel_x/y/z` (m/s²). No quaternion,
 linear-accel, gyro, mag, or BNO085 calibration-status fields. The two picos
-now carry *different* derived field sets, so the single shared `_IMU_SCHEMA`
-was split (picohost 3.10, calibrate-imu) into a common `_IMU_BASE` body plus
-two per-pico schemas in `io.py`: `_IMU_EL_SCHEMA` adds a gravity-derived
-signed `el_deg`; `_IMU_AZ_SCHEMA` adds `el_deg` (|θ|) plus the azimuth blend
-(`az_deg`, `az_from_accel_deg`, `az_from_yaw_deg`, `az_blend_weight`). All
-derived fields are `float` in the schema and `None` when the IMU is
-uncalibrated — the producer's stable shape — so the float→mean reduction and
-`_validate_metadata`'s None short-circuit handle them cleanly.
+originally carried *different* derived field sets, so the single shared
+`_IMU_SCHEMA` was split (picohost 3.10, calibrate-imu) into a common
+`_IMU_BASE` body plus two per-pico schemas in `io.py`: `_IMU_EL_SCHEMA` adds
+a gravity-derived signed `el_deg`; `_IMU_AZ_SCHEMA` adds `el_deg` (|θ|) only
+— the azimuth blend (`az_deg`, `az_from_accel_deg`, `az_from_yaw_deg`,
+`az_blend_weight`) was retired in picohost 4.3 (2026-07 descope: potmon owns
+azimuth — accel-az is physically degenerate at level; see
+`notebooks/motor_pot_imu/0708_test/`). The two schemas are now identical
+expressions but stay separate names in `SENSOR_SCHEMAS` — the sign semantics
+differ (`imu_el.el_deg` is signed, `imu_az.el_deg` is |θ|) and the names are
+load-bearing. All derived fields are `float` in the schema and `None` when
+the IMU is uncalibrated — the producer's stable shape — so the float→mean
+reduction and `_validate_metadata`'s None short-circuit handle them cleanly.
 
 Like `potmon`, the IMU schema is enforced against the **post-handler** shape,
 not the raw emulator output: `ImuEmulator.get_status()` emits only the BNO085

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -365,3 +365,44 @@ Note: after any tempctrl Pico reboot, firmware defaults to
 the cached flags — a brief `status="error"` burst on the retired stream
 is expected and harmless (schema-valid rows, at most one spurious
 health-check warning).
+
+## Orientation calibration recipe
+
+Azimuth is pot-referenced (`potmon`); elevation is IMU-referenced
+(`imu_el`, plus `imu_az`'s el-only `|θ|` as a cross-check). The
+picohost-4.3 az descope retired accel-derived `imu_az` azimuth — at
+level, azimuth rotation is rotation about gravity and unobservable to
+an accelerometer (2026-07-08 field data: ~20x noise amplification for
+a few degrees of tilt). See CLAUDE.md's "IMU mode" section for the
+schema-level detail.
+
+Three commands, run in order (all picohost CLI entry points, run
+against the running `pico-manager`; step 3 is this repo's
+`motor_manual`):
+
+1. **`calibrate-pot --mode auto`** — in-box, motor-driven pot sweep.
+   Defines az 0 = pot 0° (writes the slope/intercept to `PotCalStore`).
+2. **`calibrate-imu`** — auto-driven single elevation sweep. Defines
+   el 0 = the pose where the IMUs read most "down", derived from the
+   sweep itself (no operator-eyeballed level needed). **The az
+   turntable must be parked at az home during this sweep** — the
+   `imu_az` `el_deg` section of the fit is gated on the pot reading
+   within ~10° of the calibrated zero; `imu_el` is azimuth-invariant
+   and calibrates regardless of az position.
+3. **`motor_manual` → `h` + confirm** — drives the closed-loop
+   `MotorHomer` onto the cal-defined home (pot 0° az / IMU-level el)
+   and re-zeros the step counters there.
+
+**Order matters**: run step 1 before step 2. `calibrate-imu`'s
+`imu_az` section needs a calibrated, home-parked pot to gate against;
+running it before `calibrate-pot`, or with the turntable off home,
+still calibrates `imu_el` correctly but silently drops the `imu_az`
+cross-check section from the saved fit.
+
+**A stale motor zero is a warning, not a failure.** If step 2's
+derived level sits more than ~10° from the motor's current zero
+position, it logs a warning ("motor zero may be stale; home after
+saving") but still saves the fit — the fit is independent of the
+motor's step-counter zero. Run step 3 afterward to re-zero the
+counters against the newly-saved cal-defined home; it is not a
+prerequisite for steps 1–2 to succeed.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -394,15 +394,26 @@ against the running `pico-manager`; step 3 is this repo's
    and re-zeros the step counters there.
 
 **Order matters**: run step 1 before step 2. `calibrate-imu`'s
-`imu_az` section needs a calibrated, home-parked pot to gate against;
-running it before `calibrate-pot`, or with the turntable off home,
-still calibrates `imu_el` correctly but silently drops the `imu_az`
-cross-check section from the saved fit.
+`imu_az` section needs a calibrated, home-parked pot to gate against.
+Running it before `calibrate-pot`, or with the turntable off home,
+does **not** silently drop the `imu_az` section: the gate prints a
+warning to stderr and prompts `Continue imu_el-only? [y / Enter to
+abort]:`. The default (Enter) **aborts the entire calibration**,
+including `imu_el`; only an explicit `y` continues with `imu_el`
+alone, dropping the `imu_az` cross-check section from the saved fit.
 
 **A stale motor zero is a warning, not a failure.** If step 2's
 derived level sits more than ~10° from the motor's current zero
 position, it logs a warning ("motor zero may be stale; home after
-saving") but still saves the fit — the fit is independent of the
-motor's step-counter zero. Run step 3 afterward to re-zero the
+saving"), but the warning does not bypass or auto-trigger saving —
+saving a calibration always goes through the same `Save this
+calibration? [y/N]:` confirm, warning or not; the fit is independent
+of the motor's step-counter zero. Run step 3 afterward to re-zero the
 counters against the newly-saved cal-defined home; it is not a
 prerequisite for steps 1–2 to succeed.
+
+**Expect cross-check FLAG rows near el 0 and ±180°.** `imu_az`'s
+`|θ|` estimator has an intrinsic near-pole floor (~10–20° with a
+single-sweep cal, dominated by the along-axis accel-bias component a
+single el sweep cannot observe) — `imu_el` is the el authority, and
+`imu_az` is a cross-check/failover only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pyyaml",
   "flask",
   "plotly",
-  "picohost>=4.2",
+  "picohost>=4.3",
   "eigsep-vna>=1.4",
   "eigsep_redis>=2.3",
 ]

--- a/scripts/field_zero.py
+++ b/scripts/field_zero.py
@@ -141,8 +141,7 @@ def _render(screen, zeroer, snapshot, deg):
     screen.addstr(
         5,
         0,
-        f"imu_az: yaw={imu.get('yaw')} az={imu.get('az_deg')} "
-        f"el={imu.get('el_deg')}",
+        f"imu_az: yaw={imu.get('yaw')} el={imu.get('el_deg')}",
     )
     screen.addstr(
         7,

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -178,8 +178,18 @@ def _imu_az_avg_entry(yaw):
 # intentionally absent — it is injected at write time by
 # Transport.upload_dict, so the on-Redis blob has it but a
 # hand-authored "what calibrate-imu produced" fixture does not. Both
-# sections present (a full `--mode all` run); a partial fleet would
-# carry only one section.
+# sections present: `calibrate-imu`'s single auto-driven el sweep
+# fits both imu_el (always) and imu_az (only when the az turntable was
+# parked at its calibrated home during the sweep, per the
+# `_pot_az_home_gate` in picohost/calibrate_imu.py — an off-home /
+# uncalibrated pot drops the imu_az section and this fixture would
+# carry only imu_el). `mode` is one of picohost's `calibrate-imu`
+# CLI modes ("auto"/"manual", not the retired three-sweep "all");
+# `n_stops` is the auto-mode el-stop count (12 -> 13 stops over
+# +/-180); `derived_home_motor_deg`/`pot_az_home_deg` are the fit's
+# derived-level home offset and the pot reading at az-home stamped at
+# save time (see fit_el_calibration's `report["home_offset_motor_deg"]`
+# and calibrate_imu.py's `_pot_az_home_gate`).
 IMU_CALIBRATION = {
     "imu_el": {
         "accel_bias": [0.01, -0.02, 0.03],
@@ -197,8 +207,11 @@ IMU_CALIBRATION = {
     },
     "metadata": {
         "timestamp": "2026-06-29T12:00:00+00:00",
-        "mode": "all",
+        "mode": "auto",
         "n_samples": 200,
+        "n_stops": 12,
+        "derived_home_motor_deg": 2.1,
+        "pot_az_home_deg": 0.3,
     },
 }
 

--- a/src/eigsep_observing/_test_fixtures.py
+++ b/src/eigsep_observing/_test_fixtures.py
@@ -123,11 +123,13 @@ def _imu_avg_entry(yaw):
     }
 
 
-# Representative calibrated imu_az reading. el_deg is |theta| (>=0); the az
-# fields track yaw here as an illustrative calibrated reading. The
-# producer↔schema contract is now validated against the real handler via
-# _imu_post_handler_reading in the contract test (calibrate-imu shipped in
-# picohost 3.10). These hand-set round-trip values are retained for
+# Representative calibrated imu_az reading. el_deg is |theta| (>=0); the
+# azimuth blend (az_deg / az_from_accel_deg / az_from_yaw_deg /
+# az_blend_weight) was retired in picohost 4.3 (potmon owns azimuth;
+# accel-az is degenerate at level) so imu_az now carries only the
+# _IMU_BASE fields plus el_deg. The producer↔schema contract is
+# validated against the real handler via _imu_post_handler_reading in
+# the contract test. These hand-set round-trip values are retained for
 # exact-value assertions, the same convention as the potmon round-trip
 # golden.
 IMU_AZ_READING = {
@@ -141,17 +143,14 @@ IMU_AZ_READING = {
     "accel_y": 0.0,
     "accel_z": 9.81,
     "el_deg": 0.0,
-    "az_deg": 0.0,
-    "az_from_accel_deg": 0.0,
-    "az_from_yaw_deg": 0.0,
-    "az_blend_weight": 1.0,
 }
 
 
 def _imu_az_avg_entry(yaw):
     """One imu_az per-sample entry as avg_metadata would emit it.
 
-    az fields track yaw (see IMU_AZ_READING deviation note).
+    az fields (retired picohost 4.3) are gone; only the _IMU_BASE
+    fields plus el_deg remain.
     """
     return {
         "sensor_name": "imu_az",
@@ -164,22 +163,23 @@ def _imu_az_avg_entry(yaw):
         "accel_y": 0.0,
         "accel_z": 9.81,
         "el_deg": 0.0,
-        "az_deg": yaw,
-        "az_from_accel_deg": yaw,
-        "az_from_yaw_deg": yaw,
-        "az_blend_weight": 1.0,
     }
 
 
-# Representative imu_calibration blob, matching the picohost-3.10
+# Representative imu_calibration blob, matching the picohost-4.3
 # ImuCalStore shape (see picohost/imu_geometry.py
-# fit_calibration_from_sweeps + nearest_signed_permutation). mount_perm
-# is a list of 3 host-axis label strings; M is a 3x3 row-major matrix;
-# accel_bias is a 3-vector. `upload_time` is intentionally absent — it is
-# injected at write time by Transport.upload_dict, so the on-Redis blob
-# has it but a hand-authored "what calibrate-imu produced" fixture does
-# not. Both sections present (a full `--mode all` run); a partial fleet
-# would carry only one section.
+# fit_el_calibration + nearest_signed_permutation). Both sections
+# (imu_el and imu_az) now share the same fit_el_calibration shape —
+# the az-blend-specific keys (az_sign, az_accel_offset_deg,
+# theta_cross_deg, az_yaw_sign, az_yaw_offset_deg) were retired
+# alongside the azimuth blend in picohost 4.3 (potmon owns azimuth).
+# mount_perm is a list of 3 host-axis label strings; M is a 3x3
+# row-major matrix; accel_bias is a 3-vector. `upload_time` is
+# intentionally absent — it is injected at write time by
+# Transport.upload_dict, so the on-Redis blob has it but a
+# hand-authored "what calibrate-imu produced" fixture does not. Both
+# sections present (a full `--mode all` run); a partial fleet would
+# carry only one section.
 IMU_CALIBRATION = {
     "imu_el": {
         "accel_bias": [0.01, -0.02, 0.03],
@@ -192,13 +192,8 @@ IMU_CALIBRATION = {
         "accel_bias": [-0.04, 0.05, -0.06],
         "accel_scale": 0.998,
         "M": [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
-        "az_sign": 1.0,
-        "az_accel_offset_deg": 12.5,
-        "theta_cross_deg": 20.0,
         "mount_perm": ["-y", "+x", "+z"],
         "mount_misalign_deg": 1.3,
-        "az_yaw_sign": -1.0,
-        "az_yaw_offset_deg": 47.0,
     },
     "metadata": {
         "timestamp": "2026-06-29T12:00:00+00:00",

--- a/src/eigsep_observing/contract_tests/test_producer_contracts.py
+++ b/src/eigsep_observing/contract_tests/test_producer_contracts.py
@@ -226,8 +226,8 @@ def _imu_post_handler_reading(name, app_id):
     """Return an IMU reading after PicoIMU._imu_redis_handler.
 
     Composes ImuEmulator.get_status() with the real handler, which adds
-    the calibrate-imu derived fields (el_deg; az_deg + blend for
-    imu_az). The handler is run UNCALIBRATED, so derived fields are
+    the calibrate-imu derived fields (el_deg for both; imu_az's is
+    |theta|). The handler is run UNCALIBRATED, so derived fields are
     None — the genuine state of a freshly-deployed, not-yet-calibrated
     IMU, which is what the schema's None-when-uncalibrated contract
     describes. Mirrors _potmon_post_handler_reading (bypass __init__,

--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -810,12 +810,13 @@ def _validate_corr_header(header):
 #
 # IMU schemas reflect the BNO085 UART RVC mode introduced in picohost
 # 1.0.0: only yaw/pitch/roll orientation and acceleration are reported.
-# The two physical IMU picos now emit different field sets:
-# imu_el (panda elevation, app_id 3) adds gravity-derived signed elevation;
-# imu_az (antenna azimuth, app_id 6) adds |theta| elevation plus the azimuth
-# blend (accel-based + yaw-based, registered to the pot).
-# All derived fields are float->float (mean reduction); all are None when
-# uncalibrated.
+# The two physical IMU picos share the same derived field name but
+# different sign semantics: imu_el (panda elevation, app_id 3) adds
+# gravity-derived signed elevation; imu_az (antenna azimuth turntable,
+# app_id 6) adds |theta| elevation only — the accel/yaw azimuth blend
+# was retired in picohost 4.3 (azimuth is owned by potmon; accel-az is
+# degenerate at level). All derived fields are float->float (mean
+# reduction); all are None when uncalibrated.
 _IMU_BASE = {
     "sensor_name": str,
     "status": str,
@@ -831,17 +832,8 @@ _IMU_BASE = {
 # imu_el (panda elevation, app_id 3): gravity-derived signed elevation.
 _IMU_EL_SCHEMA = {**_IMU_BASE, "el_deg": float}
 
-# imu_az (antenna azimuth, app_id 6): |theta| elevation plus the azimuth
-# blend (accel-based + yaw-based, registered to the pot). All float ->
-# float->mean reduction; all None when uncalibrated.
-_IMU_AZ_SCHEMA = {
-    **_IMU_BASE,
-    "el_deg": float,
-    "az_deg": float,
-    "az_from_accel_deg": float,
-    "az_from_yaw_deg": float,
-    "az_blend_weight": float,
-}
+# imu_az (antenna azimuth turntable, app_id 6): |theta| elevation only.
+_IMU_AZ_SCHEMA = {**_IMU_BASE, "el_deg": float}
 
 # tempctrl publishes two flat streams (one per Peltier channel), each
 # matching this schema. The producer is

--- a/src/eigsep_observing/live_status/orientation.py
+++ b/src/eigsep_observing/live_status/orientation.py
@@ -5,6 +5,11 @@ into az/el degrees for each sensor that reports them, plus a median consensus
 and the max-min spread. The spread is the live drift/stall signal; the
 consensus is display-only (the authoritative weighted estimate is a
 post-processing concern, not a live decision).
+
+Az sources: motor + potmon. imu_az azimuth was retired with the
+picohost-4.3 descope (accel-derived azimuth is physically degenerate at
+level; potmon is the az reference). imu_az still contributes to the el
+consensus/spread alongside motor and imu_el.
 """
 
 import numpy as np
@@ -41,7 +46,6 @@ def compute_orientation(metadata, steps_to_deg):
     az = {
         "motor": steps_to_deg(az_pos) if az_pos is not None else None,
         "potmon": _val(metadata, "potmon", "pot_az_angle"),
-        "imu_az": _val(metadata, "imu_az", "az_deg"),
     }
     el = {
         "motor": steps_to_deg(el_pos) if el_pos is not None else None,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1284,13 +1284,7 @@ def test_metadata_end_to_end_round_trip():
                 {**IMU_READING, "yaw": 0.001 * i},
             ],
             "stream:imu_az": [
-                {
-                    **IMU_AZ_READING,
-                    "yaw": 0.002 * i,
-                    "az_deg": 0.002 * i,
-                    "az_from_accel_deg": 0.002 * i,
-                    "az_from_yaw_deg": 0.002 * i,
-                },
+                {**IMU_AZ_READING, "yaw": 0.002 * i},
             ],
             "stream:lidar": [
                 {
@@ -3697,30 +3691,22 @@ def test_imu_schemas_field_sets():
     }
     assert set(io._IMU_EL_SCHEMA) == base | {"el_deg"}
     assert io._IMU_EL_SCHEMA["el_deg"] is float
-    assert set(io._IMU_AZ_SCHEMA) == base | {
-        "el_deg",
-        "az_deg",
-        "az_from_accel_deg",
-        "az_from_yaw_deg",
-        "az_blend_weight",
-    }
-    for k in (
-        "el_deg",
-        "az_deg",
-        "az_from_accel_deg",
-        "az_from_yaw_deg",
-        "az_blend_weight",
-    ):
-        assert io._IMU_AZ_SCHEMA[k] is float
+    # imu_az's azimuth blend (az_deg / az_from_accel_deg /
+    # az_from_yaw_deg / az_blend_weight) was retired in picohost 4.3 —
+    # potmon owns azimuth, accel-az is degenerate at level — so imu_az
+    # now carries the same field set as imu_el (el_deg is |theta| for
+    # imu_az vs signed elevation for imu_el; the schemas stay separate
+    # names because that sign semantic differs).
+    assert set(io._IMU_AZ_SCHEMA) == base | {"el_deg"}
+    assert io._IMU_AZ_SCHEMA["el_deg"] is float
 
 
 def test_imu_az_derived_fields_round_trip():
     samples = [_imu_az_avg_entry(10.0), _imu_az_avg_entry(30.0)]
     avg = io.avg_metadata(samples)
-    assert avg["az_deg"] == 20.0  # float->mean over yaw-tracked values
+    assert avg["yaw"] == 20.0  # float->mean over yaw-tracked values
     assert avg["el_deg"] == 0.0
-    assert avg["az_blend_weight"] == 1.0
-    assert "az_from_accel_deg" in avg and "az_from_yaw_deg" in avg
+    assert "az_deg" not in avg  # retired picohost 4.3
 
 
 # -- linear-range header injection ------------------------------------

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1737,7 +1737,6 @@ def test_metadata_payload_orientation_agree_and_diverge():
             "imu_az": {
                 "sensor_name": "imu_az",
                 "status": "update",
-                "az_deg": 100.0,
                 "el_deg": 0.0,
             },
             "imu_az_ts": now,
@@ -1745,10 +1744,12 @@ def test_metadata_payload_orientation_agree_and_diverge():
         state.metadata_snapshot_read_unix = now
         return state
 
-    # Agreeing sensors: spread = 100.5 - 100.0 = 0.5 -> "ok" (< 3).
+    # Agreeing sensors: az sources are motor (~100.004) + potmon (100.5)
+    # only (imu_az azimuth retired) -> spread ~0.5 -> "ok" (< 3).
     out = _metadata_payload(make_state(100.5), _payload_thresholds())
     ori = out["orientation"]
     assert "az" in ori["value"] and "el" in ori["value"]
+    assert "imu_az" not in ori["value"]["az"]
     assert ori["classify"]["orientation.az_spread_deg"] == "ok"
 
     # Diverging: potmon ~12 deg off -> spread > 10 -> "danger".

--- a/tests/test_live_status_orientation.py
+++ b/tests/test_live_status_orientation.py
@@ -28,10 +28,12 @@ def test_compute_orientation_consensus_and_spread():
     out = orientation.compute_orientation(
         meta, steps_to_deg=lambda s: s / 80.0
     )
-    # az sources: motor 8000/80=100.0, potmon 100.5, imu_az 100.0
+    # az sources: motor + potmon only; imu_az azimuth retired
+    # (picohost 4.3 descope — accel-derived az is degenerate at level).
+    assert "imu_az" not in out["az"]
     assert out["az"]["motor"] == 100.0
     assert out["az"]["potmon"] == 100.5
-    assert out["az"]["consensus"] == 100.0  # median([100.0,100.5,100.0])
+    assert out["az"]["consensus"] == 100.25  # median([100.0, 100.5])
     assert round(out["az"]["spread"], 3) == 0.5  # 100.5 - 100.0
     # el sources: motor 960/80=12.0, imu_az 12.0, imu_el 12.4
     assert out["el"]["consensus"] == 12.0


### PR DESCRIPTION
## Summary

Retires the `imu_az` accel-derived azimuth blend across the consumer stack. Physics: at level, azimuth rotation is rotation about gravity, which is fundamentally unobservable to an accelerometer — 2026-07-08 field sweeps found the az axis only ~2.8° from gravity, giving ~20x noise amplification on any accel-derived azimuth estimate. `potmon` is the sole azimuth reference; the IMUs (`imu_el`, and `imu_az`'s el-only `|θ|`) own elevation. This is the `eigsep_observing`-side consumer of the stacked pico-firmware change: https://github.com/EIGSEP/pico-firmware/pull/152.

Two commits:

- **`feat(io):` schema/fixtures/contract (`2883b4c`, already on this branch)** — `_IMU_AZ_SCHEMA` drops `az_deg`/`az_from_accel_deg`/`az_from_yaw_deg`/`az_blend_weight`, now matching `imu_el`'s field set (base BNO085 fields + `el_deg`). Fixtures, the producer-contract test, and `CLAUDE.md`'s "IMU mode" section updated to match.
- **`feat(live_status):` + `fix(scripts):` this PR's new commits**:
  - `compute_orientation` no longer sources an az value from `imu_az` (only `motor` + `potmon` remain in the az dict); module docstring updated. Swept the dashboard JS/HTML for a hardcoded `imu_az` az row — none found: `renderImu` only ever showed yaw/pitch/roll/accel (still valid post-descope), and `renderOrientation`'s per-sensor loop is data-driven, so it silently drops the row now that the backend no longer emits it.
  - `tests/test_live_status_orientation.py` / `tests/test_live_status_app.py` updated to the new az-source set (motor + potmon consensus/spread), with an explicit `"imu_az" not in ...["az"]` assertion so the code change — not just the fixture change — is what makes the test pass.
  - `OPERATIONS.md` gains an "Orientation calibration recipe" section: `calibrate-pot --mode auto` (az 0 = pot 0°) → `calibrate-imu` (auto el sweep; el 0 = IMUs' most-down pose; az must be parked at home, gated against the calibrated pot) → `motor_manual` `h` + confirm (`MotorHomer` drives to pot 0°/el 0° and re-zeros counters). Documents that order matters (az home before the el sweep, for `imu_az`'s `|θ|` cross-check section) and that a stale motor zero triggers `calibrate-imu`'s >10° warning, not a failure.
  - `pyproject.toml` pin bumped `picohost>=4.2` → `picohost>=4.3`.
  - `scripts/field_zero.py`'s curses status line read `imu.get('az_deg')` from the `imu_az` snapshot (a reviewer-caught consumer the original plan missed) — always `None` post-descope. Dropped that element; `yaw` and `el_deg` stay.
  - Repo-wide sweep (`grep -rn "az_deg\|az_from_accel\|az_from_yaw\|az_blend" src/ scripts/ tests/ --include="*.py" | grep -v "pot_az\|motor\|el_deg"`) turned up no other stale consumers — remaining hits are either already-updated comments/assertions from the schema commit, or unrelated `residual_az_deg` fields on `MotorHomer.HomeResult` (motor homing residual, not the IMU schema).

**`uv.lock` intentionally untouched**: `picohost` 4.3.0 is not yet on PyPI (`uv lock` fails to resolve — confirmed locally, no `uv.lock` diff produced). This PR stays **DRAFT until picohost 4.3.0 is released**, at which point the pin/lock refresh lands as a follow-up commit here (same pattern as PRs #178 and #192).

## Test plan

- [x] `pytest tests/test_live_status_orientation.py -v` — 3 passed
- [x] `pytest tests/test_live_status_orientation.py tests/test_live_status_app.py -q` — 82 passed
- [x] `pytest tests/test_field_zero.py -q` — 12 passed
- [x] `pytest tests/test_live_status_orientation.py tests/test_live_status_app.py tests/test_field_zero.py tests/test_io.py -q` — 195 passed
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `uv lock` — confirmed fails to resolve (picohost 4.3.0 not on PyPI); `uv.lock` left untouched
- [ ] Full CI suite (runs on push, per this repo's convention of not re-running the full suite locally)
- [ ] Merge gated on picohost 4.3.0 PyPI release + `uv.lock` refresh

**Known follow-up**: filed https://github.com/EIGSEP/eigsep_observing/issues/216 to decide whether `imu_az`'s el_deg should stay wired into the live_status el-spread consensus, given its ~10-20° near-pole floor (el 0 / ±180°) confirmed by pico-firmware PR #152's field validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)