### PR TITLE
fix(io): name S11 files from measurement time, not write time

### DIFF
--- a/src/eigsep_observing/io.py
+++ b/src/eigsep_observing/io.py
@@ -631,6 +631,65 @@ def read_metadata_hdf5(fname):
     return out
 
 
+def _s11_filename_stamp(header):
+    """Return the ``%Y%m%d_%H%M%SZ`` stamp for an auto-generated S11 name.
+
+    Named from ``metadata_snapshot_unix`` — the panda-side wallclock at
+    the moment the bundle was published — not from write time. The two
+    diverge whenever the ground observer drains a VNA backlog: in
+    deployment 5, 36 of 40 files were written inside the same two
+    seconds while the measurements they held spanned eight days, which
+    left the archive unsortable by name.
+
+    Naming is best-effort and must never block a write. A missing or
+    unusable value falls back to write time and logs at WARNING, so a
+    filename that does not line up with its sweep stays explainable.
+    ``0.0`` is treated as unusable because it is this codebase's
+    established "no producer info" sentinel (cf. ``run_started_at_unix``
+    and ``obs_config_owner_uploaded_unix``), not a 1970 measurement.
+
+    Parameters
+    ----------
+    header : dict
+        VNA S11 header, normally carrying ``metadata_snapshot_unix``.
+
+    Returns
+    -------
+    str
+        Timestamp formatted for the filename.
+
+    """
+    snapshot = header.get("metadata_snapshot_unix")
+    usable = (
+        isinstance(snapshot, (int, float, np.integer, np.floating))
+        and not isinstance(snapshot, (bool, np.bool_))
+        and math.isfinite(snapshot)
+        and snapshot > 0
+    )
+    if usable:
+        try:
+            return datetime.datetime.fromtimestamp(
+                snapshot, datetime.timezone.utc
+            ).strftime("%Y%m%d_%H%M%SZ")
+        except (ValueError, OverflowError, OSError) as e:
+            # Out-of-range epoch value: narrow net so a nonsense
+            # timestamp degrades the filename instead of losing the file.
+            logger.warning(
+                f"S11 metadata_snapshot_unix {snapshot!r} is not a valid "
+                f"timestamp ({type(e).__name__}: {e}); naming file from "
+                "write time instead."
+            )
+    else:
+        logger.warning(
+            f"S11 header has no usable metadata_snapshot_unix "
+            f"(got {snapshot!r}); naming file from write time instead. "
+            "The filename will not reflect when the sweep was taken."
+        )
+    return datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y%m%d_%H%M%SZ"
+    )
+
+
 def write_s11_file(
     data,
     header,
@@ -658,16 +717,16 @@ def write_s11_file(
         'short', and 'load'.
     fname : Path or str
         Filename where the data will be written. If not provided, a
-        timestamped filename will be generated.
+        timestamped filename is generated from the header's
+        ``metadata_snapshot_unix`` (when the sweep was taken), falling
+        back to write time — see :func:`_s11_filename_stamp`.
     save_dir : Path or str
         Directory where the data will be saved. Must be able to
         instantiate a Path object. Ignored if ``fname'' is an absolute path.
 
     """
     if fname is None:
-        date = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y%m%d_%H%M%SZ"
-        )
+        date = _s11_filename_stamp(header)
         mode = "ant" if "ant" in data else "rec"
         file_path = Path(save_dir) / f"{mode}s11_{date}.h5"
         # Disambiguate same-second collisions on auto-generated

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -424,13 +424,13 @@ def test_write_read_s11_file():
     with tempfile.TemporaryDirectory() as tmpdir:
         # no filename, should create one automatically
         io.write_s11_file(data, S11_HEADER, fname=None, save_dir=tmpdir)
-        # check that the file was created
-        now = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y%m%d_%H%M%SZ"
-        )
-        # might be off by a second, so we use glob to find the file
-        # filename format is {mode}s11_{timestamp}Z.h5, where mode="ant" here
-        assert len(list(Path(tmpdir).glob(f"ants11_{now[:-3]}*Z.h5"))) == 1
+        # The auto-generated name encodes the measurement time from the
+        # header, not the write time, so it is fully deterministic.
+        # Filename format is {mode}s11_{timestamp}Z.h5, mode="ant" here.
+        measured = datetime.datetime.fromtimestamp(
+            S11_HEADER["metadata_snapshot_unix"], datetime.timezone.utc
+        ).strftime("%Y%m%d_%H%M%SZ")
+        assert (Path(tmpdir) / f"ants11_{measured}.h5").exists()
         filename = Path(tmpdir) / "test_s11.h5"
         io.write_s11_file(
             data,
@@ -2543,6 +2543,90 @@ def test_s11_filename_disambiguation_on_same_second_collision():
         assert len(files) == 3, f"expected 3 files, got: {files}"
         names = [Path(p).name for p in files]
         assert len(set(names)) == 3
+
+
+def test_s11_filename_uses_measurement_time_not_write_time():
+    """Auto-generated S11 filenames encode when the sweep was taken.
+
+    ``metadata_snapshot_unix`` is stamped on the panda just before the
+    bundle is published; the ground observer may write it minutes or
+    days later when a Redis backlog drains. Naming from write time made
+    a whole deployment's files unsortable (deployment 5: 36 of 40 files
+    stamped within the same two seconds, measurements spanning 8 days).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data, _ = generate_s11_data(npoints=S11_HEADER["npoints"], cal=True)
+        # A measurement time deliberately far from "now" — the whole
+        # point is that a stale backlog entry keeps its own timestamp.
+        measured = datetime.datetime(
+            2026, 7, 17, 4, 2, 30, tzinfo=datetime.timezone.utc
+        )
+        header = {**S11_HEADER, "metadata_snapshot_unix": measured.timestamp()}
+
+        io.write_s11_file(data, header, fname=None, save_dir=tmpdir)
+
+        assert [p.name for p in Path(tmpdir).glob("*.h5")] == [
+            "ants11_20260717_040230Z.h5"
+        ]
+
+
+def test_s11_filename_falls_back_to_write_time_without_snapshot(caplog):
+    """A header with no usable measurement time still produces a file.
+
+    Naming is best-effort: an S11 file must never fail to be written
+    because its provenance field is missing. The fallback is loud so a
+    filename that does not line up with the sweep is explainable.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data, _ = generate_s11_data(npoints=S11_HEADER["npoints"], cal=True)
+        header = {k: v for k, v in S11_HEADER.items()}
+        del header["metadata_snapshot_unix"]
+
+        before = datetime.datetime.now(datetime.timezone.utc)
+        with caplog.at_level(logging.WARNING, logger="eigsep_observing.io"):
+            io.write_s11_file(data, header, fname=None, save_dir=tmpdir)
+        after = datetime.datetime.now(datetime.timezone.utc)
+
+        written = list(Path(tmpdir).glob("*.h5"))
+        assert len(written) == 1
+        stamp = datetime.datetime.strptime(
+            written[0].name, "ants11_%Y%m%d_%H%M%SZ.h5"
+        ).replace(tzinfo=datetime.timezone.utc)
+        # Truncated to the second, so compare against a 1 s window.
+        assert before - datetime.timedelta(seconds=1) <= stamp <= after
+        assert "metadata_snapshot_unix" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        0.0,  # the codebase's "unknown" sentinel (cf. run_started_at_unix)
+        -1.0,
+        float("nan"),
+        float("inf"),
+        "1748734379.9",  # producer sent a string
+        None,
+        True,  # bool is an int subclass; not a timestamp
+    ],
+)
+def test_s11_filename_falls_back_on_unusable_snapshot_time(bad, caplog):
+    """Unusable measurement times fall back rather than raising.
+
+    0.0 is the sentinel this codebase already uses for "no producer
+    info" (``run_started_at_unix``, ``obs_config_owner_uploaded_unix``),
+    so it means "unknown", not 1970.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data, _ = generate_s11_data(npoints=S11_HEADER["npoints"], cal=True)
+        header = {**S11_HEADER, "metadata_snapshot_unix": bad}
+
+        with caplog.at_level(logging.WARNING, logger="eigsep_observing.io"):
+            io.write_s11_file(data, header, fname=None, save_dir=tmpdir)
+
+        written = list(Path(tmpdir).glob("*.h5"))
+        assert len(written) == 1
+        assert not written[0].name.startswith("ants11_1970")
+        assert "metadata_snapshot_unix" in caplog.text
 
 
 def test_close():

--- a/uv.lock
+++ b/uv.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "eigsep-observing"
-version = "2.13.0"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## Problem

Auto-generated S11 filenames were stamped with `datetime.now()` at write time. The ground observer writes whenever it drains the VNA stream, so a backlogged bundle gets a filename hours or days after its sweep was actually taken.

Deployment 5 is the worked example: **36 of 40 files were written inside the same two seconds** (19:08:38–39Z on 07-17, when the backlog drained) while the measurements they held spanned 2026-07-09 → 2026-07-17. Max lag 7.95 days.

The existing same-second disambiguation suffix then compounded it, because `-` sorts before `.` and `-10` before `-2`:

```
alphabetical:   …190839Z-1, -10, -11, -12, -13, -2, -3, …, -9, 190839Z
chronological:  …190839Z, -1, -2, -3, -4, …, -9, -10, -11, -12, -13
```

So the un-suffixed file — written *first* — sorts *last*, and the numeric suffixes interleave. Lexical order bore no relation to time, and the archive was effectively unsortable by name. This cost real analysis time before it was diagnosed.

## Change

Name from `header["metadata_snapshot_unix"]` — the panda-side wallclock stamped just before the bundle is published — instead of write time. At the 1/hour VNA cadence, collisions become vanishingly rare, so the `-N` suffix mostly stops appearing at all; it is retained for genuine same-second bundles.

Naming stays best-effort. An S11 file must never fail to be written because a provenance field is missing, so a missing or unusable value falls back to write time and logs at WARNING — a filename that does not line up with its sweep stays explainable rather than silently wrong.

`0.0` is treated as unusable rather than as a 1970 measurement, because it is this codebase's established "no producer info" sentinel (`run_started_at_unix`, `obs_config_owner_uploaded_unix`).

## Tests

TDD; all four watched failing first.

- `test_s11_filename_uses_measurement_time_not_write_time` — header timestamp far from now, filename must encode the header's time.
- `test_s11_filename_falls_back_to_write_time_without_snapshot` — key absent: file is still written, stamped ~now, WARNING emitted.
- `test_s11_filename_falls_back_on_unusable_snapshot_time` — parametrised over `0.0`, negative, NaN, inf, str, `None`, `True`.
- `test_write_read_s11_file` — updated; the old assertion tested the write-time behaviour this PR replaces. It now derives the expected name from the fixture rather than from the clock, so it is deterministic instead of racing the second boundary.

`tests/test_io.py` + `tests/test_observer.py`: 166 passed. `ruff check` / `ruff format --check` clean.

## Notes

- No downstream code parses S11 filenames — checked across `src/` and `scripts/`. The change affects on-disk naming only; existing files keep their names and read back unchanged.
- Includes a one-line `uv.lock` sync (`eigsep-observing` 2.13.0 → 2.14.0) that `uv run` picked up; release-please bumped `pyproject.toml` without it, so it would re-dirty any tree otherwise.
- This is one of the findings from the deployment-5 S11 audit. Related: EIGSEP/CMT-VNA#54 (the zero-filled sweeps' root cause) and #223 (consumer-side zero check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)