### PR TITLE
feat: ship 2**26 cadence (tapcp_timeout_s 0.1) + guide-for-eye linear-range rescale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,8 +369,12 @@ corr plot; NaN → JSON null → Plotly line gap). Both validate
 `OPERATING_POINT_FIELDS` (adc_gain, fft_shift, corr_scalar, ...)
 against the live corr header and **omit the bounds with an ERROR
 log on any failure** — bounds from a different operating point are
-junk, and a bad product must never block corr writes. Re-fit the
-product after any operating-point change.
+junk, and a bad product must never block corr writes. One sanctioned
+display-only exception: when `corr_acc_len` is the *sole* mismatch,
+the live-status aggregator draws the bounds rescaled by the acc_len
+ratio (`acc_len_rescale`) as an approximate guide for the eye —
+WARNING logged, legend labeled with the scale; file headers still
+omit. Re-fit the product after any operating-point change.
 
 ## Testing philosophy: dummies over mocks
 

--- a/src/eigsep_observing/config/corr_config.yaml
+++ b/src/eigsep_observing/config/corr_config.yaml
@@ -4,11 +4,15 @@ snap_ip: "10.10.10.12"
 # so it sets the stall cost of a single lost packet on the SNAP link.
 # casperfpga's default of 3 s spans 2-3 integration windows at
 # corr_acc_len 2**28 and was the root cause of the periodic
-# "Dropped 2 integration(s)" warnings (issue #204). 0.25 s is ~100x
-# the observed per-block readout cadence, so only a genuinely lost
-# packet ever waits this long; casperfpga's 8 transaction-level
+# "Dropped 2 integration(s)" warnings (issue #204). At corr_acc_len
+# 2**26 the boundary margin is only ~165 ms (268 ms window minus the
+# ~103 ms readout), so even 0.25 s turns every lost packet into one
+# torn-read drop (~3.7% loss measured 2026-07-09); 0.1 s keeps a
+# single-loss stall inside the window (0 drops in the same-day A/B)
+# while still ~40x the per-block readout cadence, so only a genuinely
+# lost packet ever waits this long. casperfpga's 8 transaction-level
 # retries are unaffected. Absent -> defaults to 0.25.
-tapcp_timeout_s: 0.25
+tapcp_timeout_s: 0.1
 fpg_file: "eigsep_fengine_1g_v2_4_2026-06-23_2052.fpg"  # path to fpg file
 fpg_version: [2, 4]  # major, minor
 sample_rate: 500.0  # in MHz
@@ -18,8 +22,11 @@ use_noise: false  # use digital noise instead of ADC data
 adc_gain: 4
 fft_shift: 0x015F
 #corr_acc_len: 0x10000000  # 2**28 fabric clocks (250 MHz): 1 tick / 1.074 s
-corr_acc_len: 0x08000000  # 2**27 fabric clocks (250 MHz): 1 tick / 0.537 s
-#corr_acc_len: 0x04000000  # 2**26 fabric clocks: 1 tick / 0.268 s
+#corr_acc_len: 0x08000000  # 2**27 fabric clocks (250 MHz): 1 tick / 0.537 s
+# 2**26 requires tapcp_timeout_s <= ~0.15: the ~165 ms boundary margin
+# must absorb a full retransmit stall or every lost packet drops one
+# integration (see tapcp_timeout_s note above).
+corr_acc_len: 0x04000000  # 2**26 fabric clocks (250 MHz): 1 tick / 0.268 s
 corr_scalar: 512  # 2**9 - 8 bits after binary point so 2**9 = 1
 corr_word: 4  # 4 bytes per word
 # acc_bins / avg_even_odd are DECLARED defaults only. The producer

--- a/src/eigsep_observing/config/corr_config.yaml
+++ b/src/eigsep_observing/config/corr_config.yaml
@@ -17,7 +17,8 @@ use_ref: false  # use synth on snap to generate adc clock from 10 MHz ref
 use_noise: false  # use digital noise instead of ADC data
 adc_gain: 4
 fft_shift: 0x015F
-corr_acc_len: 0x10000000  # 2**28 fabric clocks (250 MHz): 1 tick / 1.074 s
+#corr_acc_len: 0x10000000  # 2**28 fabric clocks (250 MHz): 1 tick / 1.074 s
+corr_acc_len: 0x08000000  # 2**27 fabric clocks (250 MHz): 1 tick / 0.537 s
 #corr_acc_len: 0x04000000  # 2**26 fabric clocks: 1 tick / 0.268 s
 corr_scalar: 512  # 2**9 - 8 bits after binary point so 2**9 = 1
 corr_word: 4  # 4 bytes per word

--- a/src/eigsep_observing/linear_range.py
+++ b/src/eigsep_observing/linear_range.py
@@ -22,6 +22,12 @@ bounds on mismatch — bounds measured at a different operating point
 (gain, FFT shift, accumulation length, ...) are junk data. Failures
 raise :class:`LinearRangeError` here; consumers log at ERROR and move
 on, so a bad product can never block corr data.
+
+One sanctioned display-only exception: when ``corr_acc_len`` is the
+sole mismatch, :func:`acc_len_rescale` gives the ratio to redraw the
+bounds as an approximate guide for the eye on the live-status plot
+(counts scale with accumulation length). File headers never carry
+rescaled bounds.
 """
 
 import functools
@@ -258,6 +264,15 @@ def validate_operating_point(product_header, live_header):
         as a mismatch — silence is not agreement.
 
     """
+    return [
+        f"{name}: product={prod!r} live={live!r}"
+        for name, prod, live in _mismatched_fields(product_header, live_header)
+    ]
+
+
+def _mismatched_fields(product_header, live_header):
+    """Return ``(name, product_value, live_value)`` per mismatched
+    ``OPERATING_POINT_FIELDS`` field (empty means a full match)."""
     mismatches = []
     for name in OPERATING_POINT_FIELDS:
         prod = product_header.get(name)
@@ -268,5 +283,45 @@ def validate_operating_point(product_header, live_header):
         if isinstance(live, tuple):
             live = list(live)
         if prod != live:
-            mismatches.append(f"{name}: product={prod!r} live={live!r}")
+            mismatches.append((name, prod, live))
     return mismatches
+
+
+def acc_len_rescale(product_header, live_header):
+    """
+    Ratio to rescale bounds when only ``corr_acc_len`` mismatches.
+
+    Raw corr counts scale linearly with the number of accumulated
+    samples, so when the accumulation length is the *only*
+    operating-point difference the product's bounds can be rescaled by
+    ``live/product`` as an approximate **guide for the eye**. The
+    fitter's floor subtraction does not necessarily scale linearly, so
+    the rescaled bounds are display-only: the live-status plot may draw
+    them (flagged as scaled); ``io.append_corr_header`` must keep
+    omitting them — approximate bounds do not belong in file headers.
+
+    Parameters
+    ----------
+    product_header, live_header : dict
+        As for :func:`validate_operating_point`.
+
+    Returns
+    -------
+    float or None
+        ``live_acc_len / product_acc_len`` if ``corr_acc_len`` is the
+        only mismatched field and both values are positive numbers;
+        None otherwise (including on a full match, where no rescale is
+        needed).
+
+    """
+    mismatches = _mismatched_fields(product_header, live_header)
+    if [name for name, _, _ in mismatches] != ["corr_acc_len"]:
+        return None
+    _, prod, live = mismatches[0]
+    if not isinstance(prod, (int, float)) or not isinstance(
+        live, (int, float)
+    ):
+        return None
+    if prod <= 0 or live <= 0:
+        return None
+    return live / prod

--- a/src/eigsep_observing/live_status/aggregator.py
+++ b/src/eigsep_observing/live_status/aggregator.py
@@ -69,6 +69,7 @@ from ..host_health import read as read_host_health
 from ..io import RFSWITCH_TRANSITION_WINDOW_S, reshape_data
 from ..linear_range import (
     LinearRangeError,
+    acc_len_rescale,
     load_linear_range,
     validate_operating_point,
 )
@@ -133,9 +134,13 @@ class StateSnapshot:
     # product's operating point validates against the live corr
     # header. ``linear_range_key`` memoizes the (file, header-upload)
     # pair so a bad product logs one ERROR per header publish, not one
-    # per ~1 s tick.
+    # per ~1 s tick. ``corr_linear_scale`` is the acc_len-ratio the
+    # bounds were multiplied by when ``corr_acc_len`` was the only
+    # operating-point mismatch (guide-for-the-eye display mode); None
+    # when the bounds are exact.
     corr_linear_min: Optional[np.ndarray] = None
     corr_linear_max: Optional[np.ndarray] = None
+    corr_linear_scale: Optional[float] = None
     linear_range_key: Optional[tuple] = None
 
     # ADC stats stream (SNAP side, one entry per diagnostics-period
@@ -961,7 +966,10 @@ class LiveStatusAggregator:
         corr config or header was (re)read. Loads the packaged product
         named by ``corr_config["linear_range_file"]`` and validates its
         operating point against the live corr header; a failed load or
-        mismatch clears the bounds. Memoized on the (file,
+        mismatch clears the bounds, except an acc_len-only mismatch,
+        which draws them rescaled by the acc_len ratio as an
+        approximate guide for the eye (WARNING logged,
+        ``corr_linear_scale`` set). Memoized on the (file,
         ``header_upload_unix``) pair so a chronic failure logs one
         ERROR per header publish instead of one per tick (the tick
         re-reads config/header every ~1 s).
@@ -972,6 +980,7 @@ class LiveStatusAggregator:
         if not lr_file or header is None:
             s.corr_linear_min = None
             s.corr_linear_max = None
+            s.corr_linear_scale = None
             s.linear_range_key = None
             return
         key = (lr_file, header.get("header_upload_unix"))
@@ -980,6 +989,7 @@ class LiveStatusAggregator:
         s.linear_range_key = key
         s.corr_linear_min = None
         s.corr_linear_max = None
+        s.corr_linear_scale = None
         try:
             product = load_linear_range(lr_file)
         except LinearRangeError as e:
@@ -993,14 +1003,32 @@ class LiveStatusAggregator:
             return
         mismatches = validate_operating_point(product["header"], header)
         if mismatches:
-            logger.error(
-                "Linear-range operating-point mismatch for %r: %s. "
-                "Dashed bounds will be missing from the corr plot. "
-                "Re-measure the product at this operating point or "
-                "fix corr_config.",
+            scale = acc_len_rescale(product["header"], header)
+            if scale is None:
+                logger.error(
+                    "Linear-range operating-point mismatch for %r: %s. "
+                    "Dashed bounds will be missing from the corr plot. "
+                    "Re-measure the product at this operating point or "
+                    "fix corr_config.",
+                    lr_file,
+                    "; ".join(mismatches),
+                )
+                return
+            # Display-only guide for the eye: counts scale with
+            # accumulation length, but the fit floor is unverified at
+            # this operating point. File headers still omit the bounds.
+            logger.warning(
+                "Linear-range product %r was fit at a different "
+                "corr_acc_len (%s); drawing bounds scaled by %.4g as "
+                "an approximate guide for the eye. Re-measure the "
+                "product at this operating point for exact bounds.",
                 lr_file,
-                "; ".join(mismatches),
+                mismatches[0],
+                scale,
             )
+            s.corr_linear_min = product["linear_min"] * scale
+            s.corr_linear_max = product["linear_max"] * scale
+            s.corr_linear_scale = scale
             return
         s.corr_linear_min = product["linear_min"]
         s.corr_linear_max = product["linear_max"]

--- a/src/eigsep_observing/live_status/app.py
+++ b/src/eigsep_observing/live_status/app.py
@@ -457,6 +457,10 @@ def _corr_payload(
         # raw (uncalibrated) view only.
         payload["linear_min"] = _nan_to_none(state.corr_linear_min)
         payload["linear_max"] = _nan_to_none(state.corr_linear_max)
+        # acc_len-ratio the bounds were rescaled by (guide-for-the-eye
+        # mode, see aggregator._maybe_load_linear_range); null when the
+        # bounds are exact. The front end labels the curves with it.
+        payload["linear_range_scale"] = state.corr_linear_scale
     if cal_meta is not None:
         payload["calibration_meta"] = cal_meta
     return payload

--- a/src/eigsep_observing/live_status/static/js/dashboard.js
+++ b/src/eigsep_observing/live_status/static/js/dashboard.js
@@ -419,23 +419,28 @@ function updateCorr(corr) {
     // the min bound only marks the bottom of the *verified* range;
     // cold cal states (load, noise-off) legitimately sit at or below
     // it, so it stays a faint informational dotted line.
+    // linear_range_scale set = the bounds were rescaled from a
+    // different corr_acc_len as a guide for the eye; surface that on
+    // the plot via a legend entry so the approximation is visible.
+    const lrScale = corr.linear_range_scale;
+    const lrSuffix = lrScale ? ` (×${lrScale} approx)` : "";
     magTraces.push({
       x: freqs,
       y: corr.linear_max,
       type: "scatter",
       mode: "lines",
-      name: "linear range max",
+      name: "linear range max" + lrSuffix,
       line: { dash: "dash", width: 1.5, color: LINEAR_MAX_WARN_COLOR },
       opacity: 0.9,
       hoverinfo: "skip",
-      showlegend: false,
+      showlegend: !!lrScale,
     });
     magTraces.push({
       x: freqs,
       y: corr.linear_min,
       type: "scatter",
       mode: "lines",
-      name: "linear range min",
+      name: "linear range min" + lrSuffix,
       line: { dash: "dot", width: 1, color: activeTheme.font },
       opacity: 0.35,
       hoverinfo: "skip",

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -1341,8 +1341,10 @@ class TestMakeFpgaTapcpTimeout:
 
     def test_default_config_ships_the_knob(self):
         """The shipped corr_config.yaml sets the knob explicitly so
-        the field value is visible in the file, not just in code."""
-        assert default_config["tapcp_timeout_s"] == 0.25
+        the field value is visible in the file, not just in code.
+        0.1 s (below the code default 0.25 s) is required by the
+        2**26 acc_len tick's ~165 ms boundary margin."""
+        assert default_config["tapcp_timeout_s"] == 0.1
 
 
 _MUX_DEPLOY_WIRING = {

--- a/tests/test_linear_range.py
+++ b/tests/test_linear_range.py
@@ -150,3 +150,46 @@ def test_extra_live_header_fields_ignored():
     freely between measurement and deployment."""
     live = dict(HEADER, sync_time=0.0, run_tag="manual-session")
     assert linear_range.validate_operating_point(HEADER, live) == []
+
+
+# ---------------------------------------------------------------------
+# acc_len_rescale — display-only guide-for-the-eye ratio
+# ---------------------------------------------------------------------
+
+
+def test_acc_len_rescale_acc_len_only_mismatch():
+    """Product at 2**28, live at 2**26 — the deployment case: counts
+    are 4x smaller, so the bounds rescale by 0.25."""
+    live = dict(HEADER, corr_acc_len=HEADER["corr_acc_len"] // 4)
+    assert linear_range.acc_len_rescale(HEADER, live) == pytest.approx(0.25)
+
+
+def test_acc_len_rescale_full_match_is_none():
+    """No mismatch means no rescale is needed — consumers use the
+    bounds as-is."""
+    assert linear_range.acc_len_rescale(HEADER, dict(HEADER)) is None
+
+
+def test_acc_len_rescale_additional_mismatch_is_none():
+    """acc_len plus any other operating-point difference stays a hard
+    omit — the ratio only transfers between otherwise-identical
+    operating points."""
+    live = dict(
+        HEADER,
+        corr_acc_len=HEADER["corr_acc_len"] // 4,
+        adc_gain=HEADER["adc_gain"] + 1,
+    )
+    assert linear_range.acc_len_rescale(HEADER, live) is None
+
+
+def test_acc_len_rescale_other_field_only_is_none():
+    live = dict(HEADER, adc_gain=HEADER["adc_gain"] + 1)
+    assert linear_range.acc_len_rescale(HEADER, live) is None
+
+
+@pytest.mark.parametrize("bad", ["DIFFERENT", None, 0, -(2**26)])
+def test_acc_len_rescale_non_positive_or_non_numeric_is_none(bad):
+    live = dict(HEADER, corr_acc_len=bad)
+    if bad is None:
+        del live["corr_acc_len"]
+    assert linear_range.acc_len_rescale(HEADER, live) is None

--- a/tests/test_live_status_aggregator.py
+++ b/tests/test_live_status_aggregator.py
@@ -1280,6 +1280,42 @@ def test_linear_range_mismatch_clears_bounds_and_logs_once(
     assert "adc_gain" in errors[0].message
 
 
+def test_linear_range_acc_len_only_mismatch_rescales_bounds(
+    transports, tmp_path, caplog
+):
+    """The deployment carve-out: a product fit at 4x the live
+    corr_acc_len (and an otherwise identical operating point) is drawn
+    rescaled by 0.25 as a guide for the eye — WARNING, not ERROR, and
+    the scale is exposed for the front-end label."""
+    measured = dict(
+        GOLDEN_HEADER, corr_acc_len=GOLDEN_HEADER["corr_acc_len"] * 4
+    )
+    agg = _seed_linear_range(transports, tmp_path, measured)
+    try:
+        with caplog.at_level(logging.WARNING):
+            agg._snap_tick()
+        state = agg.snapshot()
+    finally:
+        agg.stop(timeout=1.0)
+    np.testing.assert_array_equal(
+        state.corr_linear_min,
+        np.full(GOLDEN_HEADER["nchan"], 1e5 * 0.25),
+    )
+    np.testing.assert_array_equal(
+        state.corr_linear_max,
+        np.full(GOLDEN_HEADER["nchan"], 5e8 * 0.25),
+    )
+    assert state.corr_linear_scale == pytest.approx(0.25)
+    warnings = [r for r in caplog.records if "guide for the eye" in r.message]
+    assert len(warnings) == 1
+    assert warnings[0].levelno == logging.WARNING
+    assert not [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "mismatch" in r.message
+    ]
+
+
 def test_linear_range_none_without_config(agg):
     """The seeded fixture config has no linear_range_file — bounds
     stay None and no linear-range ERROR fires."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,9 +44,7 @@ class TestCalcInttime:
         # computed integration_time must still be the dump period
         # (2**26 fabric clocks -> 0.268 s tick).
         cfg = load_config(get_config_path("corr_config.yaml"))
-        assert cfg["integration_time"] == pytest.approx(
-            0.268435456, rel=1e-12
-        )
+        assert cfg["integration_time"] == pytest.approx(0.268435456, rel=1e-12)
 
 
 class TestRequirePandaDecorator:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,9 +41,12 @@ class TestCalcInttime:
 
     def test_load_config_computes_dump_period(self):
         # corr_config.yaml declares the v2.4 layout (acc_bins: 1); the
-        # computed integration_time must still be the dump period.
+        # computed integration_time must still be the dump period
+        # (2**26 fabric clocks -> 0.268 s tick).
         cfg = load_config(get_config_path("corr_config.yaml"))
-        assert cfg["integration_time"] == pytest.approx(1.073741824, rel=1e-12)
+        assert cfg["integration_time"] == pytest.approx(
+            0.268435456, rel=1e-12
+        )
 
 
 class TestRequirePandaDecorator:

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ requires-dist = [
     { name = "ipython", marker = "extra == 'interactive'" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "picohost", specifier = ">=4.3" },
+    { name = "picohost", specifier = ">=4.4" },
     { name = "plotly" },
     { name = "pyserial-mock", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary
- **Ship `corr_acc_len: 0x04000000`** (2**26 fabric clocks at 250 MHz, 1 tick / 0.268 s, ~3.7 Hz) with **`tapcp_timeout_s: 0.1`**. Field A/B on the Pi (2026-07-09): at 2**26 the 0.25 s retransmit stall exceeds the ~165 ms boundary margin (268 ms window − ~103 ms readout), so every lost TAPCP packet cost one torn-read drop (~3.7%); with 0.1 s the same run drops **zero**. 2**28 / 2**27 remain as commented alternatives with a note on the timeout constraint.
- **Live-status guide-for-eye linear-range rescale.** The shipped 2026-07-08 linear-range product is fit at 2**28 and there is no opportunity to re-sweep before deployment, which would leave the corr plot with no bounds at all. When `corr_acc_len` is the *only* operating-point mismatch, the aggregator now draws the bounds scaled by the live/product acc_len ratio (×0.25 here) — raw counts scale linearly with accumulation length. WARNING logged (memoized per header publish), scale exposed in the corr payload, legend labeled `linear range max (×0.25 approx)` so the approximation is visible on the dashboard itself.
- **Display-only by design**: `io.append_corr_header` keeps strict omit-on-mismatch — approximate bounds never land in file headers, and any other mismatch (alone or combined with acc_len) still omits everywhere. `acc_len_rescale` sits next to `validate_operating_point` in `linear_range.py`, sharing the field comparison via a `_mismatched_fields` helper.

## Test plan
- [x] `tests/test_linear_range.py`: `acc_len_rescale` unit tests (ratio on acc_len-only mismatch; None on full match, extra mismatch, non-acc_len mismatch, non-positive/non-numeric/missing acc_len)
- [x] `tests/test_live_status_aggregator.py`: acc_len-only mismatch rescales bounds ×0.25, logs WARNING not ERROR, exposes `corr_linear_scale`; existing hard-mismatch and match tests unchanged
- [x] Field: 2**26 + 0.1 s A/B on eigsep-pi, 0 drops (vs ~3.7% at 0.25 s)

## Notes
- Branch name still says `2p27` (created for the earlier 2**27 step); scope superseded by the 2**26 field validation.
- `uv.lock` drift and untracked notebook/test-data files are deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)