### PR TITLE
fix(live_status): re-point config-upload cal pluck at t_ns_*/t_amb_* knobs

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -345,8 +345,8 @@ the LNA connector):**
      block's `target_C` / `hysteresis_C` / `clamp` / `cooling_enabled` /
      `Kp` / `Ki` — the physical module is the same, only the channel
      (pins + stream name) changed.
-   - `calibration.t_load_stream: tempctrl_lna` — the Y-factor
-     calibration's load-temperature reference now rides the
+   - `calibration.t_amb_stream: tempctrl_lna` — the Y-factor
+     calibration's ambient-load temperature reference now rides the
      LNA-connector stream.
 4. One-time Redis cleanup so the retired `tempctrl_load` stream doesn't
    emit throttled staleness warnings on the ground side: delete its
@@ -355,8 +355,9 @@ the LNA connector):**
    set entry.
 5. Restart `panda_observe`. The live-status dashboard follows on its
    own: signal gating, tempctrl bands, and the display calibration's
-   `t_load_stream` prefer the panda's Redis config upload over the
-   dashboard host's local file, so the restarted `panda_observe`'s
+   `t_ns_*`/`t_amb_*` reference routing prefer the panda's Redis
+   config upload over the dashboard host's local file, so the
+   restarted `panda_observe`'s
    upload re-gates the dashboard within a tick — no dashboard-side
    config edit or restart. During the swap window itself the dashboard
    still renders the *last* upload's tiles (empty for the retired

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -225,8 +225,8 @@ class StateSnapshot:
     # its config to this Redis. The dashboard reads ``switch_schedule``
     # from here rather than from the on-disk YAML, so a parked switch
     # with no panda running shows no countdown. The panda-reality slice
-    # (``tempctrl_settings``, ``use_*`` gates, ``corr_ntimes``,
-    # ``calibration.t_load_stream``) is additionally merged over the
+    # (``tempctrl_settings``, ``use_*`` gates, ``corr_ntimes``, the
+    # ``calibration`` t_ns_*/t_amb_* routing knobs) is merged over the
     # local YAML into ``aggregator.obs_cfg_effective`` so signal gating
     # and config-derived bands follow what panda is actually running
     # (issue #194).

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -813,9 +813,9 @@ def _config_payload(
 
     ``obs_cfg`` here is the aggregator's *effective* config: the local
     YAML with the panda-reality slice (``tempctrl_settings``, ``use_*``
-    gates, ``corr_ntimes``, ``calibration.t_load_stream``) overridden
-    by the panda's Redis ``ConfigStore`` upload once one has landed
-    (issue #194). ``config_source`` records which side supplied that
+    gates, ``corr_ntimes``, the ``calibration`` t_ns_*/t_amb_* routing
+    knobs) overridden by the panda's Redis ``ConfigStore`` upload once
+    one has landed (issue #194). ``config_source`` records which side supplied that
     slice — ``"panda_upload"`` when an upload has been seen on this
     Redis, ``"local_file"`` when none ever has — and
     ``config_upload_unix`` dates it (the upload persists after panda
@@ -883,8 +883,9 @@ def create_app(aggregator: LiveStatusAggregator) -> Flask:
     def api_corr():
         state = aggregator.snapshot()
         calibrated = request.args.get("calibrated") == "1"
-        # Effective config so the display calibration's t_load_stream
-        # follows a hot-swap announced via the panda's config upload.
+        # Effective config so the display calibration's t_ns_*/t_amb_*
+        # reference-temperature routing follows a hot-swap announced
+        # via the panda's config upload.
         return jsonify(
             _envelope(
                 _corr_payload(

--- a/src/eigsep_observing/live_status/signals.py
+++ b/src/eigsep_observing/live_status/signals.py
@@ -247,11 +247,20 @@ PANDA_REALITY_KEYS = (
 )
 
 # Nested (section, field) pairs plucked individually from the upload.
-# Only ``calibration.t_load_stream`` follows panda reality (it names
-# the stream the hot-swapped LOAD module publishes on);
-# ``calibration.noise_diode_enr_db`` stays dashboard-local — it's a
-# display-cal tuning knob, not a claim about what panda is running.
-PANDA_REALITY_NESTED = (("calibration", "t_load_stream"),)
+# The calibration reference-temperature *routing* knobs follow panda
+# reality: a tempctrl hot-swap re-points ``t_amb_*`` at the stream the
+# moved LOAD module publishes on, and ``t_ns_*`` names the RF-switch
+# PCB thermistor channel nearest the noise-source pad (see
+# ``_solve_calibration``). The physical constants
+# (``noise_diode_enr_db`` / ``noise_source_atten_db``) stay
+# dashboard-local — display-cal tuning knobs, not claims about what
+# panda is running.
+PANDA_REALITY_NESTED = (
+    ("calibration", "t_ns_stream"),
+    ("calibration", "t_ns_field"),
+    ("calibration", "t_amb_stream"),
+    ("calibration", "t_amb_field"),
+)
 
 
 def effective_obs_cfg(local_cfg: dict, panda_cfg: Optional[dict]) -> dict:

--- a/tests/test_live_status_app.py
+++ b/tests/test_live_status_app.py
@@ -1062,7 +1062,7 @@ def test_panda_upload_regates_signals_and_thresholds():
             },
             "calibration": {
                 **OBS_CFG["calibration"],
-                "t_load_stream": "tempctrl_lna",
+                "t_amb_stream": "tempctrl_lna",
             },
         }
         ConfigStore(panda).upload(upload)
@@ -1076,10 +1076,10 @@ def test_panda_upload_regates_signals_and_thresholds():
             29.0,
             31.0,
         ]
-        # calibration.t_load_stream was plucked from the upload; the
+        # calibration.t_amb_stream was plucked from the upload; the
         # ENR knob stays dashboard-local.
         cal = agg.obs_cfg_effective["calibration"]
-        assert cal["t_load_stream"] == "tempctrl_lna"
+        assert cal["t_amb_stream"] == "tempctrl_lna"
         assert (
             cal["noise_diode_enr_db"]
             == OBS_CFG["calibration"]["noise_diode_enr_db"]
@@ -1168,16 +1168,17 @@ def test_panda_upload_malformed_keeps_previous_gating(agg_primed, caplog):
     assert agg.thresholds is not th_good
 
 
-def test_corr_route_calibrated_t_load_stream_follows_upload(agg_primed):
-    """Hot-swap contingency end-to-end: the panda upload names
-    ``tempctrl_lna`` as the cal-load stream; the calibrated corr route
-    must read T_LOAD from that stream without a dashboard restart."""
+def test_corr_route_calibrated_t_amb_stream_follows_upload(agg_primed):
+    """Hot-swap contingency end-to-end: the panda upload re-points the
+    ambient-reference stream at ``tempctrl_lna`` (the moved LOAD module
+    publishes there); the calibrated corr route must read T_amb from
+    that stream without a dashboard restart."""
     _seed_onoff_cache(agg_primed, p_off_value=100, p_on_value=250)
     upload = {
         **OBS_CFG,
         "calibration": {
             **OBS_CFG["calibration"],
-            "t_load_stream": "tempctrl_lna",
+            "t_amb_stream": "tempctrl_lna",
         },
     }
     ConfigStore(agg_primed.transport_panda).upload(upload)
@@ -1187,10 +1188,10 @@ def test_corr_route_calibrated_t_load_stream_follows_upload(agg_primed):
     app.config.update(TESTING=True)
     body = app.test_client().get("/api/corr?calibrated=1").get_json()
     meta = body["data"]["calibration_meta"]
-    assert meta["t_load_stream"] == "tempctrl_lna"
+    assert meta["t_amb_stream"] == "tempctrl_lna"
     # tempctrl_lna's T_now is 25.1 C in the fixture (vs LOAD's 25.0) —
     # proof the solve read the swapped stream, not the default.
-    assert meta["t_load_k"] == pytest.approx(25.1 + 273.15, rel=1e-9)
+    assert meta["t_amb_k"] == pytest.approx(25.1 + 273.15, rel=1e-9)
 
 
 def test_file_route(client):

--- a/tests/test_live_status_thresholds.py
+++ b/tests/test_live_status_thresholds.py
@@ -424,8 +424,12 @@ OBS_CFG_LOCAL = {
     "use_tempctrl": True,
     "switch_schedule": {"RFANT": 3600, "RFNON": 60},
     "calibration": {
-        "noise_diode_enr_db": 11.0,
-        "t_load_stream": "tempctrl_load",
+        "noise_diode_enr_db": 35.0,
+        "noise_source_atten_db": 30.0,
+        "t_ns_stream": "rfswitch_therm",
+        "t_ns_field": "temp_therm2",
+        "t_amb_stream": "tempctrl_load",
+        "t_amb_field": "T_now",
     },
     "tempctrl_settings": {
         "LNA": {"installed": True, "target_C": 25.0, "hysteresis_C": 0.5},
@@ -492,20 +496,28 @@ def test_effective_obs_cfg_missing_upload_keys_fall_back_to_local():
     assert out["tempctrl_settings"] == OBS_CFG_LOCAL["tempctrl_settings"]
 
 
-def test_effective_obs_cfg_plucks_only_t_load_stream_from_calibration():
+def test_effective_obs_cfg_plucks_only_routing_knobs_from_calibration():
     upload = _panda_upload(
         calibration={
             "noise_diode_enr_db": 99.0,  # panda copy drifted
-            "t_load_stream": "tempctrl_lna",  # hot-swap step 3
+            "noise_source_atten_db": 20.0,  # panda copy drifted
+            "t_ns_stream": "rfswitch_therm",
+            "t_ns_field": "temp_therm0",  # pad moved to another channel
+            "t_amb_stream": "tempctrl_lna",  # hot-swap step 3
+            "t_amb_field": "T_now",
         }
     )
     out = effective_obs_cfg(OBS_CFG_LOCAL, upload)
     cal = out["calibration"]
-    assert cal["t_load_stream"] == "tempctrl_lna"
-    # The ENR is a dashboard-local display-cal knob, not panda reality.
-    assert cal["noise_diode_enr_db"] == 11.0
+    # The reference-temperature routing follows the upload...
+    assert cal["t_amb_stream"] == "tempctrl_lna"
+    assert cal["t_ns_field"] == "temp_therm0"
+    # ...but the physical constants are dashboard-local display-cal
+    # knobs, not panda reality.
+    assert cal["noise_diode_enr_db"] == 35.0
+    assert cal["noise_source_atten_db"] == 30.0
     # The local dict's nested section was copied, not mutated in place.
-    assert OBS_CFG_LOCAL["calibration"]["t_load_stream"] == "tempctrl_load"
+    assert OBS_CFG_LOCAL["calibration"]["t_amb_stream"] == "tempctrl_load"
 
 
 def test_effective_obs_cfg_switch_schedule_not_merged():


### PR DESCRIPTION
**Fixes the red CI on main** introduced by the semantic (non-textual) collision between the two-temp Y-factor cal rework and #212: `test_corr_route_calibrated_t_load_stream_follows_upload` asserts on `calibration_meta["t_load_stream"]`, which the cal rework retired in favor of the `t_ns_stream` / `t_ns_field` / `t_amb_stream` / `t_amb_field` reference-temperature routing knobs. Merge this before #214.

Beyond the test, #212's prefer-Redis pluck itself was left pointing at the dead key, so the hot-swap scenario it was built for (re-pointing the ambient reference at the moved LOAD module's stream) would silently not follow the panda upload.

- `PANDA_REALITY_NESTED` now plucks the four routing knobs; the physical constants (`noise_diode_enr_db`, `noise_source_atten_db`) stay dashboard-local, same rationale as before (display-cal tuning knobs, not panda state).
- Route test rewritten to the surviving contingency: upload re-points `t_amb_stream: tempctrl_lna` → `calibration_meta` shows the swapped stream and `t_amb_k` reads the LNA-connector fixture value (25.1 °C vs LOAD's 25.0 — proves the solve read the swapped stream).
- Merge unit tests/fixtures updated to the production calibration block shape (ENR 35 dB, 30 dB pad, t_ns/t_amb routing).
- OPERATIONS.md hot-swap steps 3/5 (`calibration.t_load_stream` → `calibration.t_amb_stream`) and stale code comments updated.

131 live-status tests pass locally (previously 1 failed on exactly the main-CI failure); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)