### PR TITLE
fix(observer): gate panda re-probing to a cooldown during outages

### DIFF
--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -25,6 +25,13 @@ logger = logging.getLogger(__name__)
 # throttle in eigsep_redis.MetadataStreamReader.
 _DRAIN_WARN_INTERVAL_S = 60.0
 
+# During a panda outage, every touch of the dead host is a
+# multi-second failed TCP connect. Probing once per this window (vs
+# once per ~1 s integration) keeps the corr loop at full cadence —
+# "corr is sacred" — while reconnection stays implicit with at most
+# this much extra latency.
+_PANDA_REPROBE_INTERVAL_S = 30.0
+
 
 def _tick_liveness_deadline(deadline, liveness_timeout, reason):
     """Advance the SNAP-liveness deadline; log loudly when it expires.
@@ -392,6 +399,7 @@ class EigObserver:
         # panda_observe stopped) still drains live sensor metadata.
         metadata_stream_down = False
         last_drain_warn_monotonic = 0.0
+        last_panda_probe_monotonic = 0.0
         try:
             while not self.stop_event.is_set():
                 if file.counter == 0:
@@ -492,17 +500,32 @@ class EigObserver:
                 # ConnectionError is the real "panda unreachable" signal;
                 # corr stays sacred (metadata=None).
                 if metadata_stream_down:
-                    # On reconnect, jump every metadata stream past the
-                    # outage backlog so the next drain picks up the
-                    # producer's "now". Keeps the metadata cadence aligned
-                    # with corr integrations instead of smearing
-                    # historical readings into the current row.
-                    try:
-                        self.metadata_stream.skip_to_latest()
-                    except redis.exceptions.ConnectionError:
-                        # Bounced again between the skip attempt and the
-                        # drain; treat as still-down and try next
-                        # iteration.
+                    # Re-probing a dead panda costs seconds per attempt
+                    # (failed TCP connect) and at corr cadence that
+                    # starves the writer below the producer rate —
+                    # eventually losing corr rows to the stream cap.
+                    # Probe at most once per _PANDA_REPROBE_INTERVAL_S;
+                    # between probes, land the row immediately with
+                    # SNAP-side metadata only.
+                    now_mono = time.monotonic()
+                    probe_ok = False
+                    if (
+                        now_mono - last_panda_probe_monotonic
+                        >= _PANDA_REPROBE_INTERVAL_S
+                    ):
+                        last_panda_probe_monotonic = now_mono
+                        # On reconnect, jump every metadata stream past
+                        # the outage backlog so the next drain picks up
+                        # the producer's "now". Keeps the metadata
+                        # cadence aligned with corr integrations instead
+                        # of smearing historical readings into the
+                        # current row.
+                        try:
+                            self.metadata_stream.skip_to_latest()
+                            probe_ok = True
+                        except redis.exceptions.ConnectionError:
+                            probe_ok = False
+                    if not probe_ok:
                         metadata = {}
                         adc = self.adc_metadata_stream.drain()
                         if adc:

--- a/src/eigsep_observing/observer.py
+++ b/src/eigsep_observing/observer.py
@@ -504,8 +504,14 @@ class EigObserver:
                     # (failed TCP connect) and at corr cadence that
                     # starves the writer below the producer rate —
                     # eventually losing corr rows to the stream cap.
-                    # Probe at most once per _PANDA_REPROBE_INTERVAL_S;
-                    # between probes, land the row immediately with
+                    # Probe at most once per _PANDA_REPROBE_INTERVAL_S,
+                    # timed from when the previous probe *returned*
+                    # (not when it started): a probe that itself blocks
+                    # longer than the interval (redis-py's retry policy
+                    # can push a failed connect past 30s against a
+                    # SYN-blackholed host) must still buy a full
+                    # cooldown of gated fast iterations afterward.
+                    # Between probes, land the row immediately with
                     # SNAP-side metadata only.
                     now_mono = time.monotonic()
                     probe_ok = False
@@ -513,7 +519,6 @@ class EigObserver:
                         now_mono - last_panda_probe_monotonic
                         >= _PANDA_REPROBE_INTERVAL_S
                     ):
-                        last_panda_probe_monotonic = now_mono
                         # On reconnect, jump every metadata stream past
                         # the outage backlog so the next drain picks up
                         # the producer's "now". Keeps the metadata
@@ -525,6 +530,8 @@ class EigObserver:
                             probe_ok = True
                         except redis.exceptions.ConnectionError:
                             probe_ok = False
+                        finally:
+                            last_panda_probe_monotonic = time.monotonic()
                     if not probe_ok:
                         metadata = {}
                         adc = self.adc_metadata_stream.drain()

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1830,6 +1830,139 @@ def test_record_corr_data_drain_failure_error_is_throttled(
 
 
 @patch("eigsep_observing.io.File")
+def test_record_corr_data_outage_probe_cooldown(
+    mock_file_class, observer_both, caplog
+):
+    """During a panda outage the corr loop must NOT touch the panda
+    every integration: each failed touch is a multi-second TCP
+    connect against a dead host, which starved the writer to ~18 s
+    per ~1 s integration in the field (2026-07-09) — a corr-is-sacred
+    violation once the corr stream cap starts eating the backlog.
+    Within one _PANDA_REPROBE_INTERVAL_S window: exactly one failed
+    drain (sets the down flag) + exactly one failed probe, then zero
+    panda touches while rows keep landing at full cadence.
+    """
+    import redis.exceptions
+
+    observer = observer_both
+    observer.corr_config.upload_header({"sync_time": 1713200000.0})
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    mock_data = generate_data(ntimes=1)
+
+    read_count = [0]
+
+    def read_side_effect(*a, **kw):
+        read_count[0] += 1
+        if read_count[0] >= 6:
+            observer.stop_event.set()
+        return (123, mock_data)
+
+    drain_calls = [0]
+
+    def failing_drain(*a, **kw):
+        drain_calls[0] += 1
+        raise redis.exceptions.ConnectionError("down")
+
+    skip_calls = [0]
+
+    def failing_skip(*a, **kw):
+        skip_calls[0] += 1
+        raise redis.exceptions.ConnectionError("down")
+
+    caplog.set_level(logging.WARNING, logger="eigsep_observing.observer")
+    with (
+        patch.object(
+            observer.corr_reader, "read", side_effect=read_side_effect
+        ),
+        patch.object(
+            observer.metadata_stream, "drain", side_effect=failing_drain
+        ),
+        patch.object(
+            observer.metadata_stream,
+            "skip_to_latest",
+            side_effect=failing_skip,
+        ),
+    ):
+        observer.record_corr_data("/tmp/test", ntimes=1, timeout=5)
+
+    assert read_count[0] >= 6, "loop didn't iterate enough"
+    # Corr cadence is untouched: one row per corr entry.
+    assert mock_file.add_data.call_count == read_count[0]
+    # Panda touches are bounded: the flag-setting drain failure plus
+    # exactly one probe; all later iterations are inside the cooldown.
+    assert drain_calls[0] == 1, drain_calls
+    assert skip_calls[0] == 1, skip_calls
+    # Gated rows carry no panda metadata.
+    assert mock_file.add_data.call_args.kwargs["metadata"] is None, (
+        mock_file.add_data.call_args
+    )
+
+
+@patch("eigsep_observing.io.File")
+def test_record_corr_data_probe_resumes_after_cooldown(
+    mock_file_class, observer_both, caplog
+):
+    """The cooldown gate must reopen: with the reprobe interval
+    patched to zero, every down-iteration probes again — proving the
+    gate is a timer, not a latch (reconnection stays implicit).
+    """
+    import redis.exceptions
+
+    observer = observer_both
+    observer.corr_config.upload_header({"sync_time": 1713200000.0})
+
+    mock_file = Mock()
+    mock_file.counter = 0
+    mock_file.__len__ = Mock(return_value=0)
+    mock_file_class.return_value = mock_file
+
+    mock_data = generate_data(ntimes=1)
+
+    read_count = [0]
+
+    def read_side_effect(*a, **kw):
+        read_count[0] += 1
+        if read_count[0] >= 5:
+            observer.stop_event.set()
+        return (123, mock_data)
+
+    skip_calls = [0]
+
+    def failing_skip(*a, **kw):
+        skip_calls[0] += 1
+        raise redis.exceptions.ConnectionError("down")
+
+    caplog.set_level(logging.WARNING, logger="eigsep_observing.observer")
+    with (
+        patch("eigsep_observing.observer._PANDA_REPROBE_INTERVAL_S", 0.0),
+        patch.object(
+            observer.corr_reader, "read", side_effect=read_side_effect
+        ),
+        patch.object(
+            observer.metadata_stream,
+            "drain",
+            side_effect=redis.exceptions.ConnectionError("down"),
+        ),
+        patch.object(
+            observer.metadata_stream,
+            "skip_to_latest",
+            side_effect=failing_skip,
+        ),
+    ):
+        observer.record_corr_data("/tmp/test", ntimes=1, timeout=5)
+
+    assert read_count[0] >= 5, "loop didn't iterate enough"
+    # Interval 0 → every down-iteration after the first probes again.
+    assert skip_calls[0] == read_count[0] - 1, skip_calls
+    assert mock_file.add_data.call_count == read_count[0]
+
+
+@patch("eigsep_observing.io.File")
 def test_record_corr_data_skip_to_tail_on_panda_recover(
     mock_file_class, observer_both, transport_panda, caplog
 ):


### PR DESCRIPTION
## Summary
- During a panda outage, `record_corr_data` re-probed the dead panda every integration (`skip_to_latest()`); each probe is a multi-second failed TCP connect, starving the writer to ~18 s per ~1.07 s integration in the field (2026-07-09) — and once the corr stream backlog hits the stream cap, corr rows are permanently lost. Corr is sacred.
- Gate the probe to once per `_PANDA_REPROBE_INTERVAL_S` (30 s); between probes, rows land at full cadence with SNAP-side adc metadata only (sidecar `metadata=None`, unchanged semantics).
- Reconnection stays implicit: worst-case pickup after the panda returns is one interval; the existing reconnect path (probe → drain success → flag flip + INFO) is untouched, and the first down-iteration still probes immediately.
- Deliberately minimal for the imminent field deployment: no transport changes, SNAP/corr path untouched (separate Transport instance). The full transport-level circuit breaker is deferred — see EIGSEP/eigsep_redis#25 discussion.
- Companion (independent) fix: EIGSEP/eigsep_redis PR #25 for issue #23 (TCP keepalive, kills the mid-read deadlock from the same incident).

## Test plan
- [x] New: outage window → exactly one failed drain + one probe, rows at full cadence with `metadata=None`
- [x] New: interval patched to 0 → every down-iteration probes (gate is a timer, not a latch)
- [x] Existing outage/recovery/throttle tests in `tests/test_observer.py` pass unchanged
- [ ] Field validation: panda power-cut → corr files keep full cadence; pickup ≤ 30 s after panda returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)