### PR TITLE
feat(live_status): config panel with gating provenance (front-end)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -345,8 +345,8 @@ the LNA connector):**
      block's `target_C` / `hysteresis_C` / `clamp` / `cooling_enabled` /
      `Kp` / `Ki` — the physical module is the same, only the channel
      (pins + stream name) changed.
-   - `calibration.t_load_stream: tempctrl_lna` — the Y-factor
-     calibration's load-temperature reference now rides the
+   - `calibration.t_amb_stream: tempctrl_lna` — the Y-factor
+     calibration's ambient-load temperature reference now rides the
      LNA-connector stream.
 4. One-time Redis cleanup so the retired `tempctrl_load` stream doesn't
    emit throttled staleness warnings on the ground side: delete its
@@ -355,8 +355,9 @@ the LNA connector):**
    set entry.
 5. Restart `panda_observe`. The live-status dashboard follows on its
    own: signal gating, tempctrl bands, and the display calibration's
-   `t_load_stream` prefer the panda's Redis config upload over the
-   dashboard host's local file, so the restarted `panda_observe`'s
+   `t_ns_*`/`t_amb_*` reference routing prefer the panda's Redis
+   config upload over the dashboard host's local file, so the
+   restarted `panda_observe`'s
    upload re-gates the dashboard within a tick — no dashboard-side
    config edit or restart. During the swap window itself the dashboard
    still renders the *last* upload's tiles (empty for the retired

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -225,8 +225,8 @@ class StateSnapshot:
     # its config to this Redis. The dashboard reads ``switch_schedule``
     # from here rather than from the on-disk YAML, so a parked switch
     # with no panda running shows no countdown. The panda-reality slice
-    # (``tempctrl_settings``, ``use_*`` gates, ``corr_ntimes``,
-    # ``calibration.t_load_stream``) is additionally merged over the
+    # (``tempctrl_settings``, ``use_*`` gates, ``corr_ntimes``, the
+    # ``calibration`` t_ns_*/t_amb_* routing knobs) is merged over the
     # local YAML into ``aggregator.obs_cfg_effective`` so signal gating
     # and config-derived bands follow what panda is actually running
     # (issue #194).

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -840,6 +840,11 @@ def _config_payload(
         "use_tempctrl": obs_cfg.get("use_tempctrl", False),
         "use_switches": obs_cfg.get("use_switches", False),
         "use_vna": obs_cfg.get("use_vna", False),
+        # Effective calibration block so the config panel can show the
+        # reference-temperature routing a hot-swap re-pointed (the
+        # t_ns_*/t_amb_* knobs follow the upload; the ENR/pad physical
+        # constants are dashboard-local).
+        "calibration": obs_cfg.get("calibration", {}) or {},
         "thresholds": thresholds.as_dict(),
     }
 

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -813,9 +813,9 @@ def _config_payload(
 
     ``obs_cfg`` here is the aggregator's *effective* config: the local
     YAML with the panda-reality slice (``tempctrl_settings``, ``use_*``
-    gates, ``corr_ntimes``, ``calibration.t_load_stream``) overridden
-    by the panda's Redis ``ConfigStore`` upload once one has landed
-    (issue #194). ``config_source`` records which side supplied that
+    gates, ``corr_ntimes``, the ``calibration`` t_ns_*/t_amb_* routing
+    knobs) overridden by the panda's Redis ``ConfigStore`` upload once
+    one has landed (issue #194). ``config_source`` records which side supplied that
     slice — ``"panda_upload"`` when an upload has been seen on this
     Redis, ``"local_file"`` when none ever has — and
     ``config_upload_unix`` dates it (the upload persists after panda
@@ -883,8 +883,9 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
     def api_corr():
         state = aggregator.snapshot()
         calibrated = request.args.get("calibrated") == "1"
-        # Effective config so the display calibration's t_load_stream
-        # follows a hot-swap announced via the panda's config upload.
+        # Effective config so the display calibration's t_ns_*/t_amb_*
+        # reference-temperature routing follows a hot-swap announced
+        # via the panda's config upload.
         return jsonify(
             _envelope(
                 _corr_payload(

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -247,11 +247,20 @@ PANDA_REALITY_KEYS = (
 )
 
 # Nested (section, field) pairs plucked individually from the upload.
-# Only ``calibration.t_load_stream`` follows panda reality (it names
-# the stream the hot-swapped LOAD module publishes on);
-# ``calibration.noise_diode_enr_db`` stays dashboard-local — it's a
-# display-cal tuning knob, not a claim about what panda is running.
-PANDA_REALITY_NESTED = (("calibration", "t_load_stream"),)
+# The calibration reference-temperature *routing* knobs follow panda
+# reality: a tempctrl hot-swap re-points ``t_amb_*`` at the stream the
+# moved LOAD module publishes on, and ``t_ns_*`` names the RF-switch
+# PCB thermistor channel nearest the noise-source pad (see
+# ``_solve_calibration``). The physical constants
+# (``noise_diode_enr_db`` / ``noise_source_atten_db``) stay
+# dashboard-local — display-cal tuning knobs, not claims about what
+# panda is running.
+PANDA_REALITY_NESTED = (
+    ("calibration", "t_ns_stream"),
+    ("calibration", "t_ns_field"),
+    ("calibration", "t_amb_stream"),
+    ("calibration", "t_amb_field"),
+)
 
 
 def effective_obs_cfg(local_cfg: dict, panda_cfg: Optional[dict]) -> dict:

--- a/src/eigsep_observing/live_status/static/css/dashboard.css
+++ b/src/eigsep_observing/live_status/static/css/dashboard.css
@@ -289,3 +289,52 @@ header h1 { margin: 0; font-size: 18px; font-weight: 500; }
 .adc-cell:nth-last-child(2) {
   border-bottom: none;
 }
+
+/* Config panel: effective-config values, uploaded switch schedule, and
+   the threshold-band table. Refreshed on its own slow cadence (see
+   CONFIG_POLL_MS in dashboard.js) — config changes once per panda
+   session, not per integration. */
+.config-thresholds {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.config-thresholds h3 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.config-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.config-table th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 500;
+  padding: 2px 12px 4px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.config-table td {
+  padding: 2px 12px 2px 0;
+  border-bottom: 1px solid var(--border);
+  font-family: "JetBrains Mono", Consolas, monospace;
+  white-space: nowrap;
+}
+
+/* Signal names and provenance tags read better in the page font; the
+   numeric band columns keep the mono value styling. */
+.config-table td.signal,
+.config-table td.source {
+  font-family: inherit;
+}
+
+.config-table td.source { color: var(--muted); }
+
+.config-table tr:last-child td { border-bottom: none; }

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -1124,6 +1124,182 @@ function renderStatusLog(entries) {
   }
 }
 
+// ---- config panel ---------------------------------------------------
+
+// The config panel polls on its own slow cadence: /api/config is
+// heavier than the streaming endpoints (it carries the full threshold
+// table) and its content changes once per panda session — when a
+// panda script uploads its obs_config — not per integration, so it
+// stays out of the 2 Hz tick loop.
+const CONFIG_POLL_MS = 30000;
+
+// "[lo, hi]" band → "lo … hi", or an em-dash for a null band (signals
+// with no configured band classify as grey "unknown" tiles).
+function fmtBand(band) {
+  if (!band) return "—";
+  return `${fmt(band[0], 2)} … ${fmt(band[1], 2)}`;
+}
+
+// Provenance tile: the issue-#194 headline. Green when the gating
+// slice follows a panda upload (with that upload's age so a stale
+// last-run intent is visible); neutral when the dashboard is on its
+// local-file fallback — normal during bring-up, but worth a glance
+// when panda is supposed to be running.
+function renderConfigSourceTile(cfg) {
+  const tile = document.getElementById("config-source-tile");
+  if (!tile) return;
+  if (cfg.config_source === "panda_upload") {
+    let ageStr = "";
+    if (cfg.config_upload_unix !== null &&
+        cfg.config_upload_unix !== undefined) {
+      const age = Math.max(0, Date.now() / 1000 - cfg.config_upload_unix);
+      ageStr = ` (${fmtDuration(age)} ago)`;
+    }
+    tile.className = "tile ok";
+    tile.textContent = `Config: panda upload${ageStr}`;
+  } else {
+    tile.className = "tile";
+    tile.textContent = "Config: local file (no upload seen)";
+  }
+}
+
+function renderConfigValues(cfg) {
+  const container = document.getElementById("config-values-block");
+  if (!container) return;
+  container.replaceChildren();
+  const heading = document.createElement("h3");
+  heading.textContent = "Observing config";
+  container.appendChild(heading);
+  appendValueRow(container, "use_switches", boolText(cfg.use_switches));
+  appendValueRow(container, "use_vna", boolText(cfg.use_vna));
+  appendValueRow(container, "use_tempctrl", boolText(cfg.use_tempctrl));
+  appendValueRow(container, "corr_ntimes", fmt(cfg.corr_ntimes, 0));
+  appendValueRow(container, "corr_save_dir", cfg.corr_save_dir || "—");
+  const cal = cfg.calibration || {};
+  // Mirror _solve_calibration's defaults so the panel shows the
+  // stream.field references the display cal will actually read when
+  // the routing knobs are unset. These are the panda-reality knobs a
+  // hot-swap re-points (t_amb_*) — see OPERATIONS.md.
+  appendValueRow(
+    container,
+    "cal T_ns ref",
+    `${cal.t_ns_stream || "rfswitch_therm"}.${cal.t_ns_field || "temp_therm2"}`,
+  );
+  appendValueRow(
+    container,
+    "cal T_amb ref",
+    `${cal.t_amb_stream || "tempctrl_load"}.${cal.t_amb_field || "T_now"}`,
+  );
+  const enr = cal.noise_diode_enr_db;
+  appendValueRow(
+    container,
+    "noise diode ENR",
+    enr !== null && enr !== undefined ? `${fmt(enr, 1)} dB` : "—",
+  );
+  const atten = cal.noise_source_atten_db;
+  appendValueRow(
+    container,
+    "noise source pad",
+    atten !== null && atten !== undefined ? `${fmt(atten, 1)} dB` : "—",
+  );
+  const settings = cfg.tempctrl_settings || {};
+  for (const ch of ["LNA", "LOAD"]) {
+    const c = settings[ch] || {};
+    if (c.installed === false) {
+      // Deliberate hardware descope, not a fault — plain text. The
+      // channel's tiles/bands are gone from the rest of the dashboard;
+      // this row is where the operator confirms that's configured.
+      appendValueRow(container, `tempctrl ${ch}`, "descoped (installed: false)");
+      continue;
+    }
+    appendValueRow(
+      container,
+      `tempctrl ${ch}`,
+      `${fmt(c.target_C, 1)}±${fmt(c.hysteresis_C, 1)} °C · clamp ${fmt(c.clamp, 2)}`,
+    );
+  }
+}
+
+function renderConfigSchedule(cfg) {
+  const container = document.getElementById("config-schedule-block");
+  if (!container) return;
+  container.replaceChildren();
+  const heading = document.createElement("h3");
+  heading.textContent = "Switch schedule (uploaded)";
+  container.appendChild(heading);
+  const schedule = cfg.switch_schedule || {};
+  const names = Object.keys(schedule);
+  if (!names.length) {
+    // No local fallback by design: a parked switch with no panda ever
+    // running must not imply a schedule (see _config_payload).
+    const empty = document.createElement("div");
+    empty.textContent = "no schedule uploaded";
+    container.appendChild(empty);
+    return;
+  }
+  for (const name of names) {
+    appendValueRow(container, name, fmtDuration(schedule[name]));
+  }
+}
+
+function renderConfigThresholds(cfg) {
+  const container = document.getElementById("config-thresholds");
+  if (!container) return;
+  container.replaceChildren();
+  const heading = document.createElement("h3");
+  heading.textContent = "Threshold bands (gated signals)";
+  container.appendChild(heading);
+  const thresholds = cfg.thresholds || {};
+  const names = Object.keys(thresholds).sort();
+  if (!names.length) return;
+  const table = document.createElement("table");
+  table.className = "config-table";
+  const thead = document.createElement("thead");
+  const headRow = document.createElement("tr");
+  for (const label of ["signal", "healthy", "danger", "unit", "source"]) {
+    const th = document.createElement("th");
+    th.textContent = label;
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+  const tbody = document.createElement("tbody");
+  for (const name of names) {
+    const t = thresholds[name] || {};
+    const tr = document.createElement("tr");
+    const tdName = document.createElement("td");
+    tdName.className = "signal";
+    tdName.textContent = name;
+    if (t.description) tdName.title = t.description;
+    const tdHealthy = document.createElement("td");
+    tdHealthy.textContent = fmtBand(t.healthy);
+    const tdDanger = document.createElement("td");
+    tdDanger.textContent = fmtBand(t.danger);
+    const tdUnit = document.createElement("td");
+    tdUnit.textContent = t.unit || "";
+    const tdSource = document.createElement("td");
+    tdSource.className = "source";
+    tdSource.textContent = t.source || "";
+    tr.append(tdName, tdHealthy, tdDanger, tdUnit, tdSource);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  container.appendChild(table);
+}
+
+async function tickConfig() {
+  try {
+    const body = await fetchJson("/api/config");
+    const cfg = body.data;
+    renderConfigSourceTile(cfg);
+    renderConfigValues(cfg);
+    renderConfigSchedule(cfg);
+    renderConfigThresholds(cfg);
+  } catch (e) {
+    console.error("config poll failed:", e);
+  }
+}
+
 // ---- poll loop ------------------------------------------------------
 
 // Last successful payloads cached so the wiring-labels toggle can
@@ -1259,3 +1435,5 @@ initVnaModeToggle();
 initThemeToggle();
 tick();
 setInterval(tick, POLL_MS);
+tickConfig();
+setInterval(tickConfig, CONFIG_POLL_MS);

--- a/src/eigsep_observing/live_status/templates/index.html
+++ b/src/eigsep_observing/live_status/templates/index.html
@@ -131,6 +131,18 @@
     <h2>Event log (status stream)</h2>
     <ul id="status-log"></ul>
   </section>
+
+  <section class="card wide">
+    <div class="card-header">
+      <h2>Config (effective)</h2>
+      <span class="tile" id="config-source-tile" title="Where the dashboard's signal gating and config-derived threshold bands come from. 'panda upload' = the panda-reality slice (use_* gates, tempctrl settings, corr_ntimes, cal-load stream) follows the obs_config that panda_observe (or a sibling script) last uploaded to the panda Redis; the age is that upload's age, and the upload persists after the script exits (last-run intent). 'local file' = no upload has ever landed on this Redis, so the dashboard falls back to its own obs_config.yaml. Refreshes every 30 s.">Config: ?</span>
+    </div>
+    <div class="two-col-grid">
+      <div id="config-values-block" class="col-block"></div>
+      <div id="config-schedule-block" class="col-block"></div>
+    </div>
+    <div id="config-thresholds" class="config-thresholds"></div>
+  </section>
 </main>
 
 <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -985,6 +985,9 @@ def test_config_route_schedule_empty_when_no_config_in_redis():
         # But disk-backed fields still come through (Thresholds-driving
         # rendering decisions, not runtime claims).
         assert data["use_tempctrl"] is True
+        # The effective calibration block rides along for the config
+        # panel — local values here since no upload has landed.
+        assert data["calibration"] == OBS_CFG["calibration"]
     finally:
         agg.stop(timeout=1.0)
 
@@ -1102,6 +1105,13 @@ def test_panda_upload_regates_signals_and_thresholds():
         assert cfg_data["tempctrl_settings"]["LNA"]["installed"] is False
         assert cfg_data["tempctrl_settings"]["LOAD"]["target_C"] == 30.0
         assert "tempctrl_lna.T_now" not in cfg_data["thresholds"]
+        # The config panel reads the effective cal reference routing
+        # from here: plucked from the upload, ENR still dashboard-local.
+        assert cfg_data["calibration"]["t_amb_stream"] == "tempctrl_lna"
+        assert (
+            cfg_data["calibration"]["noise_diode_enr_db"]
+            == OBS_CFG["calibration"]["noise_diode_enr_db"]
+        )
     finally:
         agg.stop(timeout=1.0)
 
@@ -1218,6 +1228,21 @@ def test_config_route_exposes_thresholds_with_provenance(client):
     assert thresh["adc.rms"]["source"] == "yaml_override"
     # tempctrl_lna.T_now is derived from obs_config.
     assert thresh["tempctrl_lna.T_now"]["source"] == "derived"
+
+
+def test_index_page_includes_config_panel(client):
+    """The config panel's mount points must exist in the template —
+    tickConfig() in dashboard.js no-ops silently on a missing element,
+    so a template regression would otherwise drop the panel without
+    any test noticing."""
+    html = client.get("/").get_data(as_text=True)
+    for element_id in (
+        "config-source-tile",
+        "config-values-block",
+        "config-schedule-block",
+        "config-thresholds",
+    ):
+        assert f'id="{element_id}"' in html, element_id
 
 
 def test_envelope_shape(client):

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1062,7 +1062,7 @@ def test_panda_upload_regates_signals_and_thresholds():
             },
             "calibration": {
                 **OBS_CFG["calibration"],
-                "t_load_stream": "tempctrl_lna",
+                "t_amb_stream": "tempctrl_lna",
             },
         }
         ConfigStore(panda).upload(upload)
@@ -1076,10 +1076,10 @@ def test_panda_upload_regates_signals_and_thresholds():
             29.0,
             31.0,
         ]
-        # calibration.t_load_stream was plucked from the upload; the
+        # calibration.t_amb_stream was plucked from the upload; the
         # ENR knob stays dashboard-local.
         cal = agg.obs_cfg_effective["calibration"]
-        assert cal["t_load_stream"] == "tempctrl_lna"
+        assert cal["t_amb_stream"] == "tempctrl_lna"
         assert (
             cal["noise_diode_enr_db"]
             == OBS_CFG["calibration"]["noise_diode_enr_db"]
@@ -1168,16 +1168,17 @@ def test_panda_upload_malformed_keeps_previous_gating(agg_primed, caplog):
     assert agg.thresholds is not th_good
 
 
-def test_corr_route_calibrated_t_load_stream_follows_upload(agg_primed):
-    """Hot-swap contingency end-to-end: the panda upload names
-    ``tempctrl_lna`` as the cal-load stream; the calibrated corr route
-    must read T_LOAD from that stream without a dashboard restart."""
+def test_corr_route_calibrated_t_amb_stream_follows_upload(agg_primed):
+    """Hot-swap contingency end-to-end: the panda upload re-points the
+    ambient-reference stream at ``tempctrl_lna`` (the moved LOAD module
+    publishes there); the calibrated corr route must read T_amb from
+    that stream without a dashboard restart."""
     _seed_onoff_cache(agg_primed, p_off_value=100, p_on_value=250)
     upload = {
         **OBS_CFG,
         "calibration": {
             **OBS_CFG["calibration"],
-            "t_load_stream": "tempctrl_lna",
+            "t_amb_stream": "tempctrl_lna",
         },
     }
     ConfigStore(agg_primed.transport_panda).upload(upload)
@@ -1187,10 +1188,10 @@ def test_corr_route_calibrated_t_load_stream_follows_upload(agg_primed):
     app.config.update(TESTING=True)
     body = app.test_client().get("/api/corr?calibrated=1").get_json()
     meta = body["data"]["calibration_meta"]
-    assert meta["t_load_stream"] == "tempctrl_lna"
+    assert meta["t_amb_stream"] == "tempctrl_lna"
     # tempctrl_lna's T_now is 25.1 C in the fixture (vs LOAD's 25.0) —
     # proof the solve read the swapped stream, not the default.
-    assert meta["t_load_k"] == pytest.approx(25.1 + 273.15, rel=1e-9)
+    assert meta["t_amb_k"] == pytest.approx(25.1 + 273.15, rel=1e-9)
 
 
 def test_file_route(client):

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -424,8 +424,12 @@ OBS_CFG_LOCAL = {
     "use_tempctrl": True,
     "switch_schedule": {"RFANT": 3600, "RFNON": 60},
     "calibration": {
-        "noise_diode_enr_db": 11.0,
-        "t_load_stream": "tempctrl_load",
+        "noise_diode_enr_db": 35.0,
+        "noise_source_atten_db": 30.0,
+        "t_ns_stream": "rfswitch_therm",
+        "t_ns_field": "temp_therm2",
+        "t_amb_stream": "tempctrl_load",
+        "t_amb_field": "T_now",
     },
     "tempctrl_settings": {
         "LNA": {"installed": True, "target_C": 25.0, "hysteresis_C": 0.5},
@@ -492,20 +496,28 @@ def test_effective_obs_cfg_missing_upload_keys_fall_back_to_local():
     assert out["tempctrl_settings"] == OBS_CFG_LOCAL["tempctrl_settings"]
 
 
-def test_effective_obs_cfg_plucks_only_t_load_stream_from_calibration():
+def test_effective_obs_cfg_plucks_only_routing_knobs_from_calibration():
     upload = _panda_upload(
         calibration={
             "noise_diode_enr_db": 99.0,  # panda copy drifted
-            "t_load_stream": "tempctrl_lna",  # hot-swap step 3
+            "noise_source_atten_db": 20.0,  # panda copy drifted
+            "t_ns_stream": "rfswitch_therm",
+            "t_ns_field": "temp_therm0",  # pad moved to another channel
+            "t_amb_stream": "tempctrl_lna",  # hot-swap step 3
+            "t_amb_field": "T_now",
         }
     )
     out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
     cal = out["calibration"]
-    assert cal["t_load_stream"] == "tempctrl_lna"
-    # The ENR is a dashboard-local display-cal knob, not panda reality.
-    assert cal["noise_diode_enr_db"] == 11.0
+    # The reference-temperature routing follows the upload...
+    assert cal["t_amb_stream"] == "tempctrl_lna"
+    assert cal["t_ns_field"] == "temp_therm0"
+    # ...but the physical constants are dashboard-local display-cal
+    # knobs, not panda reality.
+    assert cal["noise_diode_enr_db"] == 35.0
+    assert cal["noise_source_atten_db"] == 30.0
     # The local dict's nested section was copied, not mutated in place.
-    assert OBS_CFG_LOCAL["calibration"]["t_load_stream"] == "tempctrl_load"
+    assert OBS_CFG_LOCAL["calibration"]["t_amb_stream"] == "tempctrl_load"
 
 
 def test_effective_obs_cfg_switch_schedule_not_merged():


### PR DESCRIPTION
Stacked on #215 (which fixes the red main CI — merge order: #215, then this).

## Problem

#212 made signal gating and threshold bands follow the panda's Redis config upload and exposed provenance on `/api/config` — but `dashboard.js` never fetched that endpoint, so the "gating from panda upload, N ago" line issue #194 asked to surface in the config panel had no rendered surface. There was no config panel at all.

## What this adds

A **"Config (effective)"** card at the bottom of the dashboard:

- **Provenance tile** — green `Config: panda upload (2s ago)` (age from `config_upload_unix`, recomputed per render) when the gating slice follows an upload; neutral `Config: local file (no upload seen)` on the fallback. Tooltip explains the prefer-Redis-with-local-fallback semantics and last-run-intent persistence.
- **Observing config block** — effective `use_*` gates, `corr_ntimes`, `corr_save_dir`, the calibration reference routing (`cal T_ns ref` / `cal T_amb ref` as `stream.field`, mirroring `_solve_calibration`'s defaults when unset), noise-diode ENR + pad, and per-channel tempctrl setpoints, with a descoped channel rendered as `descoped (installed: false)` — the one place the operator confirms the missing tiles elsewhere are configured, not broken.
- **Switch schedule block** — the uploaded schedule (`no schedule uploaded` when none; deliberately no local fallback, mirroring the API contract).
- **Threshold table** — every gated signal's healthy/danger band, unit, and per-band `source` tag (`derived` / `yaml_override` / `default_null`), description as tooltip.

Mechanics: own 30 s poll (`tickConfig`) rather than joining the 2 Hz loop — the payload is heavier (full threshold table) and changes once per panda session. All values land via `textContent` (no injection surface). Table styling themes through the existing CSS variables, so Sun/Light/Dark all work.

Server side: `/api/config` additionally carries the effective `calibration` block; a template-guard test asserts the panel's mount-point ids exist on the index page (`tickConfig` no-ops silently on missing elements, so a template regression would otherwise be invisible to tests).

## Verification

Headless Chrome against the real `scripts/live_status.py` on two local redis-servers, screenshots + DOM dumps both phases:

- Local fallback: neutral tile, `no schedule uploaded`, local setpoints, `tempctrl_lna.T_now` band present in the table.
- After a descope upload (`ConfigStore` write, no dashboard restart): tile flips to `Config: panda upload`, LNA row reads `descoped (installed: false)`, LOAD reads `30.0±0.5 °C`, `cal T_amb ref` reads `tempctrl_lna.T_now` (followed the upload re-point), ENR/pad read `35.0 dB` / `30.0 dB`, `tempctrl_lna.*` rows gone from the table, schedule rendered (`RFANT 1h 0m`).

132 live-status tests pass; ruff clean; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)